### PR TITLE
fix jest to transform all tested files

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,12 @@
     "unpacked-win-x86": "npm run prebuild && build --win --ia32 --dir",
     "prebuild": "npm run lint && npm run test && npm run browserify-preload",
     "lint": "eslint --ext .js js/",
-    "test": "jest --coverage --testPathPattern tests",
+    "test": "jest --testPathPattern test",
     "browserify-preload": "browserify -o js/preload/_preloadMain.js -x electron js/preload/preloadMain.js && browserify -o js/preload/_preloadChild.js -x electron js/preload/preloadChild.js"
+  },
+  "jest": {
+      "collectCoverage": true,
+      "transformIgnorePatterns": []
   },
   "build": {
     "files": [


### PR DESCRIPTION
jest needs to apply babel transform on all required files, previously some required files in node_modules was not being transformed so jest would throw errors because the file couldn't be properly transformed.