### PR TITLE
fix test failures for newer ver of node

### DIFF
--- a/js/preload/createProxy.js
+++ b/js/preload/createProxy.js
@@ -234,7 +234,6 @@ function getHandler(target, property, isStatic) {
 function instanceSetHandler(target, property, value) {
     let prototype = Object.getPrototypeOf(target);
     let desc = Object.getOwnPropertyDescriptor(prototype, property);
-
     if (desc && desc.set) {
         var args = {
             objId: target._objId,
@@ -243,7 +242,10 @@ function instanceSetHandler(target, property, value) {
         }
 
         ipcRenderer.sendSync(proxyCmds.set, args);
+        return true;
     }
+
+    return false;
 }
 
 function staticGetHandler(target, name) {

--- a/tests/apiTests/proxy-polyfill.js
+++ b/tests/apiTests/proxy-polyfill.js
@@ -19,6 +19,8 @@
  * the License.
  */
 
+// note: polyfill here can be removed when everyone is using node >= 6.4.0
+
 'use strict';
 
 (function(scope) {

--- a/tests/apiTests/proxyAPI.test.js
+++ b/tests/apiTests/proxyAPI.test.js
@@ -289,7 +289,7 @@ describe('proxy destroy tests...', function() {
         });
     });
 
-    test('destroy from implementation side', function() {
+    test('destroy from implementation side', function(done) {
         inst.close();
 
         inst.getArg1()


### PR DESCRIPTION
tests failed on version of node > 6.4.0 because Proxy is supported natively and requires that setter return non-falsely value when successful.