### PR TITLE
Enable the Chromium sandbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "author": "Symphony",
   "main": "js/main.js",
   "scripts": {
-    "dev": "npm run browserify-preload && cross-env ELECTRON_DEV=true electron .",
-    "demo": "npm run browserify-preload && cross-env ELECTRON_DEV=true electron . --url=file://$(pwd)/demo/index.html",
+    "dev": "npm run browserify-preload && cross-env ELECTRON_DEV=true electron . --enable-sandbox",
+    "demo": "npm run browserify-preload && cross-env ELECTRON_DEV=true electron . --url=file://$(pwd)/demo/index.html --enable-sandbox",
     "dist-mac": "npm run prebuild && build --mac",
     "dist-win": "npm run prebuild && build --win --x64",
     "dist-win-x86": "npm run prebuild && build --win --ia32",


### PR DESCRIPTION
According to recently added documentation, `sandbox: true` creates a sandbox 'compatible' renderer process, but doesn't actually enable the sandbox. The command line argument I've added is also required.

See discussion here: https://github.com/electron/electron/pull/9054#discussion_r108695652