### PR TITLE
fix event timing for events

### DIFF
--- a/js/notify/AnimationQueue.js
+++ b/js/notify/AnimationQueue.js
@@ -12,7 +12,7 @@ AnimationQueue.prototype.push = function(object) {
         this.queue.push(object);
     } else {
         this.running = true;
-        this.animate(object);
+        setTimeout(this.animate.bind(this, object), 0);
     }
 }
 

--- a/js/notify/electron-notify.js
+++ b/js/notify/electron-notify.js
@@ -131,7 +131,7 @@ let config = {
 //     calcDimensions();
 // }
 
-if (app.isReady) {
+if (app.isReady()) {
     setup();
 } else {
     app.on('ready', setup);
@@ -548,7 +548,9 @@ function moveNotificationAnimation(i, done) {
 }
 
 function setWindowPosition(browserWin, posX, posY) {
-    browserWin.setPosition(parseInt(posX, 10), parseInt(posY, 10))
+    if (!browserWin.isDestroyed()) {
+        browserWin.setPosition(parseInt(posX, 10), parseInt(posY, 10))
+    }
 }
 
 /*
@@ -605,10 +607,10 @@ function closeAll() {
     animationQueue.clear();
 
     activeNotifications.forEach(function(window) {
+        if (window.displayTimer) {
+            clearTimeout(window.displayTimer);
+        }
         if (window.electronNotifyOnCloseFunc) {
-            window.electronNotifyOnCloseFunc({
-                event: 'close-all'
-            });
             // ToDo: fix this: shouldn't delete method on arg
             /* eslint-disable */
             delete window.electronNotifyOnCloseFunc;
@@ -645,5 +647,4 @@ function log() {
 }
 
 module.exports.notify = notify
-// module.exports.setConfig = setConfig
-module.exports.closeAll = closeAll
+module.exports.reset = setupConfig

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -10,6 +10,7 @@ const { isMac } = require('./utils/misc.js');
 const getGuid = require('./utils/getGuid.js');
 const log = require('./log.js')
 const logLevels = require('./enums/logLevels.js');
+const notify = require('./notify/electron-notify.js');
 
 //context menu
 const contextMenu = require('./menus/contextMenu.js');
@@ -69,6 +70,8 @@ function createMainWindow(url) {
         if (!isOnline) {
             loadErrors.showNetworkConnectivityError(mainWindow, url, retry);
         } else {
+            // removes all existing notifications when main window reloads
+            notify.reset();
             log.send(logLevels.INFO, 'main window loaded');
         }
     });


### PR DESCRIPTION
fix few things related to notifications:
- close existing notfs when main window is reloaded
- add emitter queueing mechanism so that events received prior to call addEventListener are still emitted.  due to multi-process arch of electron, it is possible to subscribe to events in JS but miss early notifications.