### PR TITLE
get media source interface

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -52,6 +52,12 @@
         <button id='open-win'>open window</button>
 
         <button id='bring-to-front'>bring open window to front</button>
+
+        <hr>
+        <p>Get Media Sources:</p>
+        <button id='get-sources'>get entire desktop</button>
+        <br>
+        <video id='video'/>
     </body>
     <script>
         var notfEl = document.getElementById('notf');
@@ -152,6 +158,35 @@
         function onBoundsChange(arg) {
             console.log('bounds changed for=', arg)
         }
+
+        var getSources = document.getElementById('get-sources');
+        getSources.addEventListener('click', function() {
+            SYM_API.getMediaSources({types: ['window', 'screen']}, function(error, sources) {
+                if (error) throw error
+                  navigator.webkitGetUserMedia({
+                    audio: false,
+                    video: {
+                      mandatory: {
+                        chromeMediaSource: 'desktop',
+                        chromeMediaSourceId: sources[0].id,
+                        minWidth: 1280,
+                        maxWidth: 1280,
+                        minHeight: 720,
+                        maxHeight: 720
+                      }
+                    }
+                  }, handleStream, handleError)
+            });
+        });
+
+        function handleStream (stream) {
+          document.querySelector('video').src = URL.createObjectURL(stream)
+        }
+
+        function handleError (e) {
+          console.log(e)
+        }
+
 
     </script>
 </html>

--- a/js/desktopCapturer/getSources.js
+++ b/js/desktopCapturer/getSources.js
@@ -1,0 +1,67 @@
+'use strict';
+
+// This code provides equivalent of desktopCapturer.getSources that works in
+// a sandbox renderer. see: https://electron.atom.io/docs/api/desktop-capturer/
+//
+// The code here is not entirely kosher/stable as it is using private ipc
+// events.  The code was take directly from electron.asar file provided in
+// prebuilt node module.  Note: the slight difference here is the thumbnail
+// returns a base64 encoded image rather than a electron nativeImage.
+//
+// Until electron provides access to desktopCapturer in a sandboxed
+// renderer process, this will have to do.  See github issue posted here to
+// electron: https://github.com/electron/electron/issues/9312
+
+var { ipcRenderer } = require('electron');
+
+var nextId = 0;
+var includes = [].includes;
+
+function getNextId() {
+    return ++nextId;
+}
+
+// |options.type| can not be empty and has to include 'window' or 'screen'.
+function isValid(options) {
+    return ((options != null ? options.types : undefined) != null) && Array.isArray(options.types);
+}
+
+function getSources(options, callback) {
+    var captureScreen, captureWindow, id;
+    if (!isValid(options)) {
+        return callback(new Error('Invalid options'));
+    }
+    captureWindow = includes.call(options.types, 'window');
+    captureScreen = includes.call(options.types, 'screen');
+
+    let updatedOptions = options;
+    if (updatedOptions.thumbnailSize == null) {
+        updatedOptions.thumbnailSize = {
+            width: 150,
+            height: 150
+        }
+    }
+
+    id = getNextId();
+    ipcRenderer.send('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', captureWindow, captureScreen, updatedOptions.thumbnailSize, id);
+
+    return ipcRenderer.once('ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_' + id, function (event, sources) {
+        var source;
+        callback(null, (function () {
+            var i, len, results
+            results = [];
+            for (i = 0, len = sources.length; i < len; i++) {
+                source = sources[i]
+                results.push({
+                    id: source.id,
+                    name: source.name,
+                    thumbnail: source.thumbnail
+                })
+            }
+
+            return results
+        }()));
+    });
+}
+
+module.exports = getSources;

--- a/js/preload/preloadMain.js
+++ b/js/preload/preloadMain.js
@@ -17,6 +17,7 @@ const throttle = require('../utils/throttle.js');
 const apiEnums = require('../enums/api.js');
 const apiCmds = apiEnums.cmds;
 const apiName = apiEnums.apiName;
+const getMediaSources = require('../desktopCapturer/getSources');
 
 // hold ref so doesn't get GC'ed
 const local = {
@@ -120,7 +121,15 @@ function createAPI() {
                     cmd: apiCmds.registerLogger
                 });
             }
-        }
+        },
+
+        /**
+         * Implements equivalent of desktopCapturer.getSources - that works in
+         * a sandboxed renderer process.
+         * see: https://electron.atom.io/docs/api/desktop-capturer/
+         * for interface: see documentation in desktopCapturer/getSources.js
+         */
+        getMediaSources: getMediaSources
     };
 
     Object.freeze(window.SYM_API);


### PR DESCRIPTION
This code implements interface that allows getting list of media sources in sandbox renderer process. This code provides equivalent of desktopCapturer.getSources that works in a sandbox renderer. see: https://electron.atom.io/docs/api/desktop-capturer/.