### PR TITLE
upgrade to electron 1.6.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "babel-preset-es2015": "^6.24.0",
     "browserify": "^14.1.0",
     "cross-env": "^3.2.4",
-    "electron": "1.6.7",
+    "electron": "1.6.8",
     "electron-builder": "^13.9.0",
     "electron-builder-squirrel-windows": "^12.3.0",
     "electron-packager": "^8.5.2",


### PR DESCRIPTION
upgrade to electron 1.6.8.
release notes: https://github.com/electron/electron/releases/tag/v1.6.8

https://github.com/electron/electron/pull/9314 fixes memory leak we reported: https://github.com/electron/electron/issues/9191