### PR TITLE
electron-52: properly bring minimized window to front...

### DIFF
--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -323,9 +323,12 @@ function activate(windowName) {
     let keys = Object.keys(windows);
     for(let i = 0, len = keys.length; i < len; i++) {
         let window = windows[keys[i]];
-        if (window && !window.isDestroyed() &&
-            window.winName === windowName) {
-            window.show();
+        if (window && !window.isDestroyed() && window.winName === windowName) {
+            if (window.isMinimized()) {
+                window.restore();
+            } else {
+                window.show();
+            }
             return;
         }
     }


### PR DESCRIPTION
handles bug reported in electron-52...

Steps to reproduce the issue:
1. Click on "Open Window" button in the main screen --> window opens
2. Maximize the open window.
3. Now minimize it.
4. In the main screen, click on "bring open window to front" button.

Expected Result : When we minimize the screen and click on "bring open window to front" then the open window should be maximized.
