### PR TITLE
enforce min width and height for windows

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -144,7 +144,7 @@
 
         var openWinButton = document.getElementById('open-win');
         openWinButton.addEventListener('click', function() {
-            win = window.open('win.html?x=100&y=100', 'test-window', 'height=100,width=100');
+            win = window.open('win.html?x=100&y=100', 'test-window', 'height=800,width=400');
         });
 
         var front = document.getElementById('bring-to-front');

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -37,6 +37,9 @@ let boundsChangeWindow;
 // note: this file is built using browserify in prebuild step.
 const preloadMainScript = path.join(__dirname, 'preload/_preloadMain.js');
 
+const MIN_WIDTH = 300;
+const MIN_HEIGHT = 600;
+
 function addWindowKey(key, browserWin) {
     windows[key] = browserWin;
 }
@@ -69,6 +72,8 @@ function doCreateMainWindow(initialUrl, initialBounds) {
     let newWinOpts = {
         title: 'Symphony',
         show: true,
+        minWidth: MIN_WIDTH,
+        minHeight: MIN_HEIGHT,
         webPreferences: {
             sandbox: true,
             nodeIntegration: false,
@@ -198,8 +203,8 @@ function doCreateMainWindow(initialUrl, initialBounds) {
             let x = 0;
             let y = 0;
 
-            let width = newWinOptions.width || 300;
-            let height = newWinOptions.height || 600;
+            let width = newWinOptions.width || MIN_WIDTH;
+            let height = newWinOptions.height || MIN_HEIGHT;
 
             // try getting x and y position from query parameters
             var query = newWinParsedUrl && querystring.parse(newWinParsedUrl.query);
@@ -228,8 +233,10 @@ function doCreateMainWindow(initialUrl, initialBounds) {
             /* eslint-disable no-param-reassign */
             newWinOptions.x = x;
             newWinOptions.y = y;
-            newWinOptions.width = width;
-            newWinOptions.height = height;
+            newWinOptions.width = Math.max(width, MIN_WIDTH);
+            newWinOptions.height = Math.max(height, MIN_HEIGHT);
+            newWinOptions.minWidth = MIN_WIDTH;
+            newWinOptions.minHeight = MIN_HEIGHT;
 
             let newWinKey = getGuid();
 


### PR DESCRIPTION
enforces min width of 300 and min height for 600 for main and pop-out windows as per bug noted in electron-52