### PR TITLE
simplify protocol handler api

### DIFF
--- a/js/enums/api.js
+++ b/js/enums/api.js
@@ -10,7 +10,6 @@ const cmds = keyMirror({
     activate: null,
     registerBoundsChange: null,
     registerProtocolHandler: null,
-    checkProtocolAction: null,
     registerActivityDetection: null,
 });
 

--- a/js/mainApiMgr.js
+++ b/js/mainApiMgr.js
@@ -70,13 +70,9 @@ electron.ipcMain.on(apiName, (event, arg) => {
         return;
     }
 
-    if (arg.cmd === apiCmds.checkProtocolAction) {
-        protocolHandler.checkProtocolAction();
-        return;
-    }
-
     if (arg.cmd === apiCmds.registerProtocolHandler) {
         protocolHandler.setProtocolWindow(event.sender);
+        protocolHandler.checkProtocolAction();
     }
 
     if (arg.cmd === apiCmds.badgeDataUrl && typeof arg.dataUrl === 'string' &&

--- a/js/preload/preloadMain.js
+++ b/js/preload/preloadMain.js
@@ -137,8 +137,11 @@ function createAPI() {
         /**
          * allows JS to register a protocol handler that can be used by the
          * electron main process.
-         * @param protocolHandler {Object} protocolHandler a callback to
-         * register the protocol handler.
+         *
+         * @param protocolHandler {Function} callback will be called when app is
+         * invoked with registered protocol (e.g., symphony). The callback
+         * receives a single string argument: full uri that the app was
+         * invoked with e.g., symphony://?streamId=xyz123&streamType=chatroom
          *
          * Note: this function should only be called after client app is fully
          * able for protocolHandler callback to be invoked.  It is possible

--- a/js/preload/preloadMain.js
+++ b/js/preload/preloadMain.js
@@ -32,13 +32,6 @@ const throttledSetBadgeCount = throttle(1000, function(count) {
     });
 });
 
-// check to see if the app was opened via a url
-const checkProtocolAction = function () {
-    local.ipcRenderer.send(apiName, {
-        cmd: apiCmds.checkProtocolAction
-    });
-};
-
 createAPI();
 
 // creates API exposed from electron.
@@ -81,13 +74,6 @@ function createAPI() {
          */
         setBadgeCount: function(count) {
             throttledSetBadgeCount(count);
-        },
-
-        /**
-         * checks to see if the app was opened from a url.
-         */
-        checkProtocolAction: function () {
-            checkProtocolAction();
         },
 
         /**
@@ -153,7 +139,6 @@ function createAPI() {
          * @param protocolHandler {Object} protocolHandler a callback to register the protocol handler
          */
         registerProtocolHandler: function (protocolHandler) {
-
             if (typeof protocolHandler === 'function') {
 
                 local.processProtocolAction = protocolHandler;
@@ -163,7 +148,6 @@ function createAPI() {
                 });
 
             }
-
         },
 
         /**

--- a/js/preload/preloadMain.js
+++ b/js/preload/preloadMain.js
@@ -135,8 +135,16 @@ function createAPI() {
         },
 
         /**
-         * allows JS to register a protocol handler that can be used by the electron main process.
-         * @param protocolHandler {Object} protocolHandler a callback to register the protocol handler
+         * allows JS to register a protocol handler that can be used by the
+         * electron main process.
+         * @param protocolHandler {Object} protocolHandler a callback to
+         * register the protocol handler.
+         *
+         * Note: this function should only be called after client app is fully
+         * able for protocolHandler callback to be invoked.  It is possible
+         * the app was started using protocol handler, in this case as soon as
+         * this registration func is invoked then the protocolHandler callback
+         * will be immediately called.
          */
         registerProtocolHandler: function (protocolHandler) {
             if (typeof protocolHandler === 'function') {


### PR DESCRIPTION
this removes checkProtocolAction from preload api  as it should not be needed anymore.  requires that corresponding PR in SFE-Cilent be merged as well: https://github.com/SymphonyOSF/SFE-Client-App/pull/5622