### PR TITLE
fix opening A tag

### DIFF
--- a/js/preload/preloadMain.js
+++ b/js/preload/preloadMain.js
@@ -19,6 +19,8 @@ const apiCmds = apiEnums.cmds;
 const apiName = apiEnums.apiName;
 const getMediaSources = require('../desktopCapturer/getSources');
 
+const nodeURL = require('url');
+
 // hold ref so doesn't get GC'ed
 const local = {
     ipcRenderer: ipcRenderer
@@ -42,6 +44,25 @@ function createAPI() {
     if (window.self !== window.top) {
         return;
     }
+
+    // bug in electron is preventing using event 'will-navigate' from working
+    // in sandboxed environment. https://github.com/electron/electron/issues/8841
+    // so in the mean time using this code below to block clicking on A tags.
+    // A tags are allowed if they include href='_blank', this cause 'new-window'
+    // event to be received which is handled properly in windowMgr.js
+    window.addEventListener('beforeunload', function(event) {
+        var newUrl = document.activeElement && document.activeElement.href;
+        if (newUrl) {
+            var currHostName = window.location.hostname;
+            var parsedNewUrl = nodeURL.parse(newUrl);
+            var parsedNewUrlHostName = parsedNewUrl && parsedNewUrl.hostname;
+            if (currHostName !== parsedNewUrlHostName) {
+                /* eslint-disable no-param-reassign */
+                event.returnValue = 'false';
+                /* eslint-enable no-param-reassign */
+            }
+        }
+    });
 
     // note: window.open from main window (if in the same domain) will get
     // api access.  window.open in another domain will be opened in the default

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -178,10 +178,9 @@ function doCreateMainWindow(initialUrl, initialBounds) {
 
     mainWindow.on('closed', destroyAllWindows);
 
-    // bug in electron is preventing this from working...
+    // bug in electron is preventing this from working in sandboxed evt...
     // https://github.com/electron/electron/issues/8841
     mainWindow.webContents.on('will-navigate', function(event, willNavUrl) {
-        console.log('will nav url=' + willNavUrl)
         event.preventDefault();
         openUrlInDefaultBrower(willNavUrl);
     });


### PR DESCRIPTION
opening A tag link from browser (in different hostname) should be blocked as this causes electron page to navigate to new location.  But there is a bug in electron https://github.com/electron/electron/issues/8841 that is preventing main process from using 'will-navigate' event.  So in the mean-time using 'beforeunload' event in browser process to block.

Note:  A tag with href='_blank' is allowed and already handled by 'window-open' event; will cause link to be opened in default browser.