### PR TITLE
bump electron to ver 1.6.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "babel-preset-es2015": "^6.24.0",
     "browserify": "^14.1.0",
     "cross-env": "^3.2.4",
-    "electron": "1.6.7",
+    "electron": "1.6.11",
     "electron-builder": "^13.9.0",
     "electron-builder-squirrel-windows": "^12.3.0",
     "electron-packager": "^8.5.2",


### PR DESCRIPTION
bump to version of electron that fixes crash issue we reported: https://github.com/electron/electron/issues/9387

https://github.com/electron/electron/releases