### PR TITLE
ignore single app instance for dev mode

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -39,8 +39,8 @@ const shouldQuit = app.makeSingleInstance((argv) => {
     processProtocolAction(argv);
 });
 
-// quit if another instance is already running
-if (shouldQuit) {
+// quit if another instance is already running, ignore for dev env
+if (!isDevEnv && shouldQuit) {
     app.quit();
 }
 


### PR DESCRIPTION
for development environment mode - ignore singleton app mode.  for example, this allows dev env testing and running production at the same time.