### PR TITLE
hide readResult method

### DIFF
--- a/js/preload/preloadMain.js
+++ b/js/preload/preloadMain.js
@@ -107,7 +107,7 @@ function createAPI() {
          * provides api to allow user to capture portion of screen, see api
          * details in screenSnipper/ScreenSnippet.js
          */
-        ScreenSnippet: remote.require('./screenSnippet/ScreenSnippet.js'),
+        ScreenSnippet: remote.require('./screenSnippet/ScreenSnippet.js').ScreenSnippet,
 
         /**
          * Brings window forward and gives focus.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prebuild": "npm run lint && npm run test && npm run browserify-preload",
     "rebuild": "electron-rebuild -f",
     "lint": "eslint --ext .js js/",
-    "test": "jest --testPathPattern test",
+    "test": "jest --verbose --testPathPattern test",
     "browserify-preload": "browserify -o js/preload/_preloadMain.js -x electron --insert-global-vars=__filename,__dirname js/preload/preloadMain.js"
   },
   "jest": {

--- a/tests/ScreenSnippet.test.js
+++ b/tests/ScreenSnippet.test.js
@@ -1,5 +1,5 @@
 
-const ScreenSnippet = require('../js/screenSnippet/ScreenSnippet.js');
+const { ScreenSnippet, readResult } = require('../js/screenSnippet/ScreenSnippet.js');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
@@ -71,8 +71,7 @@ describe('Tests for ScreenSnippet', function() {
 
         it('should remove output file after completed', function(done) {
             createTestFile(function(testfileName) {
-                let s = new ScreenSnippet();
-                s._readResult(testfileName, resolve);
+                readResult(testfileName, resolve);
 
                 function resolve() {
                     // should be long enough before file
@@ -88,9 +87,8 @@ describe('Tests for ScreenSnippet', function() {
     });
 
     it('should fail if output file does not exist', function(done) {
-        let s = new ScreenSnippet();
-        let nonExistentFile = 'bogus.jpeg'
-        s._readResult(nonExistentFile, resolve, reject);
+        let nonExistentFile = 'bogus.jpeg';
+        readResult(nonExistentFile, resolve, reject);
 
         function resolve() {
             // shouldn't get here


### PR DESCRIPTION
hides the resultResult method, otherwise this will get exposed to web client via preload api and would allow client to read any file.