### PR TITLE
fix activity detection tests and build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,21 +6,17 @@
   "author": "Symphony",
   "main": "js/main.js",
   "scripts": {
-    "postinstall": "npm run rebuild",
-    "dev": "npm run browserify-preload && cross-env ELECTRON_DEV=true electron .",
-    "demo-win": "npm run browserify-preload && cross-env ELECTRON_DEV=true electron . --url=file:///demo/index.html",
-    "demo-mac": "npm run browserify-preload && cross-env ELECTRON_DEV=true electron . --url=file://$(pwd)/demo/index.html",
-    "dist-mac": "npm run prebuild && build --mac",
-    "dist-win": "npm run prebuild && build --win --x64",
-    "dist-win-x86": "npm run prebuild && build --win --ia32",
-    "unpacked-mac": "npm run prebuild && build --mac --dir",
-    "unpacked-win": "npm run prebuild && build --win --x64 --dir",
-    "unpacked-win-x86": "npm run prebuild && build --win --ia32 --dir",
-    "prebuild": "npm run lint && npm run test && npm run browserify-preload",
+    "dev": "npm run prebuild && cross-env ELECTRON_DEV=true electron .",
+    "demo-win": "npm run prebuild && cross-env ELECTRON_DEV=true electron . --url=file:///demo/index.html",
+    "demo-mac": "npm run prebuild && cross-env ELECTRON_DEV=true electron . --url=file://$(pwd)/demo/index.html",
+    "unpacked-mac": "npm run prebuild && npm run test && build --mac --dir",
+    "unpacked-win": "npm run prebuild && npm run test && build --win --x64 --dir",
+    "unpacked-win-x86": "npm run prebuild && npm run test && build --win --ia32 --dir",
+    "prebuild": "npm run rebuild && npm run browserify-preload",
+    "browserify-preload": "browserify -o js/preload/_preloadMain.js -x electron --insert-global-vars=__filename,__dirname js/preload/preloadMain.js",
     "rebuild": "electron-rebuild -f",
-    "lint": "eslint --ext .js js/",
-    "test": "jest --verbose --testPathPattern test",
-    "browserify-preload": "browserify -o js/preload/_preloadMain.js -x electron --insert-global-vars=__filename,__dirname js/preload/preloadMain.js"
+    "test": "npm run lint && jest --verbose --testPathPattern test",
+    "lint": "eslint --ext .js js/"
   },
   "jest": {
     "collectCoverage": true,
@@ -80,8 +76,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.0",
-    "jest": "^19.0.2",
-    "node-abi": "^2.0.3"
+    "jest": "^19.0.2"
   },
   "dependencies": {
     "@paulcbetts/system-idle-time": "^1.0.4",

--- a/tests/activityDetection.test.js
+++ b/tests/activityDetection.test.js
@@ -1,10 +1,7 @@
 const electron = require('./__mocks__/electron');
 const childProcess = require('child_process');
-const nodeAbi = require('node-abi');
 
 let activityDetection;
-let nodeVersion = nodeAbi.getAbi(process.version, 'node');
-let targetElectronVersion = nodeAbi.getTarget(nodeVersion, 'electron');
 
 describe('Tests for Activity Detection', function() {
 
@@ -12,7 +9,7 @@ describe('Tests for Activity Detection', function() {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
 
     beforeAll(function (done) {
-        childProcess.exec(`npm rebuild --runtime=electron --target=${targetElectronVersion} --disturl=https://atom.io/download/atom-shell --build-from-source`, function (err) {
+        childProcess.exec(`npm rebuild --target=${process.version} --build-from-source`, function (err) {
             activityDetection = require('../js/activityDetection/activityDetection.js');
             activityDetection.setActivityWindow(900000, electron.ipcRenderer);
             done();


### PR DESCRIPTION
when building activity detection for tests need to provide node version (e.g., v7.4.0) since we are building for jest env which is running in local version of node.

also re-organized build steps to ensure electron-rebuild is always run first.  this is needed since running tests will build a version that is incompatible with electron.