### PR TITLE
Electron-104 - (Removed Async Dependency)

### DIFF
--- a/js/notify/electron-notify.js
+++ b/js/notify/electron-notify.js
@@ -10,8 +10,9 @@
 //
 const path = require('path');
 const fs = require('fs');
-const async = require('async');
 const electron = require('electron');
+const asyncMap = require('async.map');
+const asyncMapSeries = require('async.mapseries');
 const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
 const ipc = electron.ipcMain;
@@ -541,9 +542,9 @@ function moveOneDown(startPos) {
             notificationPosArray.push(i)
         }
     // Start to animate all notifications at once or in parallel
-        let asyncFunc = async.map // Best performance
+        let asyncFunc = asyncMap // Best performance
         if (config.animateInParallel === false) {
-            asyncFunc = async.mapSeries // Sluggish
+            asyncFunc = asyncMapSeries // Sluggish
         }
         asyncFunc(notificationPosArray, moveNotificationAnimation, function() {
             resolve()

--- a/package.json
+++ b/package.json
@@ -87,15 +87,16 @@
   },
   "dependencies": {
     "@paulcbetts/system-idle-time": "^1.0.4",
-    "async": "^2.1.5",
+    "appdirectory": "^0.1.0",
+    "async.map": "^0.5.2",
+    "async.mapseries": "^0.5.2",
     "auto-launch": "^5.0.1",
     "electron-context-menu": "^0.8.0",
-    "electron-squirrel-startup": "^1.0.0",
-    "keymirror": "0.1.1",
-    "winreg": "^1.2.3",
     "electron-dl": "^1.9.0",
+    "electron-squirrel-startup": "^1.0.0",
     "filesize": "^3.5.10",
-    "appdirectory": "^0.1.0"
+    "keymirror": "0.1.1",
+    "winreg": "^1.2.3"
   },
   "optionalDependencies": {
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.1"


### PR DESCRIPTION
Removed [async](https://www.npmjs.com/package/async) dependency in electron-notify as it was pulling the whole of `lodash` which was huge.

Currently using [async.map](https://www.npmjs.com/package/async.map) & [async.mapseries](https://www.npmjs.com/package/async.mapseries) dependency which is very light.

| Type | Before | After |
| --- | --- | --- |
| `App size` | 123.8 MB | 121 MB |
| `asar node_modules size` | 7.1 MB | 1.5 MB  |

@VikasShashidhar , @VishwasShashidhar & @lneir Please review. Thanks.