### PR TITLE
Electron-111 (Optimised Application Size)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,10 @@
     "files": [
       "!coverage/*",
       "!installer/*",
-      "!tests/*"
+      "!tests/*",
+      "!node_modules/@paulcbetts/cld/deps/cld${/*}",
+      "!node_modules/@paulcbetts/cld/build/deps${/*}",
+      "!node_modules/@paulcbetts/spellchecker/vendor${/*}"
     ],
     "extraFiles": "config/Symphony.config",
     "appId": "symphony-electron-desktop",


### PR DESCRIPTION
Removed some unwanted internal dependencies of `electron-spellchecker`.

| Type | Before | After |
| --- | --- | --- |
| **asar** | 157 MB | 50.8 MB |
| **asar unpacked** | 159 MB | 52.8 MB  |

@VikasShashidhar , @VishwasShashidhar & @lneir Please review. Thanks