### PR TITLE
Add tooltip to display full filename in download manager.

### DIFF
--- a/js/downloadManager/index.js
+++ b/js/downloadManager/index.js
@@ -108,8 +108,8 @@ function createDOM(arg) {
 
             let h2FileName = document.createElement('h2');
             h2FileName.classList.add('text-cutoff');
-            h2FileName.innerHTML = arg.fileName;
-            h2FileName.title = arg.fileName;
+            h2FileName.innerHTML = arg.fileDisplayName;
+            h2FileName.title = arg.fileDisplayName;
             fileNameDiv.appendChild(h2FileName);
 
             let fileProgressTitle = document.createElement('span');

--- a/js/downloadManager/index.js
+++ b/js/downloadManager/index.js
@@ -109,6 +109,7 @@ function createDOM(arg) {
             let h2FileName = document.createElement('h2');
             h2FileName.classList.add('text-cutoff');
             h2FileName.innerHTML = arg.fileName;
+            h2FileName.title = arg.fileName;
             fileNameDiv.appendChild(h2FileName);
 
             let fileProgressTitle = document.createElement('span');


### PR DESCRIPTION
Added a browser tooltip to display full filename in download manager. This mimics the default behaviour of the Chrome Download Manager.

@lneir @VishwasShashidhar Please review.