### PR TITLE
Electron 135: Pop out window -> url opens in external browser

### DIFF
--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -360,7 +360,7 @@ function doCreateMainWindow(initialUrl, initialBounds) {
                     // a new window
                     browserWin.webContents.on('new-window', (childEvent, childWinUrl) => {
                         childEvent.preventDefault();
-                        openUrlInDefaultBrower(childWinUrl);
+                        openUrlInDefaultBrowser(childWinUrl);
                     });
 
                     addWindowKey(newWinKey, browserWin);
@@ -379,7 +379,7 @@ function doCreateMainWindow(initialUrl, initialBounds) {
             });
         } else {
             event.preventDefault();
-            openUrlInDefaultBrower(newWinUrl);
+            openUrlInDefaultBrowser(newWinUrl);
         }
     });
 
@@ -521,7 +521,7 @@ function sendChildWinBoundsChange(window) {
  * Opens an external url in the system's default browser
  * @param urlToOpen
  */
-function openUrlInDefaultBrower(urlToOpen) {
+function openUrlInDefaultBrowser(urlToOpen) {
     if (urlToOpen) {        
         electron.shell.openExternal(urlToOpen);
     }

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -250,17 +250,7 @@ function doCreateMainWindow(initialUrl, initialBounds) {
                 webContents.send('downloadCompleted', data);
             }
         });
-    });
-
-    // bug in electron is preventing this from working in sandboxed evt...
-    // https://github.com/electron/electron/issues/8841
-    mainWindow.webContents.on('will-navigate', function(event, willNavUrl) {
-        if (!sandboxed) {
-            return;
-        }
-        event.preventDefault();
-        openUrlInDefaultBrower(willNavUrl);
-    });
+    });    
 
     // open external links in default browser - a tag with href='_blank' or window.open
     mainWindow.webContents.on('new-window', function (event, newWinUrl,
@@ -365,6 +355,11 @@ function doCreateMainWindow(initialUrl, initialBounds) {
                         });
                     });
 
+                    browserWin.webContents.on('new-window', (childEvent, childWinUrl) => {
+                        childEvent.preventDefault();
+                        openUrlInDefaultBrower(childWinUrl);
+                    });
+
                     addWindowKey(newWinKey, browserWin);
 
                     // Method that sends bound changes as soon
@@ -381,7 +376,7 @@ function doCreateMainWindow(initialUrl, initialBounds) {
             });
         } else {
             event.preventDefault();
-            openUrlInDefaultBrower(newWinUrl)
+            openUrlInDefaultBrower(newWinUrl);
         }
     });
 
@@ -524,7 +519,7 @@ function sendChildWinBoundsChange(window) {
  * @param urlToOpen
  */
 function openUrlInDefaultBrower(urlToOpen) {
-    if (urlToOpen) {
+    if (urlToOpen) {        
         electron.shell.openExternal(urlToOpen);
     }
 }

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -355,6 +355,9 @@ function doCreateMainWindow(initialUrl, initialBounds) {
                         });
                     });
 
+                    // In case we navigate to an external link from inside a pop-out,
+                    // we open that link in an external browser rather than creating
+                    // a new window
                     browserWin.webContents.on('new-window', (childEvent, childWinUrl) => {
                         childEvent.preventDefault();
                         openUrlInDefaultBrower(childWinUrl);

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -347,10 +347,10 @@ function doCreateMainWindow(initialUrl, initialBounds) {
 
                         electron.dialog.showMessageBox(options, function (index) {
                             if (index === 0) {
-                                mainWindow.reload();
+                                browserWin.reload();
                             }
                             else {
-                                mainWindow.close();
+                                browserWin.close();
                             }
                         });
                     });
@@ -361,6 +361,12 @@ function doCreateMainWindow(initialUrl, initialBounds) {
                     browserWin.webContents.on('new-window', (childEvent, childWinUrl) => {
                         childEvent.preventDefault();
                         openUrlInDefaultBrowser(childWinUrl);
+                    });
+
+                    // Clear up the browser window once the window is closed
+                    // to avoid leakage
+                    browserWin.on('closed', () => {
+                        browserWin = null;
                     });
 
                     addWindowKey(newWinKey, browserWin);


### PR DESCRIPTION
**Problem**

When we try to open an external link from inside a pop out window, it opens the link inside electron creating a new window which isn't the expected behavior. Instead, an external link should always be opened in the default browser of the OS.

**Solution Approach**

On a pop-out (child window), we listen for the "new-window" event and prevent the default event from occurring and instead open the link in an external browser.

@VikasShashidhar Please review and merge.

CC: @lneir 