### PR TITLE
electron-155: fixes the raised issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "devDependencies": {
     "browserify": "^14.1.0",
     "cross-env": "^3.2.4",
-    "electron": "1.7.5",
+    "electron": "^1.8.1",
     "electron-builder": "^13.9.0",
     "electron-builder-squirrel-windows": "^12.3.0",
     "electron-packager": "^8.5.2",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "devDependencies": {
     "browserify": "^14.1.0",
     "cross-env": "^3.2.4",
-    "electron": "^1.8.1",
+    "electron": "1.8.1",
     "electron-builder": "^13.9.0",
     "electron-builder-squirrel-windows": "^12.3.0",
     "electron-packager": "^8.5.2",


### PR DESCRIPTION
**Problem**

When we have a pop out window open and close the main window, an exception is thrown by electron as per this screenshot. <img width="427" alt="screen shot 2017-10-06 at 16 57 57" src="https://user-images.githubusercontent.com/5968790/31276169-1c065f82-aab8-11e7-8514-5703a6bbb9d7.png">


**Solution Approach**

This is a known electron issue and has been fixed as part of electron 1.8.1. For more details, please check the JIRA ticket.

