### PR TITLE
Electron-181 (Error: Object has been destroyed)

### DIFF
--- a/js/notify/electron-notify.js
+++ b/js/notify/electron-notify.js
@@ -171,7 +171,7 @@ function setup() {
     setupConfig();
 
     // if display added/removed/changed then re-run setup and remove all existing
-    // notifications.  ToDo: should reposition notifications rather than closing.
+    // notifications.
     electron.screen.on('display-added', setupConfig);
     electron.screen.on('display-removed', setupConfig);
     electron.screen.on('display-metrics-changed', setupConfig);
@@ -238,7 +238,6 @@ function calcDimensions() {
  * Setup the notification config
  */
 function setupConfig() {
-    closeAll();
 
     // This feature only applies to windows
     if (!isMac) {
@@ -692,33 +691,6 @@ function getWindow() {
             })
         }
     })
-}
-
-/**
- * Closes all the notifications and windows
- */
-function closeAll() {
-    // Clear out animation Queue and close windows
-    animationQueue.clear();
-
-    activeNotifications.forEach(function(window) {
-        if (window.displayTimer) {
-            clearTimeout(window.displayTimer);
-        }
-        if (window.electronNotifyOnCloseFunc) {
-            // ToDo: fix this: shouldn't delete method on arg
-            /* eslint-disable */
-            delete window.electronNotifyOnCloseFunc;
-            /* eslint-enable */
-        }
-        window.close();
-    });
-
-    cleanUpInactiveWindow();
-
-    // Reset certain vars
-    nextInsertPos = {};
-    activeNotifications = [];
 }
 
 /**


### PR DESCRIPTION
**Fixes an error**: Object has been destroyed

Removed the unwanted closeAll function as notification position is updated when a display is added/removed and also it was throwing an error:

![screen shot 2017-10-25 at 1 38 03 pm](https://user-images.githubusercontent.com/13243259/31987546-c64cedd2-b989-11e7-9408-a2241806cb96.png)

@VikasShashidhar , @VishwasShashidhar & @lneir Please review. Thanks.
