### PR TITLE
 RTC-2648: Added arguments for allowing multi instance and custom data dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,6 @@ In order to achieve those goals Symphony is participating and working in close c
 - Remote logging is enabled for local and production cases and are sent to the backend server via the remote objects
 
 ## Misc notes
-If desiring to run against server without proper cert use cmd line option: --ignore-certificate-errors
+- If desiring to run against server without proper cert use cmd line option: --ignore-certificate-errors
+- To start additional instance with custom data directory (if you want seperate user) use cmd line options: --multiInstance --userDataPath=<path to data dir>
+  - if directory doesn't exist, it will be created 

--- a/js/main.js
+++ b/js/main.js
@@ -65,7 +65,7 @@ const shouldQuit = app.makeSingleInstance((argv) => {
     processProtocolAction(argv);
 });
 
-let allowMultiInstance = getCmdLineArg(process.argv, '--multiInstance', true) != null || !isDevEnv;
+let allowMultiInstance = getCmdLineArg(process.argv, '--multiInstance', true) != null || isDevEnv;
 
 // quit if another instance is already running, ignore for dev env or if app was started with multiInstance flag
 if (!allowMultiInstance && shouldQuit) {

--- a/js/main.js
+++ b/js/main.js
@@ -65,7 +65,7 @@ const shouldQuit = app.makeSingleInstance((argv) => {
     processProtocolAction(argv);
 });
 
-let allowMultiInstance = getCmdLineArg(process.argv, '--multiInstance', true) != null || isDevEnv;
+let allowMultiInstance = getCmdLineArg(process.argv, '--multiInstance', true) || isDevEnv;
 
 // quit if another instance is already running, ignore for dev env or if app was started with multiInstance flag
 if (!allowMultiInstance && shouldQuit) {
@@ -146,7 +146,6 @@ function setupThenOpenMainWindow() {
     
     if (customDataArg && customDataArg.split('=').length > 1) {
         let customDataFolder = customDataArg.split('=')[1]; 
-        console.log('Setting user data dir to ' + customDataFolder);
         app.setPath('userData', customDataFolder);
     }
     if (!isMac && hasInstallFlag) {

--- a/js/main.js
+++ b/js/main.js
@@ -65,8 +65,10 @@ const shouldQuit = app.makeSingleInstance((argv) => {
     processProtocolAction(argv);
 });
 
-// quit if another instance is already running, ignore for dev env
-if (!isDevEnv && shouldQuit) {
+let allowMultiInstance = getCmdLineArg(process.argv, '--multiInstance', true) != null || !isDevEnv;
+
+// quit if another instance is already running, ignore for dev env or if app was started with multiInstance flag
+if (!allowMultiInstance && shouldQuit) {
     app.quit();
 }
 
@@ -140,6 +142,13 @@ function setupThenOpenMainWindow() {
     // allows installer to launch app and set appropriate global / user config params.
     let hasInstallFlag = getCmdLineArg(process.argv, '--install', true);
     let perUserInstall = getCmdLineArg(process.argv, '--peruser', true);
+    let customDataArg = getCmdLineArg(process.argv, '--userDataPath=', false);
+    
+    if (customDataArg && customDataArg.split('=').length > 1) {
+        let customDataFolder = customDataArg.split('=')[1]; 
+        console.log('Setting user data dir to ' + customDataFolder);
+        app.setPath('userData', customDataFolder);
+    }
     if (!isMac && hasInstallFlag) {
         getConfigField('launchOnStartup')
             .then(setStartup)


### PR DESCRIPTION
Example usage: Symphony.app/Contents/MacOS/Symphony --multiInstance --userDataPath=/tmp/SymphonyElectron

This command will start a new instance of the app and set user data dir to /tmp/SymphonyElectron

This is needed in rtc integration testing in order to spin up multiple instances of the app and setting different user data dirs so they don't share login cookies etc