### PR TITLE
Electron 205 - Allow user to set Downloads folder through Menu dropdown

### DIFF
--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -69,22 +69,24 @@ const template = [{
         click() {
             electron.dialog.showOpenDialog({
                 title: 'Select Downloads Directory',
-                defaultPath: '~/Downloads',
                 buttonLabel: 'Select',
                 properties: ['openDirectory', 'createDirectory']
             }, (filePaths) => {
+                if (!filePaths || !Array.isArray(filePaths) || filePaths.length < 1) {
+                    return;
+                }
                 updateConfigField('downloadsDirectory', filePaths[0]);
                 eventEmitter.emit('setDownloadsDirectory', filePaths[0]);
             });
         }
     },
-        {
-            label: 'Open Crashes Directory',
-            click() {
-                const crashesDirectory = electron.crashReporter.getCrashesDirectory() + '/completed';
-                electron.shell.showItemInFolder(crashesDirectory);
-            }
-        },
+    {
+        label: 'Open Crashes Directory',
+        click() {
+            const crashesDirectory = electron.crashReporter.getCrashesDirectory() + '/completed';
+            electron.shell.showItemInFolder(crashesDirectory);
+        }
+    },
     {
         type: 'separator'
     },

--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -65,12 +65,25 @@ const template = [{
         }
     },
     {
-        label: 'Open Crashes Directory',        
+        label: 'Set Downloads Directory',
         click() {
-            const crashesDirectory = electron.crashReporter.getCrashesDirectory() + '/completed';
-            electron.shell.showItemInFolder(crashesDirectory);
+            electron.dialog.showOpenDialog({
+                title: 'Select Downloads Directory',
+                defaultPath: '~/Downloads',
+                buttonLabel: 'Select',
+                properties: ['openDirectory', 'createDirectory']
+            }, (filePaths) => {
+                updateConfigField('downloadsDirectory', filePaths[0]);
+            })
         }
     },
+        {
+            label: 'Open Crashes Directory',
+            click() {
+                const crashesDirectory = electron.crashReporter.getCrashesDirectory() + '/completed';
+                electron.shell.showItemInFolder(crashesDirectory);
+            }
+        },
     {
         type: 'separator'
     },

--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -74,7 +74,8 @@ const template = [{
                 properties: ['openDirectory', 'createDirectory']
             }, (filePaths) => {
                 updateConfigField('downloadsDirectory', filePaths[0]);
-            })
+                eventEmitter.emit('setDownloadsDirectory', filePaths[0]);
+            });
         }
     },
         {

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -244,9 +244,13 @@ function doCreateMainWindow(initialUrl, initialBounds) {
     getConfigField('downloadsDirectory')
         .then((value) => {
             downloadsDirectory = value;
-            // if the directory has been deleted, create it.
+            // if the directory has been deleted, try creating it.
             if (!fs.existsSync(downloadsDirectory)) {
-                fs.mkdirSync(downloadsDirectory);
+                const directoryCreated = fs.mkdirSync(downloadsDirectory);
+                // If the directory creation failed, we use the default downloads directory
+                if (!directoryCreated) {
+                    downloadsDirectory = null;
+                }
             }
         })
         .catch((error) => {


### PR DESCRIPTION
[**Issue**](https://perzoinc.atlassian.net/browse/ELECTRON-205)

Currently, with the electron wrapper, we don't have an option to download files onto a path that we want to. All the files are downloaded to the default download directory of the underlying OS.

This issue addresses the above problem by supporting a user to set the downloads directory specifically for electron.

**Approach**

We would be able to set the downloads directory through a menu option which opens a dialog through which we can select a directory and electron saves the path onto the user config file under the attribute "downloadsDirectory".

In case we don't have permission to set some directory, electron throws an error and we use the default downloads directory.

In case the directory is deleted by the user, we create that during the app startup everytime.

<img width="1047" alt="screen shot 2017-11-16 at 09 02 07" src="https://user-images.githubusercontent.com/5968790/32872521-293df150-caad-11e7-85c6-c4d9b0677f3b.png">
