### PR TITLE
electron-219: added a pre-install script for macOS

### DIFF
--- a/installer/mac/preinstall.sh
+++ b/installer/mac/preinstall.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+sudo killall Symphony
+sudo rm -rf /Applications/Symphony.app

--- a/installer/mac/symphony-mac-packager.pkgproj
+++ b/installer/mac/symphony-mac-packager.pkgproj
@@ -450,6 +450,13 @@
 					<key>PATH_TYPE</key>
 					<integer>1</integer>
 				</dict>
+				<key>PREINSTALL_PATH</key>
+				<dict>
+					<key>PATH</key>
+					<string>preinstall.sh</string>
+					<key>PATH_TYPE</key>
+					<integer>1</integer>
+				</dict>
 				<key>RESOURCES</key>
 				<array/>
 			</dict>


### PR DESCRIPTION
## Description
Currently, on macOS, when a new version of electron is installed, we are facing javascript issues, so, we have a ticket [ELECTRON-219](https://perzoinc.atlassian.net/browse/ELECTRON-219) which would address this by removing (quitting the app first) an already installed app on macOS during the mac installation process.

## Approach
How does this change address the problem?
- #### Problem with the code: Currently, there is no pre-install script
- #### Fix : Added a pre-install script which is part of the installer to quit & delete the already installed Symphony app.


## Learning
N/A


#### Blog Posts
N/A


## Related PRs
N/A

## Open Questions if any and Todos
N/A
