### PR TITLE
electron-219: added logic to set default values in the postinstall script

### DIFF
--- a/installer/mac/postinstall.sh
+++ b/installer/mac/postinstall.sh
@@ -12,6 +12,22 @@ minimize_on_close=$(sed -n '2p' '/tmp/sym_settings.txt');
 launch_on_startup=$(sed -n '3p' '/tmp/sym_settings.txt');
 always_on_top=$(sed -n '4p' '/tmp/sym_settings.txt');
 
+if [ "$pod_url" == "" ]; then
+    pod_url="https://corporate.symphony.com"
+fi
+
+if [ "$minimize_on_close" == "" ]; then
+    minimize_on_close=true;
+fi
+
+if [ "$launch_on_startup" == "" ]; then
+    launch_on_startup=true;
+fi
+
+if [ "$always_on_top" == "" ]; then
+    always_on_top=false;
+fi
+
 ## Replace the default settings with the user selected settings ##
 sed -i "" -E "s#\"url\" ?: ?\".*\"#\"url\"\: \"$pod_url\"#g" ${newPath}
 sed -i "" -E "s#\"minimizeOnClose\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"minimizeOnClose\":\ $minimize_on_close#g" ${newPath}


### PR DESCRIPTION
## Description
With installation on Mac via command line, the installer is not equipped to set default values (podUrl and other settings) currently. This PR addresses the problem [ELECTRON-219](https://perzoinc.atlassian.net/browse/ELECTRON-219)

## Approach
In the post install script, we check if the podUrl and other values are not empty (case where the installation is done via command line), if they are, we set default values accordingly.

## Learning
N/A

#### Blog Posts
N/A

## Related PRs
N/A

## Open Questions if any and Todos
N/A