### PR TITLE
electron-205: fixed file overwrite issues when a custom download folder is set by the user

### DIFF
--- a/js/downloadManager/index.js
+++ b/js/downloadManager/index.js
@@ -56,7 +56,8 @@ function showInFinder(id) {
 function createDOM(arg) {
 
     if (arg && arg._id) {
-        let fileDisplayName = getFileDisplayName(arg.fileName);
+        
+        let fileDisplayName = arg.fileName;
         let downloadItemKey = arg._id;
 
         local.downloadItems.push(arg);
@@ -196,33 +197,4 @@ function initiate() {
             });
         }
     }
-}
-
-/**
- * Return a file display name for the download item
- */
-function getFileDisplayName(fileName) {
-    let fileList = local.downloadItems;
-    let fileNameCount = 0;
-    let fileDisplayName = fileName;
-
-    /* Check if a file with the same name exists 
-     * (akin to the user downloading a file with the same name again)
-     * in the download bar
-     */
-    for (let i = 0; i < fileList.length; i++) {
-        if (fileName === fileList[i].fileName) {
-            fileNameCount++;
-        }
-    }
-
-    /* If it exists, add a count to the name like how Chrome does */
-    if (fileNameCount) {
-        let extLastIndex = fileDisplayName.lastIndexOf('.');
-        let fileCount = ' (' + fileNameCount + ')';
-
-        fileDisplayName = fileDisplayName.slice(0, extLastIndex) + fileCount + fileDisplayName.slice(extLastIndex);
-    }
-
-    return fileDisplayName;
 }

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -268,8 +268,7 @@ function doCreateMainWindow(initialUrl, initialBounds) {
         
         // We check the downloads directory to see if a file with the similar name
         // already exists and get a unique filename if that's the case
-        let newFileName;
-        newFileName = getUniqueFileName(item.getFilename());
+        let newFileName = getUniqueFileName(item.getFilename());
         item.setSavePath(downloadsDirectory + "/" + newFileName);
         
         // Send file path to construct the DOM in the UI when the download is complete
@@ -771,7 +770,7 @@ function getUniqueFileName(filename) {
     const fileExists = true;
     
     // We break the file from it's extension to get the name
-    const fileName = filename.substr(0, filename.lastIndexOf('.')) || filename;
+    const actualFilename = filename.substr(0, filename.lastIndexOf('.')) || filename;
     const fileType = filename.split('.').pop();
     
     // We use this to set the new file name with an increment on the previous existing file
@@ -780,7 +779,7 @@ function getUniqueFileName(filename) {
     
     while (fileExists) {
         
-        let fileNumber_str = fileNumber.toString();
+        let fileNameString = fileNumber.toString();
         
         // By default, we know if the file doesn't exist,
         // we can use the filename sent by the remote server
@@ -790,7 +789,7 @@ function getUniqueFileName(filename) {
         // file number variable is increased, so,
         // we construct a new file name with the file number
         if (fileNumber > 0) {
-            current = fileName + " (" + fileNumber_str + ")." + fileType;
+            current = actualFilename + " (" + fileNameString + ")." + fileType;
         }
         
         // If the file exists, increment the file number and repeat the loop

--- a/tests/DownloadManager.test.js
+++ b/tests/DownloadManager.test.js
@@ -16,11 +16,11 @@ describe('download manager', function() {
         });
 
         it('should inject multiple download items during multiple downloads', function() {
-            electron.ipcRenderer.send('downloadCompleted', { _id: '12345', fileName: 'test.png', total: 100 });
-            electron.ipcRenderer.send('downloadCompleted', { _id: '67890', fileName: 'test.png', total: 200 });
+            electron.ipcRenderer.send('downloadCompleted', { _id: '12345', fileName: 'test (1).png', total: 100 });
+            electron.ipcRenderer.send('downloadCompleted', { _id: '67890', fileName: 'test (2).png', total: 200 });
 
             let fileNames = document.getElementsByClassName('text-cutoff');
-            let fNames = [];            
+            let fNames = [];
             
             for (var i = 0; i < fileNames.length; i++) {
                 fNames.push(fileNames[i].innerHTML);


### PR DESCRIPTION
## Description
Supports functionality to set a custom downloads folder in electron [electron-205](https://perzoinc.atlassian.net/browse/electron-205)

Although this was already done, there was an issue where in with a custom downloads folder, an existing file used to be overwritten unlike chrome which appends a number to the new filename in case the file already exists.

## Approach
How does this change address the problem?
- #### Problem with the code: Electron's default download mechanism doesn't support the increment behaviour for a custom folder
- #### Fix : Wrote a custom logic to support the above functionality


## Learning
N/A

#### Blog Posts
N/A

## Related PRs
N/A


## Open Questions if any and Todos
N/A