### PR TITLE
electron-255: fixes electron-255

### DIFF
--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -270,7 +270,12 @@ function doCreateMainWindow(initialUrl, initialBounds) {
         // We check the downloads directory to see if a file with the similar name
         // already exists and get a unique filename if that's the case
         let newFileName = getUniqueFileName(item.getFilename());
-        item.setSavePath(downloadsDirectory + "/" + newFileName);
+        
+        if (isMac) {
+            item.setSavePath(downloadsDirectory + "/" + newFileName);
+        } else {
+            item.setSavePath(downloadsDirectory + "\\" + newFileName);
+        }
         
         // Send file path to construct the DOM in the UI when the download is complete
         item.once('done', (e, state) => {


### PR DESCRIPTION
## Description
As a result of electron-205, on Windows, when an item was asked to be "Show in Folder", the item was not being highlighted.

This was because we need to use backslashes and escape them on Windows. It has been fixed now.

## Approach
As per this ticket, found the fix -> https://github.com/electron/electron/issues/11362