### PR TITLE
ELECTRON-299: upgrade to Electron 1.7.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "devDependencies": {
     "browserify": "^14.1.0",
     "cross-env": "^3.2.4",
-    "electron": "^1.7.11",
+    "electron": "^1.7.12",
     "electron-builder": "^13.9.0",
     "electron-builder-squirrel-windows": "^12.3.0",
     "electron-packager": "^8.5.2",


### PR DESCRIPTION
## Description
Electron 1.7.12 adds a security fix for windows apps.
 [JIRA-ticket](https://perzoinc.atlassian.net/browse/ELECTRON-299)

## Open Questions if any and Todos
- [x] Unit-Tests
