### PR TITLE
ELECTRON-305: Upgrade to electron 1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "devDependencies": {
     "browserify": "^14.1.0",
     "cross-env": "^3.2.4",
-    "electron": "^1.7.12",
+    "electron": "^1.8.2",
     "electron-builder": "^13.9.0",
     "electron-builder-squirrel-windows": "^12.3.0",
     "electron-packager": "^8.5.2",


### PR DESCRIPTION
## Description
Upgrade to electron 1.8.2 which bundles chrome 59, node 8.x and fixes a number of bugs. More details are in the [JIRA-ticket](https://perzoinc.atlassian.net/browse/ELECTRON-305)

## Open Questions if any and Todos
- [x] Unit-Tests
- [x] Documentation
- [x] Automation-Tests
When solved, check the box and explain the answer.
