### PR TITLE
SEARCH-605 (Electron - Cannot enable swift search on Windows 7)

### DIFF
--- a/js/search/searchConfig.js
+++ b/js/search/searchConfig.js
@@ -57,7 +57,10 @@ const searchConfig = {
     LIBRARY_CONSTANTS: libraryPaths,
     FOLDERS_CONSTANTS: folderPaths,
     TAR_LZ4_EXT: '.tar.lz4',
-    MINIMUM_DISK_SPACE: 300000000 // in bytes
+    MINIMUM_DISK_SPACE: 300000000, // in bytes
+    PERMISSION_ERROR: "The FSUTIL utility requires that you have administrative privileges.",
+    WIN_PATH_ERROR: "Error:  The system cannot find the path specified.",
+    MAC_PATH_ERROR: "No such file or directory"
 };
 
 module.exports = searchConfig;

--- a/js/search/utils/checkDiskSpace.js
+++ b/js/search/utils/checkDiskSpace.js
@@ -32,13 +32,13 @@ function checkDiskSpace(path, resolve, reject) {
                 }
                 if (stdout.indexOf("The FSUTIL utility requires that you have administrative privileges.") !== -1) {
                     // this is temporary until we use the custom exe file.
-                    return true;
+                    return resolve(true);
                 }
                 return reject(new Error("Error : " + error));
             }
             if (stdout.indexOf("The FSUTIL utility requires that you have administrative privileges.") !== -1) {
                 // this is temporary until we use the custom exe file.
-                return true;
+                return resolve(true);
             }
             let data = stdout.trim().split("\n");
 

--- a/js/search/utils/checkDiskSpace.js
+++ b/js/search/utils/checkDiskSpace.js
@@ -25,12 +25,20 @@ function checkDiskSpace(path, resolve, reject) {
             return resolve(space >= searchConfig.MINIMUM_DISK_SPACE);
         });
     } else {
-        exec(`fsutil volume diskfree ${path}`, (error, stdout, stderr) => {
+        exec(`fsutil volume diskfree ${path}`, (error, stdout) => {
             if (error) {
-                if (stderr.indexOf("No such file or directory") !== -1) {
+                if (stdout.indexOf("Error:  The system cannot find the path specified.") !== -1) {
                     return reject(new Error("No such file or directory : " + error));
                 }
+                if (stdout.indexOf("The FSUTIL utility requires that you have administrative privileges.") !== -1) {
+                    // this is temporary until we use the custom exe file.
+                    return true;
+                }
                 return reject(new Error("Error : " + error));
+            }
+            if (stdout.indexOf("The FSUTIL utility requires that you have administrative privileges.") !== -1) {
+                // this is temporary until we use the custom exe file.
+                return true;
             }
             let data = stdout.trim().split("\n");
 

--- a/js/search/utils/checkDiskSpace.js
+++ b/js/search/utils/checkDiskSpace.js
@@ -11,8 +11,8 @@ function checkDiskSpace(path, resolve, reject) {
     if (isMac) {
         exec("df -k '" + path.replace(/'/g,"'\\''") + "'", (error, stdout, stderr) => {
             if (error) {
-                if (stderr.indexOf("No such file or directory") !== -1) {
-                    return reject(new Error("No such file or directory : " + error))
+                if (stderr.indexOf(searchConfig.MAC_PATH_ERROR) !== -1) {
+                    return reject(new Error(`${searchConfig.MAC_PATH_ERROR} ${error}`))
                 }
                 return reject(new Error("Error : " + error));
             }
@@ -27,16 +27,16 @@ function checkDiskSpace(path, resolve, reject) {
     } else {
         exec(`fsutil volume diskfree ${path}`, (error, stdout) => {
             if (error) {
-                if (stdout.indexOf("Error:  The system cannot find the path specified.") !== -1) {
-                    return reject(new Error("No such file or directory : " + error));
+                if (stdout.indexOf(searchConfig.WIN_PATH_ERROR) !== -1) {
+                    return reject(new Error(`${searchConfig.WIN_PATH_ERROR} ${error}`));
                 }
-                if (stdout.indexOf("The FSUTIL utility requires that you have administrative privileges.") !== -1) {
+                if (stdout.indexOf(searchConfig.PERMISSION_ERROR) !== -1) {
                     // this is temporary until we use the custom exe file.
                     return resolve(true);
                 }
                 return reject(new Error("Error : " + error));
             }
-            if (stdout.indexOf("The FSUTIL utility requires that you have administrative privileges.") !== -1) {
+            if (stdout.indexOf(searchConfig.PERMISSION_ERROR) !== -1) {
                 // this is temporary until we use the custom exe file.
                 return resolve(true);
             }

--- a/tests/Search.test.js
+++ b/tests/Search.test.js
@@ -59,7 +59,7 @@ describe('Tests for Search', function() {
             tempBatchPath = path.join(userConfigDir, 'data', 'temp_batch_indexes');
             dataFolderPath = path.join(userConfigDir, 'data');
             if (fs.existsSync(dataFolderPath)) {
-                fs.unlinkSync(dataFolderPath)
+                deleteIndexFolders(dataFolderPath)
             }
             done();
         });

--- a/tests/Search.test.js
+++ b/tests/Search.test.js
@@ -1,7 +1,7 @@
 const childProcess = require('child_process');
 const path = require('path');
 const fs = require('fs');
-const { isMac } = require('../js/utils/misc.js');
+const { isWindowsOS } = require('../js/utils/misc.js');
 
 let executionPath = null;
 let userConfigDir = null;
@@ -46,7 +46,7 @@ describe('Tests for Search', function() {
             key = 'jjjehdnctsjyieoalskcjdhsnahsadndfnusdfsdfsd=';
 
             executionPath = path.join(__dirname, 'library');
-            if (!isMac) {
+            if (isWindowsOS) {
                 executionPath = path.join(__dirname, '..', 'library');
             }
             userConfigDir = path.join(__dirname, '..');

--- a/tests/SearchUtils.test.js
+++ b/tests/SearchUtils.test.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { isMac } = require('../js/utils/misc.js');
+const { isMac, isWindowsOS } = require('../js/utils/misc.js');
 
 let executionPath = null;
 let userConfigDir = null;
@@ -33,7 +33,7 @@ describe('Tests for Search Utils', function() {
 
     beforeAll(function (done) {
         executionPath = path.join(__dirname, 'library');
-        if (!isMac) {
+        if (isWindowsOS) {
             executionPath = path.join(__dirname, '..', 'library');
         }
         userConfigDir = path.join(__dirname, '..');
@@ -84,7 +84,7 @@ describe('Tests for Search Utils', function() {
         it('should return error invalid path', function (done) {
             const checkFreeSpace = jest.spyOn(SearchUtilsAPI, 'checkFreeSpace');
             SearchUtilsAPI.path = './tp';
-            if (!isMac) {
+            if (isWindowsOS) {
                 SearchUtilsAPI.path = 'A://test';
             }
             SearchUtilsAPI.checkFreeSpace().catch(function (err) {

--- a/tests/SearchUtils.test.js
+++ b/tests/SearchUtils.test.js
@@ -33,6 +33,9 @@ describe('Tests for Search Utils', function() {
 
     beforeAll(function (done) {
         executionPath = path.join(__dirname, 'library');
+        if (!isMac) {
+            executionPath = path.join(__dirname, '..', 'library');
+        }
         userConfigDir = path.join(__dirname, '..');
         searchConfig = require('../js/search/searchConfig.js');
         const { SearchUtils } = require('../js/search/searchUtils.js');


### PR DESCRIPTION
## Description
Electron - Cannot enable swift search on Windows 7
[JIRA-ticket](https://perzoinc.atlassian.net/browse/SEARCH-605)

_Note: This is a temporary patch. If there are permission issue and the disk space is less than 300MB the swift search will be enabled._

## Approach
How does this change address the problem?
- #### Problem with the code: FSUTIL utility requires administrative privileges
- #### Fix: This fix will be released as a part of [SEARCH-621](https://perzoinc.atlassian.net/browse/SEARCH-621)

@VikasShashidhar @serkanmulayim Please review. Thanks

## Learning
[Fsutil](https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc753059(v=ws.10))

## Open Questions if any and Todos
- [x] Unit-Tests
![screen shot 2018-02-15 at 12 31 31 pm](https://user-images.githubusercontent.com/596478/36244436-30ac4cb6-124c-11e8-96f3-0453b26537be.png)
- [x] Documentation
- [ ] Automation-Tests