### PR TITLE
Electron 276: add gpu flags in electron

### DIFF
--- a/config/Symphony.config
+++ b/config/Symphony.config
@@ -17,8 +17,6 @@
     "customFlags": {
         "authServerWhitelist": "",
         "authNegotiateDelegateWhitelist": "",
-        "disableGpu": false,
-        "disableGpuCompositing": false,
-        "disableD3d11": false
+        "disableGpu": false
     }
 }

--- a/config/Symphony.config
+++ b/config/Symphony.config
@@ -16,6 +16,9 @@
     },
     "customFlags": {
         "authServerWhitelist": "",
-        "authNegotiateDelegateWhitelist": ""
+        "authNegotiateDelegateWhitelist": "",
+        "disableGpu": false,
+        "disableGpuCompositing": false,
+        "disableD3d11": false
     }
 }

--- a/js/main.js
+++ b/js/main.js
@@ -13,7 +13,7 @@ const urlParser = require('url');
 // Local Dependencies
 const {getConfigField, updateUserConfigWin, updateUserConfigMac, readConfigFileSync} = require('./config.js');
 const {setCheckboxValues} = require('./menus/menuTemplate.js');
-const { isMac, isDevEnv } = require('./utils/misc.js');
+const { isMac, isDevEnv, isWindowsOS } = require('./utils/misc.js');
 const protocolHandler = require('./protocolHandler');
 const getCmdLineArg = require('./utils/getCmdLineArg.js');
 const log = require('./log.js');
@@ -21,6 +21,15 @@ const logLevels = require('./enums/logLevels.js');
 const { deleteIndexFolder } = require('./search/search.js');
 
 require('electron-dl')();
+
+// ELECTRON-261: On Windows, due to gpu issues, we need to disable gpu
+// to ensure screen sharing works effectively with multiple monitors
+// https://github.com/electron/electron/issues/4380
+if (isWindowsOS) {
+    app.commandLine.appendSwitch("disable-gpu", true);
+    app.commandLine.appendSwitch("disable-gpu-compositing", true);
+    app.commandLine.appendSwitch("disable-d3d11", true);
+}
 
 //setting the env path child_process issue https://github.com/electron/electron/issues/7688
 shellPath()

--- a/js/main.js
+++ b/js/main.js
@@ -138,17 +138,9 @@ function setChromeFlags() {
         // to disable gpu which fixes the black screen issue observed on
         // multiple monitors
         if (config.customFlags.disableGpu) {
-            log.send(logLevels.INFO, 'Setting disable gpu flag');
+            log.send(logLevels.INFO, 'Setting disable gpu, gpu compositing and d3d11 flags to true');
             app.commandLine.appendSwitch("disable-gpu", true);
-        }
-
-        if (config.customFlags.disableGpuCompositing) {
-            log.send(logLevels.INFO, 'Setting disable gpu compositing flag');
             app.commandLine.appendSwitch("disable-gpu-compositing", true);
-        }
-
-        if (config.customFlags.disableD3d11) {
-            log.send(logLevels.INFO, 'Setting disable d3d11 flag');
             app.commandLine.appendSwitch("disable-d3d11", true);
         }
 

--- a/js/main.js
+++ b/js/main.js
@@ -13,7 +13,7 @@ const urlParser = require('url');
 // Local Dependencies
 const {getConfigField, updateUserConfigWin, updateUserConfigMac, readConfigFileSync} = require('./config.js');
 const {setCheckboxValues} = require('./menus/menuTemplate.js');
-const { isMac, isDevEnv, isWindowsOS } = require('./utils/misc.js');
+const { isMac, isDevEnv } = require('./utils/misc.js');
 const protocolHandler = require('./protocolHandler');
 const getCmdLineArg = require('./utils/getCmdLineArg.js');
 const log = require('./log.js');


### PR DESCRIPTION
## Description
For windows environments to ensure screen-sharing doesn't break with multiple monitors, we add flags to disable gpu
 [JIRA-ticket](https://perzoinc.atlassian.net/browse/ELECTRON-276)

## Approach
With electron, we can set chrome flags which should help us with the issue.

## Learning
https://windowsreport.com/chrome-black-screen-problem-windows-10/