### PR TITLE
ELECTRON-274: fix issue for diagnostics link

### DIFF
--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -323,7 +323,7 @@ function doCreateMainWindow(initialUrl, initialBounds) {
 
         // only allow window.open to succeed is if coming from same hsot,
         // otherwise open in default browser.
-        if (((newWinHost === mainWinHost) || newWinUrl === emptyUrlString) && dispositionWhitelist.includes(disposition)) {
+        if ((newWinHost === mainWinHost || newWinUrl === emptyUrlString) && dispositionWhitelist.includes(disposition)) {
             // handle: window.open
 
             if (!frameName) {

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -311,7 +311,7 @@ function doCreateMainWindow(initialUrl, initialBounds) {
     // open external links in default browser - a tag with href='_blank' or window.open
     mainWindow.webContents.on('new-window', function (event, newWinUrl,
         frameName, disposition, newWinOptions) {
-        
+
         let newWinParsedUrl = getParsedUrl(newWinUrl);
         let mainWinParsedUrl = getParsedUrl(url);
 
@@ -319,10 +319,11 @@ function doCreateMainWindow(initialUrl, initialBounds) {
         let mainWinHost = mainWinParsedUrl && mainWinParsedUrl.host;
 
         let emptyUrlString = 'about:blank';
-        
+        let dispositionWhitelist = ['new-window', 'foreground-tab'];
+
         // only allow window.open to succeed is if coming from same hsot,
         // otherwise open in default browser.
-        if (disposition === 'new-window' && ((newWinHost === mainWinHost) || newWinUrl === emptyUrlString)) {
+        if (((newWinHost === mainWinHost) || newWinUrl === emptyUrlString) && dispositionWhitelist.includes(disposition)) {
             // handle: window.open
 
             if (!frameName) {


### PR DESCRIPTION
## Description
Currently, when we try to open the diagnostics link from Electron, it gets opened in a browser. This doesn't help in trying to collect information for the electron client. This PR provides a fix for the same where in a new pop up is opened instead of opening the diagnostics link in a new window. [JIRA-ticket](https://perzoinc.atlassian.net/browse/ELECTRON-274)

## Approach
- #### Problem with the code: We have a condition to check if the disposition for opening a new pop up is "new-window" and only those cases are being considered to create a new pop up. For the diagnostics link which is a relative url, the disposition is a "foreground-tab" which is not whitelisted on electron's side.
- #### Fix: We whitelist "foreground-tab" in the list of allowed disposition cases for opening a new pop up window.