### PR TITLE
ELECTRON-293: remove notification limit of 5 and match it with screen size

### DIFF
--- a/js/notify/electron-notify.js
+++ b/js/notify/electron-notify.js
@@ -283,7 +283,6 @@ function setupConfig() {
 
     // Maximum amount of Notifications we can show:
     config.maxVisibleNotifications = Math.floor(display.workAreaSize.height / config.totalHeight);
-    config.maxVisibleNotifications = config.maxVisibleNotifications > 5 ? 5 : config.maxVisibleNotifications;
 }
 
 /**


### PR DESCRIPTION
## Description
Currently, on Windows systems, we restrict the number of notifications to 5 regardless of how big the screen is. GS requested this to be changed to match the screen real estate. [ELECTRON-293](https://perzoinc.atlassian.net/browse/ELECTRON-293)

## Approach
We calculate the screen size and based on that display the number of notifications.
- #### Problem with the code: Currently, we set the max number of notifications to 5
- #### Fix: Remove the restriction.

## Open Questions if any and Todos
- [x] Unit-Tests
- [x] Documentation
- [x] Automation-Tests
[electron-293 - spectron-tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1794046/electron-293.-.spectron-tests.pdf)
[electron-293 - unit-tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1794047/electron-293.-.unit-tests.pdf)
