### PR TITLE
Electron-325 (Removed restriction from opening a popup from another popup window)

### DIFF
--- a/demo/childWin.html
+++ b/demo/childWin.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Child pop-out window</title>
+</head>
+<body>
+<h3>This is a child window created by a child window</h3>
+<button id="open-win">Open a new child window</button>
+<br>
+<br>
+
+<button id="open-in-browser">Open Symphony in browser</button>
+
+<br>
+<script>
+    var openWinButton = document.getElementById('open-win');
+    openWinButton.addEventListener('click', function() {
+        win = window.open('childWin.html?x=100&y=100', 'childWin', 'height=800,width=400');
+    });
+
+    var openInBrowser = document.getElementById('open-in-browser');
+    openInBrowser.addEventListener('click', function () {
+        window.open('https://symphony.com');
+    });
+</script>
+</body>
+</html>

--- a/demo/win.html
+++ b/demo/win.html
@@ -17,7 +17,7 @@ Test Window has been opened
 <br>
 <br>
 
-<a href="https://symphony.com" target="_blank">Open Symphony Anchor Tag</a>
+<a href="https://symphony.com" target="_blank">Open Symphony</a>
 
 <hr>
 <p>Badge Count:<p>

--- a/demo/win.html
+++ b/demo/win.html
@@ -1,11 +1,23 @@
 <html>
 <head>
+    <meta charset="UTF-8">
+    <title>Test pop-out window</title>
 </head>
 Test Window has been opened
 <p>
     <label for='tag'>tag:</label>
     <input type='text' id='tag' value=''/>
 </p>
+
+<button id="open-win">Open a new child window</button>
+<br>
+<br>
+
+<button id="open-in-browser">Open Symphony in browser</button>
+<br>
+<br>
+
+<a href="https://symphony.com" target="_blank">Open Symphony Anchor Tag</a>
 
 <hr>
 <p>Badge Count:<p>
@@ -20,5 +32,16 @@ Test Window has been opened
             badgeCount++;
             ssf.setBadgeCount(badgeCount);
         });
+
+        var openWinButton = document.getElementById('open-win');
+        openWinButton.addEventListener('click', function() {
+            win = window.open('childWin.html?x=200&y=200', 'childWin', 'height=500,width=500');
+        });
+
+        var openInBrowser = document.getElementById('open-in-browser');
+        openInBrowser.addEventListener('click', function () {
+            window.open('https://symphony.com');
+        });
+
     </script>
 </html>

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -309,8 +309,9 @@ function doCreateMainWindow(initialUrl, initialBounds) {
     }
 
     // open external links in default browser - a tag with href='_blank' or window.open
-    mainWindow.webContents.on('new-window', function (event, newWinUrl,
-        frameName, disposition, newWinOptions) {
+    mainWindow.webContents.on('new-window', handleNewWindow);
+
+    function handleNewWindow(event, newWinUrl, frameName, disposition, newWinOptions) {
 
         let newWinParsedUrl = getParsedUrl(newWinUrl);
         let mainWinParsedUrl = getParsedUrl(url);
@@ -419,7 +420,7 @@ function doCreateMainWindow(initialUrl, initialBounds) {
                     });
 
                     browserWin.on('close', () => {
-                        browserWin.webContents.removeListener('new-window', handleChildNewWindowEvent);
+                        browserWin.webContents.removeListener('new-window', handleNewWindow);
                         browserWin.webContents.removeListener('crashed', handleChildWindowCrashEvent);
                     });
 
@@ -443,15 +444,10 @@ function doCreateMainWindow(initialUrl, initialBounds) {
 
                     browserWin.webContents.on('crashed', handleChildWindowCrashEvent);
 
-                    let handleChildNewWindowEvent = (childEvent, childWinUrl) => {
-                        childEvent.preventDefault();
-                        openUrlInDefaultBrowser(childWinUrl);
-                    };
-
                     // In case we navigate to an external link from inside a pop-out,
                     // we open that link in an external browser rather than creating
                     // a new window
-                    browserWin.webContents.on('new-window', handleChildNewWindowEvent);
+                    browserWin.webContents.on('new-window', handleNewWindow.bind(this));
 
                     addWindowKey(newWinKey, browserWin);
 
@@ -471,7 +467,7 @@ function doCreateMainWindow(initialUrl, initialBounds) {
             event.preventDefault();
             openUrlInDefaultBrowser(newWinUrl);
         }
-    });
+    }
 
     // whenever the main window is navigated for ex: window.location.href or url redirect
     mainWindow.webContents.on('will-navigate', function (event, navigatedURL) {

--- a/tests/spectron/popOuts.spectron.js
+++ b/tests/spectron/popOuts.spectron.js
@@ -1,0 +1,99 @@
+const Application = require('./spectronSetup');
+const path = require('path');
+
+let app = new Application({});
+
+describe('Tests for pop outs', () => {
+
+    let originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = Application.getTimeOut();
+
+    beforeAll((done) => {
+        return app.startApplication().then((startedApp) => {
+            app = startedApp;
+            done();
+        }).catch((err) => {
+            console.error(`Unable to start application error: ${err}`);
+            expect(err).toBeNull();
+            done();
+        });
+    });
+
+    afterAll((done) => {
+        if (app && app.isRunning()) {
+            jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+            app.stop().then(() => {
+                done();
+            }).catch((err) => {
+                done();
+            });
+        }
+    });
+
+    it('should launch the app', (done) => {
+        return app.client.waitUntilWindowLoaded().then(() => {
+            return app.client.getWindowCount().then((count) => {
+                expect(count === 1).toBeTruthy();
+                done();
+            }).catch((err) => {
+                expect(err).toBeNull();
+            });
+        }).catch((err) => {
+            expect(err).toBeNull();
+        });
+    });
+
+    it('should check window count', () => {
+        return app.client.url('file:///' + path.join(__dirname, '..', '..', 'demo/index.html'));
+    });
+
+    it('should open a new window and verify', function (done) {
+        app.client.waitForExist('#open-win', 2000);
+        app.client.moveToObject('#open-win', 10, 10);
+        app.client.leftClick('#open-win', 10, 10);
+
+        setTimeout(() => {
+            app.client.getWindowCount().then((count) => {
+                expect(count === 2).toBeTruthy();
+                done();
+            });
+        }, 2000);
+    });
+
+    it('should click on the external link and verify window', function () {
+        return app.client.windowByIndex(1).then(() => {
+            app.client.waitForExist('#open-in-browser', 2000);
+            app.client.moveToObject('#open-in-browser', 10, 10);
+            app.client.leftClick('#open-in-browser', 10, 10);
+
+            return app.client.getWindowCount().then((count) => {
+                expect(count === 2).toBeTruthy();
+            });
+        });
+    });
+
+    it('should open a child window from pop-out and verify', function (done) {
+        app.client.waitForExist('#open-win', 2000);
+        app.client.moveToObject('#open-win', 10, 10);
+        app.client.leftClick('#open-win', 10, 10);
+
+        setTimeout(() => {
+            app.client.getWindowCount().then((count) => {
+                expect(count === 3).toBeTruthy();
+                done();
+            });
+        }, 2000);
+    });
+
+    it('should click on the external link in a child pop-out without creating a window', function () {
+        return app.client.windowByIndex(2).then(() => {
+            app.client.waitForExist('#open-in-browser', 2000);
+            app.client.moveToObject('#open-in-browser', 10, 10);
+            app.client.leftClick('#open-in-browser', 10, 10);
+
+            return app.client.getWindowCount().then((count) => {
+                expect(count === 3).toBeTruthy();
+            });
+        });
+    });
+});

--- a/tests/spectron/popOuts.spectron.js
+++ b/tests/spectron/popOuts.spectron.js
@@ -13,7 +13,7 @@ describe('Tests for pop outs', () => {
             app = startedApp;
             done();
         }).catch((err) => {
-            console.error(`Unable to start application error: ${err}`);
+            console.error(`Unable to start application: ${err}`);
             expect(err).toBeNull();
             done();
         });
@@ -43,7 +43,7 @@ describe('Tests for pop outs', () => {
         });
     });
 
-    it('should check window count', () => {
+    it('should load the demo page', () => {
         return app.client.url('file:///' + path.join(__dirname, '..', '..', 'demo/index.html'));
     });
 


### PR DESCRIPTION
## Description
Removed restriction from opening a popup from another popup window [ELECTRON-325](https://perzoinc.atlassian.net/browse/ELECTRON-325)


## Approach
How does this change address the problem?
#### Problem with the code: 
- The previous implementation was restricted to popup a window only from the main window.
#### Fix:
- Removed the restriction which validates and creates the pop-out window

## Before
![electron-325-before](https://user-images.githubusercontent.com/13243259/37206330-37f120ea-23be-11e8-8b9b-f505bfa88adc.gif)

## After
![electron-325-after](https://user-images.githubusercontent.com/13243259/37206373-68214fb0-23be-11e8-9073-7b1f2c640cd3.gif)

## Spectron test results
[Test Results — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1796756/Test.Results.Spectron.pdf)

## Unit test results
[Test Results — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1796758/Test.Results.Unit.Tests.pdf)


## Learning
- N/A


#### Blog Posts
- N/A


## Open Questions if any and Todos
- [X] Unit-Tests (N/A)
- [x] Documentation
- [X] Automation-Tests
When solved, check the box and explain the answer.

@VikasShashidhar & @VishwasShashidhar Please review. Thanks 😄 