### PR TITLE
Electron-338 (Replace html tags from message content)

### DIFF
--- a/js/notify/notifyImpl.js
+++ b/js/notify/notifyImpl.js
@@ -33,8 +33,10 @@ class Notify {
         let emitter = new EventEmitter();
         this.emitter = Queue(emitter);
 
-        // Replaces all html <> tags to entity name
-        let message = replaceHTMLTags(options.body);
+        // Replace strong html tags from the options.body
+        let message = replaceStrongTag(options.body);
+        // Replaces all html angle brackets w.r.t their entity name
+        message = replaceHTMLTags(message);
 
         this._id = notify({
             title: title,
@@ -252,6 +254,11 @@ function Queue(emitter) {
  * @return {void | string | *}
  */
 function replaceHTMLTags(string) {
+
+    if (typeof string !== 'string') {
+        return null;
+    }
+
     const tagsToReplace = {
         '<': '&lt;',
         '>': '&gt;'
@@ -262,6 +269,22 @@ function replaceHTMLTags(string) {
     }
 
     return string.replace(/[<>]/g, replaceTag);
+}
+
+/**
+ * Replace strong HTML tags from the string
+ *
+ * @param string
+ * @return {void | string | *}
+ */
+// TODO(KiranNiranjan): Can be removed after 2-3 sprints
+function replaceStrongTag(string) {
+
+    if (typeof string !== 'string') {
+        return null;
+    }
+
+    return string.replace(/(?:<strong>)|(?:<\/strong>)+/g, '');
 }
 
 

--- a/js/notify/notifyImpl.js
+++ b/js/notify/notifyImpl.js
@@ -277,7 +277,6 @@ function replaceHTMLTags(string) {
  * @param string
  * @return {void | string | *}
  */
-// TODO(KiranNiranjan): Can be removed after 2-3 sprints
 function replaceStrongTag(string) {
 
     if (typeof string !== 'string') {
@@ -286,6 +285,5 @@ function replaceStrongTag(string) {
 
     return string.replace(/(?:<strong>)|(?:<\/strong>)+/g, '');
 }
-
 
 module.exports = Notify;

--- a/js/notify/notifyImpl.js
+++ b/js/notify/notifyImpl.js
@@ -33,9 +33,12 @@ class Notify {
         let emitter = new EventEmitter();
         this.emitter = Queue(emitter);
 
+        // Replaces all html <> tags to entity name
+        let message = replaceHTMLTags(options.body);
+
         this._id = notify({
             title: title,
-            text: options.body,
+            text: message || '',
             image: options.image || options.icon,
             flash: options.flash,
             color: options.color,
@@ -240,5 +243,26 @@ function Queue(emitter) {
 
     return modifiedEmitter;
 }
+
+/**
+ * Replace HTML tags <> from messages test to prevent
+ * HTML injection
+ *
+ * @param string
+ * @return {void | string | *}
+ */
+function replaceHTMLTags(string) {
+    const tagsToReplace = {
+        '<': '&lt;',
+        '>': '&gt;'
+    };
+
+    function replaceTag(tag) {
+        return tagsToReplace[tag] || tag;
+    }
+
+    return string.replace(/[<>]/g, replaceTag);
+}
+
 
 module.exports = Notify;

--- a/js/notify/notifyImpl.js
+++ b/js/notify/notifyImpl.js
@@ -250,12 +250,12 @@ function Queue(emitter) {
  * Replace HTML tags <> from messages test to prevent
  * HTML injection
  *
- * @param string
+ * @param message {String}    main text to display in notifications
  * @return {void | string | *}
  */
-function replaceHTMLTags(string) {
+function replaceHTMLTags(message) {
 
-    if (typeof string !== 'string') {
+    if (typeof message !== 'string') {
         return null;
     }
 
@@ -268,22 +268,22 @@ function replaceHTMLTags(string) {
         return tagsToReplace[tag] || tag;
     }
 
-    return string.replace(/[<>]/g, replaceTag);
+    return message.replace(/[<>]/g, replaceTag);
 }
 
 /**
  * Replace strong HTML tags from the string
  *
- * @param string
+ * @param message {String}    main text to display in notifications
  * @return {void | string | *}
  */
-function replaceStrongTag(string) {
+function replaceStrongTag(message) {
 
-    if (typeof string !== 'string') {
+    if (typeof message !== 'string') {
         return null;
     }
 
-    return string.replace(/(?:<strong>)|(?:<\/strong>)+/g, '');
+    return message.replace(/(?:<strong>)|(?:<\/strong>)+/g, '');
 }
 
 module.exports = Notify;


### PR DESCRIPTION
## Description
Replace HTML tag `<>` from message content to prevent HTML injection [ELECTRON-338](https://perzoinc.atlassian.net/browse/ELECTRON-338)


## Approach
How does this change address the problem?
#### Problem with the code:
- Messages with HTML content were not being filtered and was able to inject arbitrary HTML code into notifications
#### Fix:
- Replacing HTML tags `<>` with the entity names

### Before
![screen shot 2018-03-12 at 4 58 15 pm](https://user-images.githubusercontent.com/13243259/37282853-ea33da86-261b-11e8-9530-b05a33f05a44.png)

### After
![screen shot 2018-03-12 at 4 58 55 pm](https://user-images.githubusercontent.com/13243259/37282868-f06d5e36-261b-11e8-9a8e-06d2478b69fa.png)

## Spectron test results
[Electron-338 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1803034/Electron-338.Spectron.pdf)

## Unit test results
[Electron-338 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1803036/Electron-338.Unit.Tests.pdf)


## Open Questions if any and Todos
- [X] Unit-Tests (Not Applicable)
- [X] Documentation
- [ ] Automation-Tests
When solved, check the box and explain the answer.

@VikasShashidhar & @VishwasShashidhar Please review. Thanks 😄 
