### PR TITLE
ELECTRON-370: upgrade electron dependency to 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "bluebird": "3.5.1",
     "browserify": "14.5.0",
     "cross-env": "3.2.4",
-    "electron": "1.8.3",
+    "electron": "1.8.4",
     "electron-builder": "13.11.1",
     "electron-builder-squirrel-windows": "12.3.0",
     "electron-chromedriver": "1.8.0",


### PR DESCRIPTION
## Description
Upgrade electron library dependency to 1.8.4 [ELECTRON-370](https://perzoinc.atlassian.net/browse/ELECTRON-370)

## Approach
N/A

## Learning
N/A

#### Blog Posts
N/A

## Related PRs
N/A

## Unit Tests Results
[ELECTRON-370 - Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1824954/ELECTRON-370.-.Unit.Tests.pdf)

## Spectron Tests Results
[ELECTRON-370 - Spectron Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1825000/ELECTRON-370.-.Spectron.Tests.pdf)

## Open Questions if any and Todos
- [x] Unit-Tests
- [x] Documentation
- [x] Automation-Tests
