### PR TITLE
Electron-373 (Fix issue with closing screen picker modal)

### DIFF
--- a/js/desktopCapturer/screen-picker.html
+++ b/js/desktopCapturer/screen-picker.html
@@ -45,6 +45,8 @@
         #x-button {
             width: 20px;
             color: rgba(221, 221, 221, 1);
+            -webkit-app-region: no-drag;
+            cursor: pointer;
         }
 
         span {


### PR DESCRIPTION
## Description
Fix issue with closing screen picker modal [ELECTRON-373](https://perzoinc.atlassian.net/browse/ELECTRON-373)


## Approach
How does this change address the problem?
#### Problem with the code:
- Close was a child of `app-region: drag` content which was blocking the click event
#### Fix:
- Adding `app-region: no-drag` fixes the issue


## Learning
- [Issue](https://github.com/electron/electron/issues/1354)


## Spectron test results
[Electron-373 — Spectron Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1829514/Electron-373.Spectron.Tests.pdf)

## Unit test results
[Electron-373 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1829518/Electron-373.Unit.Tests.pdf)


## Open Questions if any and Todos
- [X] Unit-Tests (Not Applicable)
- [ ] Documentation
- [ ] Automation-Tests
When solved, check the box and explain the answer.

@VishwasShashidhar & @VikasShashidhar Please review. Thanks 😄 
