### PR TITLE
ELECTRON-337: remove dev tools menu item

### DIFF
--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -81,15 +81,6 @@ const template = [{
         }
     },
     {
-        label: 'Toggle Developer Tools',
-        accelerator: isMac ? 'Alt+Command+I' : 'Ctrl+Shift+I',
-        click(item, focusedWindow) {
-            if (focusedWindow) {
-                focusedWindow.webContents.toggleDevTools();
-            }
-        }
-    },
-    {
         label: 'Set Downloads Directory',
         click() {
             electron.dialog.showOpenDialog({

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const electron = require('electron');
 const app = electron.app;
+const globalShortcut = electron.globalShortcut;
 const crashReporter = electron.crashReporter;
 const BrowserWindow = electron.BrowserWindow;
 const path = require('path');
@@ -224,6 +225,7 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
         });
     });
     
+    registerShortcuts();
     handlePermissionRequests(mainWindow.webContents);
 
     addWindowKey(key, mainWindow);
@@ -505,7 +507,25 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
             });
     });
     
-    // ELECTRON-323: Handle session permission requests
+    /**
+     * Register shortcuts for the app
+     */
+    function registerShortcuts() {
+        
+        // Register dev tools shortcut
+        globalShortcut.register(isMac ? 'Alt+Command+I' : 'Ctrl+Shift+I', () => {
+            let focusedWindow = BrowserWindow.getFocusedWindow();
+            if (focusedWindow && !focusedWindow.isDestroyed()) {
+                focusedWindow.webContents.toggleDevTools();
+            }
+        });
+        
+    }
+    
+    /**
+     * Sets permission requests for the window
+     * @param webContents Web contents of the window
+     */
     function handlePermissionRequests(webContents) {
         
         let session = webContents.session;

--- a/tests/spectron/alwaysOnTop.spectron.js
+++ b/tests/spectron/alwaysOnTop.spectron.js
@@ -138,9 +138,9 @@ describe('Tests for Always on top', () => {
             robot.setMouseDelay(200);
             robot.moveMouse(190, 0);
             robot.mouseClick();
-            // Key tap 10 times as "Always on Top" is in the
-            // 10th position under view menu item
-            for (let i = 0; i < 10; i++) {
+            // Key tap 9 times as "Always on Top" is in the
+            // 9th position under view menu item
+            for (let i = 0; i < 9; i++) {
                 robot.keyTap('down');
             }
             robot.keyTap('enter');

--- a/tests/spectron/full-screen.spectron.js
+++ b/tests/spectron/full-screen.spectron.js
@@ -105,9 +105,9 @@ describe('Tests for Full screen', () => {
             robot.mouseClick();
             robot.setKeyboardDelay(100);
 
-            // Key tap 8 times as "Enter Full Screen" is in the
-            // 8th position under view menu item
-            for (let i = 0; i < 8; i++) {
+            // Key tap 7 times as "Enter Full Screen" is in the
+            // 7th position under view menu item
+            for (let i = 0; i < 7; i++) {
                 robot.keyTap('down');
             }
             robot.keyTap('enter');

--- a/tests/spectron/minimize-on-close.spectron.js
+++ b/tests/spectron/minimize-on-close.spectron.js
@@ -119,9 +119,9 @@ describe('Tests for Minimize on Close', () => {
                     robot.mouseClick();
                     robot.setKeyboardDelay(100);
 
-                    // Key tap 9 times as "Minimize on Close" is in the
-                    // 9th position under view menu item
-                    for (let i = 0; i < 9; i++) {
+                    // Key tap 10 times as "Minimize on Close" is in the
+                    // 10th position under view menu item
+                    for (let i = 0; i < 10; i++) {
                         robot.keyTap('down');
                     }
                     robot.keyTap('enter');


### PR DESCRIPTION
## Description
As part of [ELECTRON-337](https://perzoinc.atlassian.net/browse/ELECTRON-337), we've removed the "Toggle Dev Tools" menu item from the "View" menu as it is not required for end customers. If we still want to toggle the dev tools, we can do so using "Cmd+Alt+I" on macOS and "Ctrl+Shift+I" on Windows.

## Approach
- Removed the toggle dev tools item from menu template
- Added a global shortcut in window manager mapping the callback against the above mentioned shortcuts

## Before
<img width="1440" alt="screen shot 2018-03-29 at 12 01 59" src="https://user-images.githubusercontent.com/5968790/38073701-c6bcd36a-3349-11e8-966b-4bd1afa066b2.png">

## After
<img width="1440" alt="screen shot 2018-03-29 at 12 01 30" src="https://user-images.githubusercontent.com/5968790/38073707-cd233082-3349-11e8-8fa4-a780631a168e.png">

## Open Questions if any and Todos
- [x] Unit-Tests
[ELECTRON-337 - unit-tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1858830/ELECTRON-337.-.unit-tests.pdf)
- [x] Documentation
- [x] Automation-Tests
[ELECTRON-337 - spectron-tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1858835/ELECTRON-337.-.spectron-tests.pdf)
