### PR TITLE
ELECTRON-397: fix the regression on opening external urls

### DIFF
--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -77,17 +77,17 @@ function removeWindowKey(key) {
 
 /**
  * Gets the parsed url
- * @returns {String}
+ * @returns {Url}
  * @param appUrl
  */
 function getParsedUrl(appUrl) {
     let parsedUrl = nodeURL.parse(appUrl);
-    if (!parsedUrl.protocol || parsedUrl.protocol !== 'https') {
+    if (!parsedUrl.protocol || parsedUrl.protocol !== 'https:') {
         parsedUrl.protocol = 'https:';
         parsedUrl.slashes = true
     }
     let url = nodeURL.format(parsedUrl);
-    return url;
+    return nodeURL.parse(url);
 }
 
 /**


### PR DESCRIPTION
## Description
A regression was caused in opening external urls. Due to the issue [ELECTRON-397](https://perzoinc.atlassian.net/browse/ELECTRON-397), external urls were being opened in a window rather than in the browser.

## Approach
- #### Problem with the code: The method responsible for validating the URL was returning a string rather than a URL object
- #### Fix: Fixed the above problem to return a URL object rather than a string.

## Open Questions if any and Todos
- [x] Unit-Tests
[ELECTRON-397 - unit tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1867666/ELECTRON-397.-.unit.tests.pdf)

- [x] Automation-Tests
[ELECTRON-397 - spectron tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1867667/ELECTRON-397.-.spectron.tests.pdf)
