### PR TITLE
Electron-401 (fixes crash reporter)

### DIFF
--- a/js/aboutApp/renderer.js
+++ b/js/aboutApp/renderer.js
@@ -1,5 +1,5 @@
 'use strict';
-const { remote, ipcRenderer } = require('electron');
+const { remote, ipcRenderer, crashReporter } = require('electron');
 
 renderDom();
 
@@ -23,5 +23,11 @@ ipcRenderer.on('buildNumber', (event, buildNumber) => {
 
     if (versionText) {
         versionText.innerHTML = version ? `Version ${version} (${version}.${buildNumber})` : 'N/A';
+    }
+});
+
+ipcRenderer.on('register-crash-reporter', (event, arg) => {
+    if (arg && typeof arg === 'object') {
+        crashReporter.start(arg);
     }
 });

--- a/js/basicAuth/renderer.js
+++ b/js/basicAuth/renderer.js
@@ -1,6 +1,5 @@
 'use strict';
-const electron = require('electron');
-const ipc = electron.ipcRenderer;
+const { ipcRenderer, crashReporter } = require('electron');
 
 renderDom();
 
@@ -26,7 +25,7 @@ function loadContent() {
 
     if (cancel) {
         cancel.addEventListener('click', () => {
-            ipc.send('close-basic-auth');
+            ipcRenderer.send('close-basic-auth');
         });
     }
 }
@@ -39,14 +38,14 @@ function submitForm() {
     let password = document.getElementById('password').value;
 
     if (username && password) {
-        ipc.send('login', { username, password });
+        ipcRenderer.send('login', { username, password });
     }
 }
 
 /**
  * Updates the hosts name
  */
-ipc.on('hostname', (event, host) => {
+ipcRenderer.on('hostname', (event, host) => {
     let hostname = document.getElementById('hostname');
 
     if (hostname){
@@ -57,10 +56,16 @@ ipc.on('hostname', (event, host) => {
 /**
  * Triggered if user credentials are invalid
  */
-ipc.on('isValidCredentials', (event, isValidCredentials) => {
+ipcRenderer.on('isValidCredentials', (event, isValidCredentials) => {
     let credentialsError = document.getElementById('credentialsError');
 
     if (credentialsError){
         credentialsError.style.display = isValidCredentials ? 'none' : 'block'
+    }
+});
+
+ipcRenderer.on('register-crash-reporter', (event, arg) => {
+    if (arg && typeof arg === 'object') {
+        crashReporter.start(arg);
     }
 });

--- a/js/crashReporter.js
+++ b/js/crashReporter.js
@@ -4,7 +4,8 @@ const { getMultipleConfigField } = require('./config.js');
 const log = require('./log.js');
 const logLevels = require('./enums/logLevels.js');
 
-let configData;
+const configFields = ['url', 'crashReporter'];
+let crashReporterData;
 
 /**
  * Method that returns all the required field for crash reporter
@@ -15,30 +16,21 @@ let configData;
 function getCrashReporterConfig(extras) {
     return new Promise((resolve, reject) => {
 
-        if (configData && configData.crashReporter) {
-            let crashReporterData = {
-                companyName: configData.crashReporter.companyName,
-                submitURL: configData.crashReporter.submitURL,
-                uploadToServer: configData.crashReporter.uploadToServer,
-                extra: Object.assign(
-                    {podUrl: configData.url},
-                    extras
-                )
-            };
+        if (crashReporterData && crashReporterData.companyName) {
+            crashReporterData.extra = Object.assign(crashReporterData.extra, extras);
             resolve(crashReporterData);
             return;
         }
 
-        getMultipleConfigField(['url', 'crashReporter'])
+        getMultipleConfigField(configFields)
             .then((data) => {
 
                 if (!data && !data.crashReporter && !data.crashReporter.companyName) {
-                    reject('company name cannot be empty');
+                    reject('Company name cannot be empty');
                     return;
                 }
 
-                configData = data;
-                let crashReporterData = {
+                crashReporterData = {
                     companyName: data.crashReporter.companyName,
                     submitURL: data.crashReporter.submitURL,
                     uploadToServer: data.crashReporter.uploadToServer,
@@ -61,7 +53,7 @@ function initCrashReporterMain(extras) {
         try {
             crashReporter.start(mainCrashReporterData);
         } catch (err) {
-            log.send(logLevels.ERROR, 'failed to start crash reporter main process. Error is ->  ' + err);
+            log.send(logLevels.ERROR, 'Failed to start crash reporter main process. Error is ->  ' + err);
         }
     }).catch((err) => log.send(
         logLevels.ERROR,

--- a/js/crashReporter.js
+++ b/js/crashReporter.js
@@ -53,18 +53,18 @@ function initCrashReporterMain(extras) {
 
 
 /**
- * Method to initialize crash reporter for render process
+ * Method to initialize crash reporter for renderer process
  *
  * @param browserWindow {Electron.BrowserWindow}
  * @param extras {Object}
  */
 function initCrashReporterRenderer(browserWindow, extras) {
     if (browserWindow && browserWindow.webContents && !browserWindow.isDestroyed()) {
-        getCrashReporterConfig(extras).then((renderCrashReporterData) => {
-            browserWindow.webContents.send('register-crash-reporter', renderCrashReporterData);
+        getCrashReporterConfig(extras).then((rendererCrashReporterData) => {
+            browserWindow.webContents.send('register-crash-reporter', rendererCrashReporterData);
         }).catch((err) => log.send(
             logLevels.ERROR,
-            'Unable to initialize crash reporter for render process. Error is ->  ' + err
+            'Unable to initialize crash reporter for renderer process. Error is ->  ' + err
         ));
     }
 }

--- a/js/crashReporter.js
+++ b/js/crashReporter.js
@@ -1,0 +1,75 @@
+const { crashReporter } = require('electron');
+const { getMultipleConfigField } = require('./config.js');
+
+const log = require('./log.js');
+const logLevels = require('./enums/logLevels.js');
+
+/**
+ * Method that returns all the required field for crash reporter
+ *
+ * @param extras {object}
+ * @return {Promise<any>}
+ */
+function getCrashReporterConfig(extras) {
+    return new Promise((resolve, reject) => {
+        getMultipleConfigField(['url', 'crashReporter'])
+            .then((configData) => {
+
+                if (!configData && !configData.crashReporter && !configData.crashReporter.companyName) {
+                    reject('company name cannot be empty');
+                    return;
+                }
+
+                let crashReporterData = {
+                    companyName: configData.crashReporter.companyName,
+                    submitURL: configData.crashReporter.submitURL,
+                    uploadToServer: configData.crashReporter.uploadToServer,
+                    extra: Object.assign(
+                        {podUrl: configData.url},
+                        extras
+                    )
+                };
+                resolve(crashReporterData);
+            })
+            .catch((err) => log.send(
+                logLevels.ERROR,
+                'Unable to initialize crash reporter failed to read config file. Error is ->  ' + err
+            ));
+    })
+}
+
+function initCrashReporterMain(extras) {
+    getCrashReporterConfig(extras).then((mainCrashReporterData) => {
+        try {
+            crashReporter.start(mainCrashReporterData);
+        } catch (err) {
+            log.send(logLevels.ERROR, 'failed to start crash reporter main process. Error is ->  ' + err);
+        }
+    }).catch((err) => log.send(
+        logLevels.ERROR,
+        'Unable to initialize crash reporter for main process. Error is ->  ' + err
+    ));
+}
+
+
+/**
+ * Method to initialize crash reporter for render process
+ *
+ * @param browserWindow {Electron.BrowserWindow}
+ * @param extras {Object}
+ */
+function initCrashReporterRenderer(browserWindow, extras) {
+    if (browserWindow && browserWindow.webContents && !browserWindow.isDestroyed()) {
+        getCrashReporterConfig(extras).then((renderCrashReporterData) => {
+            browserWindow.webContents.send('register-crash-reporter', renderCrashReporterData);
+        }).catch((err) => log.send(
+            logLevels.ERROR,
+            'Unable to initialize crash reporter for render process. Error is ->  ' + err
+        ));
+    }
+}
+
+module.exports = {
+    initCrashReporterMain,
+    initCrashReporterRenderer,
+};

--- a/js/crashReporter.js
+++ b/js/crashReporter.js
@@ -4,6 +4,8 @@ const { getMultipleConfigField } = require('./config.js');
 const log = require('./log.js');
 const logLevels = require('./enums/logLevels.js');
 
+let configData;
+
 /**
  * Method that returns all the required field for crash reporter
  *
@@ -12,20 +14,36 @@ const logLevels = require('./enums/logLevels.js');
  */
 function getCrashReporterConfig(extras) {
     return new Promise((resolve, reject) => {
-        getMultipleConfigField(['url', 'crashReporter'])
-            .then((configData) => {
 
-                if (!configData && !configData.crashReporter && !configData.crashReporter.companyName) {
+        if (configData && configData.crashReporter) {
+            let crashReporterData = {
+                companyName: configData.crashReporter.companyName,
+                submitURL: configData.crashReporter.submitURL,
+                uploadToServer: configData.crashReporter.uploadToServer,
+                extra: Object.assign(
+                    {podUrl: configData.url},
+                    extras
+                )
+            };
+            resolve(crashReporterData);
+            return;
+        }
+
+        getMultipleConfigField(['url', 'crashReporter'])
+            .then((data) => {
+
+                if (!data && !data.crashReporter && !data.crashReporter.companyName) {
                     reject('company name cannot be empty');
                     return;
                 }
 
+                configData = data;
                 let crashReporterData = {
-                    companyName: configData.crashReporter.companyName,
-                    submitURL: configData.crashReporter.submitURL,
-                    uploadToServer: configData.crashReporter.uploadToServer,
+                    companyName: data.crashReporter.companyName,
+                    submitURL: data.crashReporter.submitURL,
+                    uploadToServer: data.crashReporter.uploadToServer,
                     extra: Object.assign(
-                        {podUrl: configData.url},
+                        {podUrl: data.url},
                         extras
                     )
                 };

--- a/js/desktopCapturer/renderer.js
+++ b/js/desktopCapturer/renderer.js
@@ -1,5 +1,5 @@
 'use strict';
-const { ipcRenderer } = require('electron');
+const { ipcRenderer, crashReporter } = require('electron');
 
 const screenRegExp = new RegExp(/^Screen \d+$/gmi);
 
@@ -266,3 +266,9 @@ function closeScreenPickerWindow() {
     document.removeEventListener('keyUp', handleKeyUpPress.bind(this), true);
     ipcRenderer.send('close-screen-picker');
 }
+
+ipcRenderer.on('register-crash-reporter', (event, arg) => {
+    if (arg && typeof arg === 'object') {
+        crashReporter.start(arg);
+    }
+});

--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -156,7 +156,7 @@ const template = [{
                     }
                 },
                 {
-                    label: 'Open Crashes Directory',
+                    label: isMac ? 'Show crash dump in Finder' : 'Show crash dump in Explorer',
                     click() {
                         const FILE_EXTENSIONS = isMac ? [ '.dmp' ] : [ '.dmp', '.txt' ];
                         const crashesDirectory = electron.crashReporter.getCrashesDirectory();

--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -127,7 +127,8 @@ const template = [{
                 {
                     label: isMac ? 'Show Logs in Finder' : 'Show Logs in Explorer',
                     click() {
-            
+
+                        const FILE_EXTENSIONS = [ '.log' ];
                         const MAC_LOGS_PATH = '/Library/Logs/Symphony/';
                         const WINDOWS_LOGS_PATH = '\\AppData\\Roaming\\Symphony\\';
             
@@ -144,7 +145,7 @@ const template = [{
                         
                         let destination = electron.app.getPath('downloads') + destPath + timestamp + '.zip';
             
-                        archiveHandler.generateArchiveForDirectory(source, destination)
+                        archiveHandler.generateArchiveForDirectory(source, destination, FILE_EXTENSIONS)
                             .then(() => {
                                 electron.shell.showItemInFolder(destination);
                             })
@@ -157,8 +158,27 @@ const template = [{
                 {
                     label: 'Open Crashes Directory',
                     click() {
-                        const crashesDirectory = electron.crashReporter.getCrashesDirectory() + '/completed';
-                        electron.shell.showItemInFolder(crashesDirectory);
+                        const FILE_EXTENSIONS = isMac ? [ '.dmp' ] : [ '.dmp', '.txt' ];
+                        const crashesDirectory = electron.crashReporter.getCrashesDirectory();
+                        let source = isMac ? crashesDirectory + '/completed' : crashesDirectory;
+
+                        if (!fs.existsSync(crashesDirectory)) {
+                            electron.dialog.showErrorBox('Failed!', 'No crashes available to share');
+                            return;
+                        }
+
+                        let destPath = isMac ? '/crashes_symphony_' : '\\crashes_symphony_';
+                        let timestamp = new Date().getTime();
+
+                        let destination = electron.app.getPath('downloads') + destPath + timestamp + '.zip';
+
+                        archiveHandler.generateArchiveForDirectory(source, destination, FILE_EXTENSIONS)
+                            .then(() => {
+                                electron.shell.showItemInFolder(destination);
+                            })
+                            .catch((err) => {
+                                electron.dialog.showErrorBox('Failed!', 'Unable to generate crash report due to -> ' + err);
+                            });
                     }
                 }
             ]

--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -162,7 +162,7 @@ const template = [{
                         const crashesDirectory = electron.crashReporter.getCrashesDirectory();
                         let source = isMac ? crashesDirectory + '/completed' : crashesDirectory;
 
-                        if (!fs.existsSync(crashesDirectory)) {
+                        if (!fs.existsSync(source) || fs.readdirSync(source).length === 0) {
                             electron.dialog.showErrorBox('Failed!', 'No crashes available to share');
                             return;
                         }

--- a/js/preload/preloadMain.js
+++ b/js/preload/preloadMain.js
@@ -122,19 +122,6 @@ function createAPI() {
         ScreenSnippet: remote.require('./screenSnippet/index.js').ScreenSnippet,
 
         /**
-         * Provides API to crash the renderer process that calls this function
-         * Is only used for demos.
-         */
-        crashRendererProcess: function () {
-            // For practical purposes, we don't allow
-            // this method to work in non-dev environments
-            if (!process.env.ELECTRON_DEV) {
-                return;
-            }
-            process.crash();
-        },
-
-        /**
          * Provides api for client side searching
          * using the SymphonySearchEngine library
          * details in ./search/search.js & ./search/searchLibrary.js
@@ -385,9 +372,13 @@ function createAPI() {
 
     });
 
+    /**
+     * an event triggered by the main process to start crash reporter
+     * in the render thread
+     */
     local.ipcRenderer.on('register-crash-reporter', (event, arg) => {
-        if (arg) {            
-            crashReporter.start({companyName: arg.companyName, submitURL: arg.submitURL, uploadToServer: arg.uploadToServer, extra: {'process': arg.process, podUrl: arg.podUrl}});
+        if (arg && typeof arg === 'object') {
+            crashReporter.start(arg);
         }
     });
 

--- a/js/utils/archiveHandler.js
+++ b/js/utils/archiveHandler.js
@@ -3,6 +3,11 @@
 const fs = require('fs');
 const path = require('path');
 const archiver = require('archiver');
+const log = require('../log.js');
+const logLevels = require('../enums/logLevels.js');
+const mmm = require('mmmagic');
+const Magic = mmm.Magic;
+const magic = new Magic(mmm.MAGIC_MIME_TYPE);
 
 /**
  * Archives files in the source directory
@@ -31,26 +36,51 @@ function generateArchiveForDirectory(source, destination, fileExtensions) {
         archive.pipe(output);
 
         let files = fs.readdirSync(source);
-        files
-            .filter((file) => fileExtensions.indexOf(path.extname(file)) !== -1)
-            .forEach((file) => {
-                switch (path.extname(file)) {
-                    case '.log':
-                        archive.file(source + '/' + file, { name: 'logs/' + file });
-                        break;
-                    case '.dmp':
-                    case '.txt': // on Windows .txt files will be created as part of crash dump
-                        archive.file(source + '/' + file, { name: 'crashes/' + file });
-                        break;
-                    default:
-                        break;
+
+        let filtered = files.filter((file) => fileExtensions.indexOf(path.extname(file)) !== -1);
+        mapMimeType(filtered, source)
+            .then((mappedData) => {
+                if (mappedData.length > 0) {
+                    mappedData.map((data) => {
+                        switch (data.mimeType) {
+                            case 'text/plain':
+                                if (path.extname(data.file) === '.txt') {
+                                    archive.file(source + '/' + data.file, { name: 'crashes/' + data.file });
+                                } else {
+                                    archive.file(source + '/' + data.file, { name: 'logs/' + data.file });
+                                }
+                                break;
+                            case 'application/x-dmp':
+                                archive.file(source + '/' + data.file, { name: 'crashes/' + data.file });
+                                break;
+                            default:
+                                break;
+                        }
+                    });
                 }
+                archive.finalize();
+            })
+            .catch((err) => {
+                log.send(logLevels.ERROR, 'Failed to find mime type. Error is ->  ' + err);
             });
-        
-        archive.finalize();
-        
+
     });
     
+}
+
+function mapMimeType(files, source) {
+    return Promise.all(files.map((file) => {
+        return new Promise((resolve, reject) => {
+            return magic.detectFile(source + '/' + file, (err, result) => {
+                if (err) {
+                    return reject(err);
+                }
+                return resolve({file: file, mimeType: result});
+            });
+        });
+    }))
+        .then((data) => data)
+        .catch((err) => log.send(logLevels.ERROR, 'Failed to find mime type. Error is ->  ' + err));
 }
 
 module.exports = {

--- a/js/utils/archiveHandler.js
+++ b/js/utils/archiveHandler.js
@@ -16,7 +16,7 @@ const archiver = require('archiver');
 function generateArchiveForDirectory(source, destination, fileExtensions) {
     
     return new Promise((resolve, reject) => {
-        
+
         let output = fs.createWriteStream(destination);
         let archive = archiver('zip', {zlib: {level: 9}});
 
@@ -29,7 +29,7 @@ function generateArchiveForDirectory(source, destination, fileExtensions) {
         });
         
         archive.pipe(output);
-        
+
         let files = fs.readdirSync(source);
         files
             .filter((file) => fileExtensions.indexOf(path.extname(file)) !== -1)

--- a/js/utils/archiveHandler.js
+++ b/js/utils/archiveHandler.js
@@ -4,7 +4,16 @@ const fs = require('fs');
 const path = require('path');
 const archiver = require('archiver');
 
-function generateArchiveForDirectory(source, destination) {
+/**
+ * Archives files in the source directory
+ * that matches the given file extension
+ *
+ * @param source {String} source path
+ * @param destination {String} destination path
+ * @param fileExtensions {Array} array of file ext
+ * @return {Promise<any>}
+ */
+function generateArchiveForDirectory(source, destination, fileExtensions) {
     
     return new Promise((resolve, reject) => {
         
@@ -22,11 +31,21 @@ function generateArchiveForDirectory(source, destination) {
         archive.pipe(output);
         
         let files = fs.readdirSync(source);
-        files.forEach((file) => {
-            if (path.extname(file) === '.log') {
-                archive.file(source + '/' + file, { name: 'logs/' + file });
-            }
-        });
+        files
+            .filter((file) => fileExtensions.indexOf(path.extname(file)) !== -1)
+            .forEach((file) => {
+                switch (path.extname(file)) {
+                    case '.log':
+                        archive.file(source + '/' + file, { name: 'logs/' + file });
+                        break;
+                    case '.dmp':
+                    case '.txt': // on Windows .txt files will be created as part of crash dump
+                        archive.file(source + '/' + file, { name: 'crashes/' + file });
+                        break;
+                    default:
+                        break;
+                }
+            });
         
         archive.finalize();
         

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -4,7 +4,6 @@ const fs = require('fs');
 const electron = require('electron');
 const app = electron.app;
 const globalShortcut = electron.globalShortcut;
-const crashReporter = electron.crashReporter;
 const BrowserWindow = electron.BrowserWindow;
 const path = require('path');
 const nodeURL = require('url');
@@ -24,6 +23,7 @@ const { getConfigField, updateConfigField, getGlobalConfigField } = require('./c
 const { isMac, isNodeEnv, isWindows10, isWindowsOS } = require('./utils/misc');
 const { deleteIndexFolder } = require('./search/search.js');
 const { isWhitelisted } = require('./utils/whitelistHandler');
+const { initCrashReporterMain, initCrashReporterRenderer } = require('./crashReporter.js');
 
 // show dialog when certificate errors occur
 require('./dialogs/showCertError.js');
@@ -187,6 +187,10 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
     // content can be cached and will still finish load but
     // we might not have network connectivity, so warn the user.
     mainWindow.webContents.on('did-finish-load', function () {
+        // Initialize crash reporter
+        initCrashReporterMain({ process: 'main window' });
+        initCrashReporterRenderer(mainWindow, { process: 'render | main window' });
+
         url = mainWindow.webContents.getURL();
         if (isCustomTitleBarEnabled) {
             mainWindow.webContents.insertCSS(fs.readFileSync(path.join(__dirname, '/windowsTitleBar/style.css'), 'utf8').toString());
@@ -317,23 +321,6 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
         });
     });
 
-    getConfigField('url')
-        .then(initializeCrashReporter)
-        .catch(app.quit);
-
-    function initializeCrashReporter(podUrl) {
-        getConfigField('crashReporter')
-            .then((crashReporterConfig) => {
-                log.send(logLevels.INFO, 'Initializing crash reporter on the main window!');
-                crashReporter.start({ companyName: crashReporterConfig.companyName, submitURL: crashReporterConfig.submitURL, uploadToServer: crashReporterConfig.uploadToServer, extra: { 'process': 'renderer / main window', podUrl: podUrl } });
-                log.send(logLevels.INFO, 'initialized crash reporter on the main window!');
-                mainWindow.webContents.send('register-crash-reporter', { companyName: crashReporterConfig.companyName, submitURL: crashReporterConfig.submitURL, uploadToServer: crashReporterConfig.uploadToServer, process: 'preload script / main window renderer' });
-            })
-            .catch((err) => {
-                log.send(logLevels.ERROR, 'Unable to initialize crash reporter in the main window. Error is -> ' + err);
-            });
-    }
-
     // open external links in default browser - a tag with href='_blank' or window.open
     mainWindow.webContents.on('new-window', handleNewWindow);
 
@@ -419,19 +406,8 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
                         browserWin.setMenu(null);
                     }
 
-                    getConfigField('url')
-                        .then((podUrl) => {
-                            getConfigField('crashReporter')
-                                .then((crashReporterConfig) => {
-                                    crashReporter.start({ companyName: crashReporterConfig.companyName, submitURL: crashReporterConfig.submitURL, uploadToServer: crashReporterConfig.uploadToServer, extra: { 'process': 'renderer / child window', podUrl: podUrl } });
-                                    log.send(logLevels.INFO, 'initialized crash reporter on a child window!');
-                                    browserWin.webContents.send('register-crash-reporter', { companyName: crashReporterConfig.companyName, submitURL: crashReporterConfig.submitURL, uploadToServer: crashReporterConfig.uploadToServer, process: 'preload script / child window renderer' });
-                                })
-                                .catch((err) => {
-                                    log.send(logLevels.ERROR, 'Unable to initialize crash reporter in the child window. Error is -> ' + err);
-                                });
-                        })
-                        .catch(app.quit);
+                    initCrashReporterMain({ process: 'pop-out window' });
+                    initCrashReporterRenderer(browserWin, { process: 'render | pop-out window' });
 
                     browserWin.winName = frameName;
                     browserWin.setAlwaysOnTop(alwaysOnTop);
@@ -451,7 +427,7 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
                         browserWin.webContents.removeListener('crashed', handleChildWindowCrashEvent);
                     });
 
-                    let handleChildWindowCrashEvent = () => {
+                    let handleChildWindowCrashEvent = (e) => {
                         const options = {
                             type: 'error',
                             title: 'Renderer Process Crashed',
@@ -459,14 +435,16 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
                             buttons: ['Reload', 'Close']
                         };
 
-                        electron.dialog.showMessageBox(options, function (index) {
-                            if (index === 0) {
-                                browserWin.reload();
-                            }
-                            else {
-                                browserWin.close();
-                            }
-                        });
+                        let childBrowserWindow = BrowserWindow.fromWebContents(e.sender);
+                        if (childBrowserWindow && !childBrowserWindow.isDestroyed()) {
+                            electron.dialog.showMessageBox(childBrowserWindow, options, function (index) {
+                                if (index === 0) {
+                                    childBrowserWindow.reload();
+                                } else {
+                                    childBrowserWindow.close();
+                                }
+                            });
+                        }
                     };
 
                     browserWin.webContents.on('crashed', handleChildWindowCrashEvent);

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "lodash.isequal": "4.5.0",
     "lodash.omit": "4.5.0",
     "lodash.pick": "4.4.0",
+    "mmmagic": "0.5.0",
     "parse-domain": "2.0.0",
     "ref": "1.3.5",
     "shell-path": "2.1.0",


### PR DESCRIPTION
## Description
Fixes crash dump not being generated on Windows OS [ELECTRON-401](https://perzoinc.atlassian.net/browse/ELECTRON-401)

## Approach
How does this change address the problem?
#### Problem with the code:
 - The crash reporter was initialized before `DOM` ready event
#### Fix:
 - Initializing the crash reporter after `DOM` ready event
 - Initialized crash reporter for `about app window`, `desktop capture window`, `basic auth window` 

## Spectron test results
[Electron-401 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1883622/Electron-401.Spectron.pdf)

## Unit test results
[Electron-401 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1883621/Electron-401.Unit.Tests.pdf)


## Open Questions if any and Todos
- [x] Unit-Tests
- [x] Documentation
- [x] Automation-Tests
When solved, check the box and explain the answer.

@VishwasShashidhar , @VikasShashidhar Please review. Thanks 😄 
