### PR TITLE
Electron-420 (Add 'bringToFront' to the ignoreSettings)

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -23,7 +23,7 @@ const dirs = new AppDirectory('Symphony');
 let userConfig;
 let globalConfig;
 
-let ignoreSettings = ['minimizeOnClose', 'launchOnStartup', 'alwaysOnTop', 'url', 'memoryRefresh'];
+let ignoreSettings = ['minimizeOnClose', 'launchOnStartup', 'alwaysOnTop', 'url', 'memoryRefresh', 'bringToFront'];
 
 /**
  * Tries to read given field from user config file, if field doesn't exist
@@ -403,7 +403,7 @@ function readConfigFileSync() {
     try {
         return JSON.parse(data);
     } catch (err) {
-        console.log("parsing config failed", err);
+        log.send(logLevels.ERROR, 'config: parsing config failed: ' + err);
     }
     
     return null;


### PR DESCRIPTION
## Description
Add 'bringToFront' to the ignoreSettings [ELECTRON-420](https://perzoinc.atlassian.net/browse/ELECTRON-420)


## Approach
How does this change address the problem?
#### Problem with the code:
 - `bringToFront` was not added to the list if configs to ignore
#### Fix:
 - Added `bringToFront` to the ignore settings list

## Spectron test results
[Electron-420 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1905862/Electron-420.Spectron.pdf)

## Unit test results
[Electron-420 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1905863/Electron-420.Unit.Tests.pdf)


## Open Questions if any and Todos
- [X] Unit-Tests (No changes)
- [X] Documentation
- [X] Automation-Tests
When solved, check the box and explain the answer.

@VishwasShashidhar @VikasShashidhar Please review. Thanks 😄 
