### PR TITLE
Electron-414 (Add a logic not to close the notifications on mouse hover)

### DIFF
--- a/js/notify/electron-notify-preload.js
+++ b/js/notify/electron-notify-preload.js
@@ -218,10 +218,6 @@ function reset() {
     container.parentNode.replaceChild(newContainer, container);
     let newCloseButton = closeButton.cloneNode(true);
     closeButton.parentNode.replaceChild(newCloseButton, closeButton);
-
-    // Reset timers
-    if (closeTimer) clearTimeout(closeTimer);
-    if (mouseLeaveTimer) clearTimeout(mouseLeaveTimer);
 }
 
 ipc.on('electron-notify-set-contents', setContents);

--- a/js/notify/electron-notify-preload.js
+++ b/js/notify/electron-notify-preload.js
@@ -10,8 +10,6 @@ const electron = require('electron');
 const ipc = electron.ipcRenderer;
 
 const whiteColorRegExp = new RegExp(/^(?:white|#fff(?:fff)?|rgba?\(\s*255\s*,\s*255\s*,\s*255\s*(?:,\s*1\s*)?\))$/i);
-let mouseLeaveTimer;
-let closeTimer;
 
 /**
  * Sets style for a notification
@@ -136,25 +134,16 @@ function setContents(event, notificationObj) {
 
     const winId = notificationObj.windowId;
 
-    let displayTime = notificationObj.displayTime || 5000;
     if (!notificationObj.sticky) {
         container.addEventListener('mouseleave', onMouseLeave);
         container.addEventListener('mouseover', onMouseOver);
-
-        closeTimer = setTimeout(() => {
-            ipc.send('electron-notify-close', winId, notificationObj)
-        }, displayTime);
     }
 
     /**
      * Start a new timer to close the notification
      */
     function onMouseLeave() {
-        if (!mouseLeaveTimer) {
-            mouseLeaveTimer = setTimeout(() => {
-                ipc.send('electron-notify-close', winId, notificationObj)
-            }, 3000);
-        }
+        ipc.send('electron-notify-mouseleave', winId, notificationObj);
     }
 
     /**
@@ -162,9 +151,7 @@ function setContents(event, notificationObj) {
      * from closing
      */
     function onMouseOver() {
-        if (closeTimer) clearTimeout(closeTimer);
-        if (mouseLeaveTimer) clearTimeout(mouseLeaveTimer);
-        mouseLeaveTimer = undefined;
+        ipc.send('electron-notify-mouseover', winId);
     }
 
     // note: use onclick because we only want one handler, for case

--- a/js/notify/electron-notify-preload.js
+++ b/js/notify/electron-notify-preload.js
@@ -10,6 +10,8 @@ const electron = require('electron');
 const ipc = electron.ipcRenderer;
 
 const whiteColorRegExp = new RegExp(/^(?:white|#fff(?:fff)?|rgba?\(\s*255\s*,\s*255\s*,\s*255\s*(?:,\s*1\s*)?\))$/i);
+let mouseLeaveTimer;
+let closeTimer;
 
 /**
  * Sets style for a notification
@@ -135,8 +137,6 @@ function setContents(event, notificationObj) {
     const winId = notificationObj.windowId;
 
     let displayTime = notificationObj.displayTime || 5000;
-    let mouseLeaveTimer;
-    let closeTimer;
     if (!notificationObj.sticky) {
         container.addEventListener('mouseleave', onMouseLeave);
         container.addEventListener('mouseover', onMouseOver);
@@ -162,8 +162,8 @@ function setContents(event, notificationObj) {
      * from closing
      */
     function onMouseOver() {
-        clearTimeout(closeTimer);
-        clearTimeout(mouseLeaveTimer);
+        if (closeTimer) clearTimeout(closeTimer);
+        if (mouseLeaveTimer) clearTimeout(mouseLeaveTimer);
         mouseLeaveTimer = undefined;
     }
 
@@ -230,7 +230,11 @@ function reset() {
     let newContainer = container.cloneNode(true);
     container.parentNode.replaceChild(newContainer, container);
     let newCloseButton = closeButton.cloneNode(true);
-    closeButton.parentNode.replaceChild(newCloseButton, closeButton)
+    closeButton.parentNode.replaceChild(newCloseButton, closeButton);
+
+    // Reset timers
+    if (closeTimer) clearTimeout(closeTimer);
+    if (mouseLeaveTimer) clearTimeout(mouseLeaveTimer);
 }
 
 ipc.on('electron-notify-set-contents', setContents);

--- a/js/notify/electron-notify-preload.js
+++ b/js/notify/electron-notify-preload.js
@@ -134,6 +134,39 @@ function setContents(event, notificationObj) {
 
     const winId = notificationObj.windowId;
 
+    let displayTime = notificationObj.displayTime || 5000;
+    let mouseLeaveTimer;
+    let closeTimer;
+    if (!notificationObj.sticky) {
+        container.addEventListener('mouseleave', onMouseLeave);
+        container.addEventListener('mouseover', onMouseOver);
+
+        closeTimer = setTimeout(() => {
+            ipc.send('electron-notify-close', winId, notificationObj)
+        }, displayTime);
+    }
+
+    /**
+     * Start a new timer to close the notification
+     */
+    function onMouseLeave() {
+        if (!mouseLeaveTimer) {
+            mouseLeaveTimer = setTimeout(() => {
+                ipc.send('electron-notify-close', winId, notificationObj)
+            }, 3000);
+        }
+    }
+
+    /**
+     * Clear all timeouts to prevent notification
+     * from closing
+     */
+    function onMouseOver() {
+        clearTimeout(closeTimer);
+        clearTimeout(mouseLeaveTimer);
+        mouseLeaveTimer = undefined;
+    }
+
     // note: use onclick because we only want one handler, for case
     // when content gets overwritten by notf with same tag
     closeButton.onclick = function(clickEvent) {

--- a/js/notify/electron-notify-preload.js
+++ b/js/notify/electron-notify-preload.js
@@ -10,6 +10,9 @@ const electron = require('electron');
 const ipc = electron.ipcRenderer;
 
 const whiteColorRegExp = new RegExp(/^(?:white|#fff(?:fff)?|rgba?\(\s*255\s*,\s*255\s*,\s*255\s*(?:,\s*1\s*)?\))$/i);
+// event functions ref
+let onMouseLeaveFunc;
+let onMouseOverFunc;
 
 /**
  * Sets style for a notification
@@ -135,8 +138,10 @@ function setContents(event, notificationObj) {
     const winId = notificationObj.windowId;
 
     if (!notificationObj.sticky) {
-        container.addEventListener('mouseleave', onMouseLeave);
-        container.addEventListener('mouseover', onMouseOver);
+        onMouseLeaveFunc = onMouseLeave.bind(this);
+        onMouseOverFunc = onMouseOver.bind(this);
+        container.addEventListener('mouseleave', onMouseLeaveFunc);
+        container.addEventListener('mouseover', onMouseOverFunc);
     }
 
     /**
@@ -218,6 +223,9 @@ function reset() {
     container.parentNode.replaceChild(newContainer, container);
     let newCloseButton = closeButton.cloneNode(true);
     closeButton.parentNode.replaceChild(newCloseButton, closeButton);
+
+    container.removeEventListener('mouseleave', onMouseLeaveFunc);
+    container.removeEventListener('mouseover', onMouseOverFunc);
 }
 
 ipc.on('electron-notify-set-contents', setContents);

--- a/js/notify/electron-notify.js
+++ b/js/notify/electron-notify.js
@@ -418,30 +418,12 @@ function showNotification(notificationObj) {
  */
 function setNotificationContents(notfWindow, notfObj) {
 
-    // Display time per notification basis.
-    let displayTime = notfObj.displayTime ? notfObj.displayTime : config.displayTime;
-
-    if (notfWindow.displayTimer) {
-        clearTimeout(notfWindow.displayTimer);
-    }
-
     const updatedNotificationWindow = notfWindow;
 
     updatedNotificationWindow.notfyObj = notfObj;
 
-    let timeoutId;
-    let closeFunc = buildCloseNotification(notfWindow, notfObj, function() {
-        return timeoutId
-    });
+    let closeFunc = buildCloseNotification(notfWindow, notfObj);
     let closeNotificationSafely = buildCloseNotificationSafely(closeFunc);
-
-    // don't start timer to close if we aren't sticky
-    if (!notfObj.sticky) {
-        timeoutId = setTimeout(function() {
-            closeNotificationSafely('timeout');
-        }, displayTime);
-        updatedNotificationWindow.displayTimer = timeoutId;
-    }
 
     // Trigger onShowFunc if existent
     if (notfObj.onShowFunc) {
@@ -479,10 +461,9 @@ function setNotificationContents(notfWindow, notfObj) {
  * Closes the notification
  * @param notificationWindow
  * @param notificationObj
- * @param getTimeoutId
  * @returns {Function}
  */
-function buildCloseNotification(notificationWindow, notificationObj, getTimeoutId) {
+function buildCloseNotification(notificationWindow, notificationObj) {
     return function(event) {
 
         // safety check to prevent from using an
@@ -511,10 +492,6 @@ function buildCloseNotification(notificationWindow, notificationObj, getTimeoutI
 
         // reset content
         notificationWindow.webContents.send('electron-notify-reset');
-        if (getTimeoutId && typeof getTimeoutId === 'function') {
-            let timeoutId = getTimeoutId();
-            clearTimeout(timeoutId);
-        }
 
         // Recycle window
         let pos = activeNotifications.indexOf(notificationWindow);


### PR DESCRIPTION
## Description
Add a logic not to close the notifications on mouse hover [ELECTRON-414](https://perzoinc.atlassian.net/browse/ELECTRON-414)


## Approach
How does this change address the problem?
#### Problem with the code:
 - Non-sticky notification where being closed after a timeout of 5sec even on mouse hover
#### Fix:
 - Restart the timer on `mouseleave` event to close the notification

## Spectron test results
[Electron-414 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1907141/Electron-414.Spectron.pdf)

## Unit test results
[Electron-414 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1907142/Electron-414.Unit.Tests.pdf)


## Open Questions if any and Todos
- [X] Unit-Tests (No changes)
- [X] Documentation
- [X] Automation-Tests
When solved, check the box and explain the answer.

@VikasShashidhar @VishwasShashidhar Please review. Thanks 😄 
