### PR TITLE
Electron-417 (Reposition active notifications whenever the config is updated)

### DIFF
--- a/js/notify/electron-notify.js
+++ b/js/notify/electron-notify.js
@@ -165,7 +165,12 @@ function updateConfig(customConfig) {
     if (customConfig.display) {
         displayId = customConfig.display;
     }
-    closeAll();
+    // Reposition active notification on config changes
+    setupConfig();
+    moveOneDown(0)
+        .then(() => {
+            log.send(logLevels.INFO, 'updateConfig: repositioned '+ activeNotifications.length +' active notification');
+        });
 }
 
 /**
@@ -737,31 +742,6 @@ function cleanUpInactiveWindow() {
         }
     });
     inactiveWindows = [];
-}
-
-/**
- * Closes all the notifications and windows
- */
-function closeAll() {
-    // Clear out animation Queue and close windows
-    animationQueue.clear();
-
-    let notificationWindows = Array.from(activeNotifications);
-
-    notificationWindows.forEach((window) => {
-        if (window.displayTimer) {
-            clearTimeout(window.displayTimer);
-        }
-        if (!window.isDestroyed()) {
-            window.close();
-        }
-    });
-
-    cleanUpInactiveWindow();
-
-    // Reset certain vars
-    nextInsertPos = {};
-    activeNotifications = [];
 }
 
 

--- a/tests/spectron/notificationPosition.spectron.js
+++ b/tests/spectron/notificationPosition.spectron.js
@@ -144,7 +144,7 @@ describe('Tests for Notification position', () => {
     it('should change notification position to upper-right', (done) => {
         return app.client
             .click('#open-config-win')
-            .windowByIndex(2)
+            .windowByIndex(3)
             .click('#upper-right')
             .click('#ok-button')
             .windowByIndex(0)
@@ -194,7 +194,7 @@ describe('Tests for Notification position', () => {
             .windowByIndex(0)
             .click('#notf')
             .getWindowCount().then((count) => {
-                expect(count === 3).toBeTruthy();
+                expect(count === 4).toBeTruthy();
                 done();
             }).catch((err) => {
                 done.fail(new Error(`notificationPosition failed in getWindowCount with error: ${err}`));


### PR DESCRIPTION
## Description
Reposition active notifications whenever the config is updated instead of closing the notifications [ELECTRON-417](https://perzoinc.atlassian.net/browse/ELECTRON-417)


## Approach
How does this change address the problem?
#### Problem with the code:
 - Notification was being closed whenever the notification configuration is updated
#### Fix:
 - Repositioning active notification whenever the config is updated 

## Spectron test results
[Electron-417 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1919482/Electron-417.Spectron.pdf)

## Unit test results
[Electron-417 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1919484/Electron-417.Unit.Tests.pdf)


## Open Questions if any and Todos
- [X] Unit-Tests
- [X] Documentation
- [X] Automation-Tests
When solved, check the box and explain the answer.
