### PR TITLE
ELECTRON-426 (Only first character of room name displays for the toast of room starting with '<" or '>' character) - R52

### DIFF
--- a/js/notify/electron-notify-preload.js
+++ b/js/notify/electron-notify-preload.js
@@ -113,10 +113,10 @@ function setContents(event, notificationObj) {
     }
 
     // Title
-    titleDoc.innerHTML = notificationObj.title || '';
+    titleDoc.innerText = notificationObj.title || '';
 
     // message
-    messageDoc.innerHTML = notificationObj.text || '';
+    messageDoc.innerText = notificationObj.text || '';
 
     // Image
     if (notificationObj.image) {
@@ -127,7 +127,7 @@ function setContents(event, notificationObj) {
 
     // Company
     if (notificationObj.company) {
-        companyDoc.innerHTML = notificationObj.company
+        companyDoc.innerText = notificationObj.company
     } else {
         messageDoc.style.marginTop = '15px';
     }

--- a/js/notify/notifyImpl.js
+++ b/js/notify/notifyImpl.js
@@ -33,10 +33,7 @@ class Notify {
         let emitter = new EventEmitter();
         this.emitter = Queue(emitter);
 
-        // Replace strong html tags from the options.body
-        let message = replaceStrongTag(options.body);
-        // Replaces all html angle brackets w.r.t their entity name
-        message = replaceHTMLTags(message);
+        let message = options.body;
 
         this._id = notify({
             title: title,
@@ -244,46 +241,6 @@ function Queue(emitter) {
     };
 
     return modifiedEmitter;
-}
-
-/**
- * Replace HTML tags <> from messages test to prevent
- * HTML injection
- *
- * @param message {String}    main text to display in notifications
- * @return {void | string | *}
- */
-function replaceHTMLTags(message) {
-
-    if (typeof message !== 'string') {
-        return null;
-    }
-
-    const tagsToReplace = {
-        '<': '&lt;',
-        '>': '&gt;'
-    };
-
-    function replaceTag(tag) {
-        return tagsToReplace[tag] || tag;
-    }
-
-    return message.replace(/[<>]/g, replaceTag);
-}
-
-/**
- * Replace strong HTML tags from the string
- *
- * @param message {String}    main text to display in notifications
- * @return {void | string | *}
- */
-function replaceStrongTag(message) {
-
-    if (typeof message !== 'string') {
-        return null;
-    }
-
-    return message.replace(/(?:<strong>)|(?:<\/strong>)+/g, '');
 }
 
 module.exports = Notify;


### PR DESCRIPTION
## Description
Title, Body and Company name was rendered in the notification instead of plain text.
[ELECTRON-426](https://perzoinc.atlassian.net/browse/ELECTRON-426)

## Before
![screen shot 2018-04-27 at 3 51 12 pm](https://user-images.githubusercontent.com/596478/39358180-ea0260f6-4a32-11e8-9a72-b390f998ff84.png)

## After
![screen shot 2018-04-27 at 3 49 54 pm](https://user-images.githubusercontent.com/596478/39358187-f087fd0a-4a32-11e8-82c2-09fb3b3537f8.png)


## Approach
How does this change address the problem?
- #### Problem with the code: Using innerHTML caused the text to render inside the notification.
- #### Fix: Changed to innerText will not render HTML content.


## Learning
N/A

#### Blog Posts
N/A

## Related PRs
N/A

## Unit Tests Result
[Test Results — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1954797/Test.Results.Unit.Tests.pdf)

## Spectron Tests Result
[Test Results — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1954798/Test.Results.Spectron.pdf)

@KiranNiranjan @VikasShashidhar @VishwasShashidhar @lneir Please review. Thanks 😃 

## Open Questions if any and Todos
- [x] Unit-Tests
- [x] Documentation
- [ ] Automation-Tests
