### PR TITLE
Electron-385 (Remove third party dependency and write custom implementation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "lodash.isequal": "4.5.0",
     "lodash.omit": "4.5.0",
     "lodash.pick": "4.4.0",
-    "parse-domain": "2.0.0",
     "ref": "1.3.5",
     "shell-path": "2.1.0",
     "winreg": "1.2.4"

--- a/tests/utils/whitelist.test.js
+++ b/tests/utils/whitelist.test.js
@@ -57,6 +57,13 @@ describe('validate url with whitelist', function() {
             return expect(checkWhitelist(url, whitelist)).toBeFalsy();
         });
 
+        it('should return false when TLD does not match', function () {
+            const whitelist = 'www.symphony.com, app.symphony.com, my.symphony.com';
+            const url = 'https://my.symphony.echonet/';
+
+            return expect(checkWhitelist(url, whitelist)).toBeFalsy();
+        });
+
         it('should return false when the URL is invalid', function () {
             const whitelist = 'www.symphony.com, app.symphony.com, my.symphony.com';
             const url = 'invalidUrl';

--- a/tests/utils/whitelist.test.js
+++ b/tests/utils/whitelist.test.js
@@ -32,6 +32,13 @@ describe('validate url with whitelist', function() {
             return expect(checkWhitelist(url, whitelist)).toBeTruthy();
         });
 
+        it('should return true for non-standard TLDs', function() {
+            const whitelist = 'symphony.com, symphony.econet';
+            const url = 'https://my.symphony.econet/';
+
+            return expect(checkWhitelist(url, whitelist)).toBeTruthy();
+        });
+
     });
 
     describe('checkWhitelist falsity tests', function () {


### PR DESCRIPTION
## Description
(Remove third party dependency and write custom implementation) [ELECTRON-385](https://perzoinc.atlassian.net/browse/ELECTRON-385)


## Approach
How does this change address the problem?
#### Problem with the code:
 - Using a third party package `parseDomain` which had a strict `TLD` validation caused issues with the whitelist for the following TLD `.econet`
#### Fix:
 - Wrote a custom URL parser that returns any `TLDs`


## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
Old changes | [link](https://github.com/symphonyoss/SymphonyElectron/pull/347)

## Spectron test results
[Electron-385 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1963421/Electron-385.Spectron.pdf)


## Unit test results
[Electron-385 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1963418/Electron-385.Unit.Tests.pdf)


## Open Questions if any and Todos
- [X] Unit-Tests
- [X] Documentation
- [X] Automation-Tests
When solved, check the box and explain the answer.

@VishwasShashidhar @VikasShashidhar Please review. Thanks 😃 