### PR TITLE
ELECTRON-448: upgrade electron to 2.0.0 stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "bluebird": "3.5.1",
     "browserify": "14.5.0",
     "cross-env": "3.2.4",
-    "electron": "1.8.4",
+    "electron": "2.0.0",
     "electron-builder": "20.10.0",
     "electron-builder-squirrel-windows": "12.3.0",
     "electron-chromedriver": "1.8.0",


### PR DESCRIPTION
## Description
As part of keeping up with the latest version of Electron, this is to upgrade to Electron 2.0.0 stable which comes with Chromium 61 and Node 8.9.3 [ELECTRON-448](https://perzoinc.atlassian.net/browse/ELECTRON-448)

## Approach
Update the electron dependency in package.json

## Learning
N/A

#### Blog Posts
N/A

## Related PRs
N/A

## Open Questions if any and Todos
- [x] Unit-Tests
[ELECTRON-448 - Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1966109/ELECTRON-448.-.Unit.Tests.pdf)
- [x] Documentation
- [x] Automation-Tests
[ELECTRON-448 - Spectron Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1966110/ELECTRON-448.-.Spectron.Tests.pdf)