### PR TITLE
Electron 451: add a new menu item "Symphony Help" under the help menu

### DIFF
--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -104,6 +104,10 @@ const template = [{
     submenu: 
     [
         {
+            label: 'Symphony Help',
+            click() { electron.shell.openExternal('https://support.symphony.com'); }
+        },
+        {
             label: 'Learn More',
             click() { electron.shell.openExternal('https://www.symphony.com'); }
         },

--- a/tests/spectron/share-logs.spectron.js
+++ b/tests/spectron/share-logs.spectron.js
@@ -111,6 +111,7 @@ describe('Tests for Generating & Sharing Logs', () => {
             robot.mouseClick();
             robot.keyTap('down');
             robot.keyTap('down');
+            robot.keyTap('down');
             robot.keyTap('right');
             robot.keyTap('enter');
             


### PR DESCRIPTION
## Description
To make it easier for users to contact the Symphony support team, we've added a new menu item under the "Help" menu in the Electron app [ELECTRON-451](https://perzoinc.atlassian.net/browse/ELECTRON-451)
<img width="1440" alt="screen shot 2018-05-02 at 12 52 42" src="https://user-images.githubusercontent.com/5968790/39510604-df7ad98c-4e07-11e8-8ae7-bd9bed50a1d9.png">

## Approach
Add a new menu item in the menuTemplate.js file.

## Learning
N/A

#### Blog Posts
N/A

## Related PRs
N/A

## Open Questions if any and Todos
- [x] Unit-Tests
[ELECTRON-451 - Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1966231/ELECTRON-451.-.Unit.Tests.pdf)
- [x] Documentation
- [x] Automation-Tests
[ELECTRON-451 - Spectron Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1966243/ELECTRON-451.-.Spectron.Tests.pdf)