### PR TITLE
Electron-267 (Prevent updating alwaysOnTop property for notification windows)

### DIFF
--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -753,9 +753,11 @@ function isAlwaysOnTop(boolean) {
     alwaysOnTop = boolean;
     let browserWins = BrowserWindow.getAllWindows();
     if (browserWins.length > 0) {
-        browserWins.forEach(function (browser) {
-            browser.setAlwaysOnTop(boolean);
-        });
+        browserWins
+            .filter((browser) => typeof browser.notfyObj !== 'object')
+            .forEach(function (browser) {
+                browser.setAlwaysOnTop(boolean);
+            });
 
         // An issue where changing the alwaysOnTop property
         // focus the pop-out window


### PR DESCRIPTION
## Description
Prevent updating alwaysOnTop property for notification windows [ELECTRON-267](https://perzoinc.atlassian.net/browse/ELECTRON-267)


## Approach
How does this change address the problem?
#### Problem with the code:
 - Was updating `alwaysOnTop` property for all the windows including notifications
#### Fix:
 - Filtered out notifications windows

## Spectron tests result
[Electron-267 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1967025/Electron-267.Spectron.pdf)

## Unit tests result
[Electron-267 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1967028/Electron-267.Unit.Tests.pdf)



## Open Questions if any and Todos
- [X] Unit-Tests
- [X] Documentation
- [X] Automation-Tests
When solved, check the box and explain the answer.
