### PR TITLE
Electron-469 (Fix log path)

### DIFF
--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -120,7 +120,7 @@ const template = [{
 
                         const FILE_EXTENSIONS = [ '.log' ];
                         const MAC_LOGS_PATH = '/Library/Logs/Symphony/';
-                        const WINDOWS_LOGS_PATH = '\\AppData\\Roaming\\Symphony\\';
+                        const WINDOWS_LOGS_PATH = '\\AppData\\Roaming\\Symphony\\logs';
             
                         let logsPath = isMac ? MAC_LOGS_PATH : WINDOWS_LOGS_PATH;
                         let source = electron.app.getPath('home') + logsPath;


### PR DESCRIPTION
## Description
Fix log path [ELECTRON-469](https://perzoinc.atlassian.net/browse/ELECTRON-469)


## Approach
How does this change address the problem?
#### Problem with the code:
 - Log path defined for Windows was incorrect
#### Fix:
 - Corrected the log path


## Open Questions if any and Todos
- [X] Unit-Tests
- [X] Documentation
- [X] Automation-Tests
When solved, check the box and explain the answer.

@VikasShashidhar @VishwasShashidhar Please review. Thanks 😃 