### PR TITLE
Electron 455: fix memory leak with pop outs

### DIFF
--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -395,21 +395,6 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
                     browserWin.winName = frameName;
                     browserWin.setAlwaysOnTop(alwaysOnTop);
 
-                    let handleChildWindowClosed = () => {
-                        removeWindowKey(newWinKey);
-                        browserWin.removeListener('move', throttledBoundsChange);
-                        browserWin.removeListener('resize', throttledBoundsChange);
-                    };
-
-                    browserWin.once('closed', () => {
-                        handleChildWindowClosed();
-                    });
-
-                    browserWin.on('close', () => {
-                        browserWin.webContents.removeListener('new-window', handleNewWindow);
-                        browserWin.webContents.removeListener('crashed', handleChildWindowCrashEvent);
-                    });
-
                     let handleChildWindowCrashEvent = (e) => {
                         const options = {
                             type: 'error',
@@ -450,6 +435,21 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
                     browserWin.on('move', throttledBoundsChange);
                     browserWin.on('resize', throttledBoundsChange);
     
+                    let handleChildWindowClosed = () => {
+                        removeWindowKey(newWinKey);
+                        browserWin.removeListener('move', throttledBoundsChange);
+                        browserWin.removeListener('resize', throttledBoundsChange);
+                    };
+    
+                    browserWin.on('close', () => {
+                        browserWin.webContents.removeListener('new-window', handleNewWindow);
+                        browserWin.webContents.removeListener('crashed', handleChildWindowCrashEvent);
+                    });
+    
+                    browserWin.once('closed', () => {
+                        handleChildWindowClosed();
+                    });
+                    
                     handlePermissionRequests(browserWin.webContents);
                 }
             });


### PR DESCRIPTION
## Description
When pop outs are closed, some of the event listeners were not being removed and that was causing memory to not be released on those event listeners. [ELECTRON-455](https://perzoinc.atlassian.net/browse/ELECTRON-455)

## Approach
How does this change address the problem?
- #### Problem with the code: When an event listener is registered, it was not being removed when a pop out was closed.
- #### Fix: Added logic to remove event listeners upon closing pop outs.

## Learning
N/A

#### Blog Posts
N/A

## Related PRs
N/A

## Open Questions if any and Todos
- [x] Unit-Tests
[ELECTRON-455 Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1979444/ELECTRON-455.Unit.Tests.pdf)
- [x] Documentation
- [x] Automation-Tests
[ELECTRON-455 Spectron Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1979445/ELECTRON-455.Spectron.Tests.pdf)