### PR TITLE
Electron-470 (Add a new boolean check whether to activate main window)

### DIFF
--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -287,7 +287,10 @@ function getTemplate(app) {
         checked: isAlwaysOnTop,
         click: (item) => {
             isAlwaysOnTop = item.checked;
-            eventEmitter.emit('isAlwaysOnTop', isAlwaysOnTop, true);
+            eventEmitter.emit('isAlwaysOnTop', {
+                isAlwaysOnTop,
+                shouldActivateMainWindow: true
+            });
             updateConfigField('alwaysOnTop', isAlwaysOnTop);
         }
     });
@@ -374,7 +377,10 @@ function setCheckboxValues() {
                                 break;
                             case 'alwaysOnTop':
                                 isAlwaysOnTop = configData[key];
-                                eventEmitter.emit('isAlwaysOnTop', configData[key], true);
+                                eventEmitter.emit('isAlwaysOnTop', {
+                                    isAlwaysOnTop: configData[key],
+                                    shouldActivateMainWindow: true
+                                });
                                 break;
                             case 'notificationSettings':
                                 eventEmitter.emit('notificationSettings', configData[key]);

--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -287,7 +287,7 @@ function getTemplate(app) {
         checked: isAlwaysOnTop,
         click: (item) => {
             isAlwaysOnTop = item.checked;
-            eventEmitter.emit('isAlwaysOnTop', isAlwaysOnTop);
+            eventEmitter.emit('isAlwaysOnTop', isAlwaysOnTop, true);
             updateConfigField('alwaysOnTop', isAlwaysOnTop);
         }
     });
@@ -374,7 +374,7 @@ function setCheckboxValues() {
                                 break;
                             case 'alwaysOnTop':
                                 isAlwaysOnTop = configData[key];
-                                eventEmitter.emit('isAlwaysOnTop', configData[key]);
+                                eventEmitter.emit('isAlwaysOnTop', configData[key], true);
                                 break;
                             case 'notificationSettings':
                                 eventEmitter.emit('notificationSettings', configData[key]);

--- a/js/screenSnippet/index.js
+++ b/js/screenSnippet/index.js
@@ -70,7 +70,10 @@ class ScreenSnippet {
                 if (windows && windows.length > 0) {
                     isAlwaysOnTop = windows[ 0 ].isAlwaysOnTop();
                     if (isAlwaysOnTop) {
-                        eventEmitter.emit('isAlwaysOnTop', false, false);
+                        eventEmitter.emit('isAlwaysOnTop', {
+                            isAlwaysOnTop: false,
+                            shouldActivateMainWindow: false
+                        });
                     }
                 }
 
@@ -87,7 +90,10 @@ class ScreenSnippet {
             child = childProcess.execFile(captureUtil, captureUtilArgs, (error) => {
                 // Method to reset always on top feature
                 if (isAlwaysOnTop) {
-                    eventEmitter.emit('isAlwaysOnTop', true, false);
+                    eventEmitter.emit('isAlwaysOnTop', {
+                        isAlwaysOnTop: true,
+                        shouldActivateMainWindow: false
+                    });
                 }
                 // will be called when child process exits.
                 if (error && error.killed) {

--- a/js/screenSnippet/index.js
+++ b/js/screenSnippet/index.js
@@ -70,7 +70,7 @@ class ScreenSnippet {
                 if (windows && windows.length > 0) {
                     isAlwaysOnTop = windows[ 0 ].isAlwaysOnTop();
                     if (isAlwaysOnTop) {
-                        eventEmitter.emit('isAlwaysOnTop', false);
+                        eventEmitter.emit('isAlwaysOnTop', false, false);
                     }
                 }
 
@@ -87,7 +87,7 @@ class ScreenSnippet {
             child = childProcess.execFile(captureUtil, captureUtilArgs, (error) => {
                 // Method to reset always on top feature
                 if (isAlwaysOnTop) {
-                    eventEmitter.emit('isAlwaysOnTop', true);
+                    eventEmitter.emit('isAlwaysOnTop', true, false);
                 }
                 // will be called when child process exits.
                 if (error && error.killed) {

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -770,8 +770,8 @@ function isAlwaysOnTop(boolean, shouldActivateMainWindow = true) {
 }
 
 // node event emitter to update always on top
-eventEmitter.on('isAlwaysOnTop', (boolean, shouldActivateMainWindow) => {
-    isAlwaysOnTop(boolean, shouldActivateMainWindow);
+eventEmitter.on('isAlwaysOnTop', (params) => {
+    isAlwaysOnTop(params.isAlwaysOnTop, params.shouldActivateMainWindow);
 });
 
 // node event emitter for notification settings

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -747,9 +747,10 @@ function openUrlInDefaultBrowser(urlToOpen) {
 
 /**
  * Called when an event is received from menu
- * @param boolean weather to enable or disable alwaysOnTop.
+ * @param {boolean} boolean whether to enable or disable alwaysOnTop.
+ * @param {boolean} shouldActivateMainWindow whether to activate main window
  */
-function isAlwaysOnTop(boolean) {
+function isAlwaysOnTop(boolean, shouldActivateMainWindow = true) {
     alwaysOnTop = boolean;
     let browserWins = BrowserWindow.getAllWindows();
     if (browserWins.length > 0) {
@@ -761,16 +762,16 @@ function isAlwaysOnTop(boolean) {
 
         // An issue where changing the alwaysOnTop property
         // focus the pop-out window
-        // Issue - Electron-209
-        if (mainWindow && mainWindow.winName) {
+        // Issue - Electron-209/470
+        if (mainWindow && mainWindow.winName && shouldActivateMainWindow) {
             activate(mainWindow.winName);
         }
     }
 }
 
 // node event emitter to update always on top
-eventEmitter.on('isAlwaysOnTop', (boolean) => {
-    isAlwaysOnTop(boolean);
+eventEmitter.on('isAlwaysOnTop', (boolean, shouldActivateMainWindow) => {
+    isAlwaysOnTop(boolean, shouldActivateMainWindow);
 });
 
 // node event emitter for notification settings


### PR DESCRIPTION
## Description
An issue with `always on top` feature in Electron that brings pop-out to the top refer `Electron-209` and an issue with screen snippet where if always on top is enabled snipping tool goes to background refer `Electron-118`  [Electron470](https://perzoinc.atlassian.net/browse/ELECTRON-470)


## Approach
How does this change address the problem?
#### Problem with the code:
 - The main window is activated when the snippet is initialized from a pop-out window
#### Fix:
 - Added a check to activate the main window whenever required

## Before
![electron-470-before](https://user-images.githubusercontent.com/13243259/39797661-d3a3e586-537a-11e8-826e-04efb53e7330.gif)

## After
![electron-470-after](https://user-images.githubusercontent.com/13243259/39797666-d8fc7cd2-537a-11e8-8c04-78f4e934b2af.gif)


## Spectron tests result
[Electron-470 _ Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1986540/Electron-470._.Spectron.pdf)

## Unit tests result
[Electron-470 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1986541/Electron-470.Unit.Tests.pdf)
 

## Open Questions if any and Todos
- [X] Unit-Tests
- [X] Documentation
- [X] Automation-Tests
When solved, check the box and explain the answer.
