### PR TITLE
ELECTRON-481: fix the error dialogs with always on top use case

### DIFF
--- a/js/downloadManager/index.js
+++ b/js/downloadManager/index.js
@@ -27,8 +27,9 @@ function openFile(id) {
     });
     if (fileIndex !== -1) {
         let openResponse = remote.shell.openExternal(`file:///${local.downloadItems[fileIndex].savedPath}`);
-        if (!openResponse) {
-            remote.dialog.showErrorBox("File not found", 'The file you are trying to open cannot be found in the specified path.');
+        let focusedWindow = remote.BrowserWindow.getFocusedWindow();
+        if (!openResponse && focusedWindow && !focusedWindow.isDestroyed()) {
+            remote.dialog.showMessageBox(focusedWindow, {type: 'error', title: 'File not found', message: 'The file you are trying to open cannot be found in the specified path.'});
         }
     }
 }
@@ -43,8 +44,9 @@ function showInFinder(id) {
     });
     if (showFileIndex !== -1) {
         let showResponse = remote.shell.showItemInFolder(local.downloadItems[showFileIndex].savedPath);
-        if (!showResponse) {
-            remote.dialog.showErrorBox("File not found", 'The file you are trying to access cannot be found in the specified path.');
+        let focusedWindow = remote.BrowserWindow.getFocusedWindow();
+        if (!showResponse && focusedWindow && !focusedWindow.isDestroyed()) {
+            remote.dialog.showMessageBox(focusedWindow, {type: 'error', title: 'File not found', message: 'The file you are trying to open cannot be found in the specified path.'});
         }
     }
 }

--- a/js/main.js
+++ b/js/main.js
@@ -328,8 +328,8 @@ function getUrlAndCreateMainWindow() {
 
     getConfigField('url')
         .then(createWin).catch(function(err) {
-            let title = 'Error loading configuration';
-            electron.dialog.showErrorBox(title, title + ': ' + err);
+            log.send(logLevels.ERROR, `unable to create main window -> ${err}`);
+            app.quit();
         });
 }
 

--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -116,7 +116,7 @@ const template = [{
             submenu: [
                 {
                     label: isMac ? 'Show Logs in Finder' : 'Show Logs in Explorer',
-                    click() {
+                    click(item, focusedWindow) {
 
                         const FILE_EXTENSIONS = [ '.log' ];
                         const MAC_LOGS_PATH = '/Library/Logs/Symphony/';
@@ -125,8 +125,8 @@ const template = [{
                         let logsPath = isMac ? MAC_LOGS_PATH : WINDOWS_LOGS_PATH;
                         let source = electron.app.getPath('home') + logsPath;
             
-                        if (!fs.existsSync(source)) {
-                            electron.dialog.showErrorBox('Failed!', 'No logs are available to share');
+                        if (!fs.existsSync(source) && focusedWindow && !focusedWindow.isDestroyed()) {
+                            electron.dialog.showMessageBox(focusedWindow, {type: 'error', title: 'Failed!', message: 'No logs are available to share'});
                             return;
                         }
             
@@ -140,20 +140,22 @@ const template = [{
                                 electron.shell.showItemInFolder(destination);
                             })
                             .catch((err) => {
-                                electron.dialog.showErrorBox('Failed!', 'Unable to generate logs due to -> ' + err);
+                                if (focusedWindow && !focusedWindow.isDestroyed()) {
+                                    electron.dialog.showMessageBox(focusedWindow, {type: 'error', title: 'Failed!', message: `Unable to generate logs due to -> ${err}`});
+                                }
                             })
             
                     }
                 },
                 {
                     label: isMac ? 'Show crash dump in Finder' : 'Show crash dump in Explorer',
-                    click() {
+                    click(item, focusedWindow) {
                         const FILE_EXTENSIONS = isMac ? [ '.dmp' ] : [ '.dmp', '.txt' ];
                         const crashesDirectory = electron.crashReporter.getCrashesDirectory();
                         let source = isMac ? crashesDirectory + '/completed' : crashesDirectory;
 
-                        if (!fs.existsSync(source) || fs.readdirSync(source).length === 0) {
-                            electron.dialog.showErrorBox('Failed!', 'No crashes available to share');
+                        if (!fs.existsSync(source) || fs.readdirSync(source).length === 0 && focusedWindow && !focusedWindow.isDestroyed()) {
+                            electron.dialog.showMessageBox(focusedWindow, {type: 'error', title: 'Failed!', message: 'No crashes available to share'});
                             return;
                         }
 
@@ -167,7 +169,9 @@ const template = [{
                                 electron.shell.showItemInFolder(destination);
                             })
                             .catch((err) => {
-                                electron.dialog.showErrorBox('Failed!', 'Unable to generate crash report due to -> ' + err);
+                                if (focusedWindow && !focusedWindow.isDestroyed()) {
+                                    electron.dialog.showMessageBox(focusedWindow, {type: 'error', title: 'Failed!', message: `Unable to generate crash reports due to -> ${err}`});
+                                }
                             });
                     }
                 }
@@ -259,20 +263,24 @@ function getTemplate(app) {
         label: 'Auto Launch On Startup',
         type: 'checkbox',
         checked: launchOnStartup,
-        click: function(item) {
+        click: function(item, focusedWindow) {
             if (item.checked) {
                 symphonyAutoLauncher.enable()
                     .catch(function(err) {
                         let title = 'Error setting AutoLaunch configuration';
                         log.send(logLevels.ERROR, 'MenuTemplate: ' + title + ': auto launch error ' + err);
-                        electron.dialog.showErrorBox(title, title + ': ' + err);
+                        if (focusedWindow && !focusedWindow.isDestroyed()) {
+                            electron.dialog.showMessageBox(focusedWindow, {type: 'error', title, message: title + ': ' + err});
+                        }
                     });
             } else {
                 symphonyAutoLauncher.disable()
                     .catch(function(err) {
                         let title = 'Error setting AutoLaunch configuration';
                         log.send(logLevels.ERROR, 'MenuTemplate: ' + title + ': auto launch error ' + err);
-                        electron.dialog.showErrorBox(title, title + ': ' + err);
+                        if (focusedWindow && !focusedWindow.isDestroyed()) {
+                            electron.dialog.showMessageBox(focusedWindow, {type: 'error', title, message: title + ': ' + err});
+                        }
                     });
             }
             launchOnStartup = item.checked;
@@ -401,7 +409,9 @@ function setCheckboxValues() {
             .catch((err) => {
                 let title = 'Error loading configuration';
                 log.send(logLevels.ERROR, 'MenuTemplate: error reading configuration fields, error: ' + err);
-                electron.dialog.showErrorBox(title, title + ': ' + err);
+                if (electron.BrowserWindow.getFocusedWindow() && !electron.BrowserWindow.getFocusedWindow().isDestroyed()) {
+                    electron.dialog.showMessageBox(electron.BrowserWindow.getFocusedWindow(), {type: 'error', title, message: title + ': ' + err});
+                }
                 return resolve();
             });
     });

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -513,7 +513,7 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
                         
                         if (!userPermission) {
                             let fullMessage = `Your administrator has disabled ${message}. Please contact your admin for help.`;
-                            electron.dialog.showErrorBox('Permission Denied!', fullMessage);
+                            electron.dialog.showMessageBox(BrowserWindow.fromWebContents(webContents), {type: 'error', title: 'Permission Denied!', message: fullMessage});
                         }
                         
                         return cb(userPermission);


### PR DESCRIPTION
## Description
When always on top is enabled and an error dialog is to be shown, the dialog goes in the background and the menu items get disabled on Windows. To fix this, we use a message box with the type "error" instead of an error box [ELECTRON-481](https://perzoinc.atlassian.net/browse/ELECTRON-481)

## Approach
How does this change address the problem?
- #### Problem with the code: Using `showErrorBox` to show dialogs
- #### Fix: Using `showMessageBox` to show dialogs with type "error"

## Learning
N/A

#### Blog Posts
N/A

## Related PRs
N/A

## Open Questions if any and Todos
- [x] Unit-Tests
[ELECTRON-481 Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1991003/ELECTRON-481.Unit.Tests.pdf)
- [x] Documentation
- [x] Automation-Tests
[ELECTRON-481 Spectron Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1991077/ELECTRON-481.Spectron.Tests.pdf)