### PR TITLE
Electron-435 (Optimize reading "isCustomTitleBar" global config field)

### DIFF
--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -93,32 +93,34 @@ function getParsedUrl(appUrl) {
  * @param initialUrl
  */
 function createMainWindow(initialUrl) {
-    Promise.all([
-        getConfigField('mainWinPos'),
-        getGlobalConfigField('isCustomTitleBar')
-    ]).then((values) => {
-        doCreateMainWindow(initialUrl, values[ 0 ], values[ 1 ]);
-    }).catch(() => {
-        // failed use default bounds and frame
-        doCreateMainWindow(initialUrl, null, false);
-    });
+    getConfigField('mainWinPos')
+        .then(winPos => {
+            doCreateMainWindow(initialUrl, winPos);
+        })
+        .catch(() => {
+            // failed use default bounds and frame
+            doCreateMainWindow(initialUrl, null);
+        });
 }
 
 /**
  * Creates the main window with bounds
  * @param initialUrl
  * @param initialBounds
- * @param isCustomTitleBar {Boolean} - Global config value weather to enable custom title bar
  */
-function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
+function doCreateMainWindow(initialUrl, initialBounds) {
     let url = initialUrl;
     let key = getGuid();
+
+    const config = readConfigFileSync();
+
     // condition whether to enable custom Windows 10 title bar
-    const isCustomTitleBarEnabled = typeof isCustomTitleBar === 'boolean' && isCustomTitleBar && isWindows10();
+    const isCustomTitleBarEnabled = config
+        && typeof config.isCustomTitleBar === 'boolean'
+        && config.isCustomTitleBar
+        && isWindows10();
 
     log.send(logLevels.INFO, 'creating main window url: ' + url);
-    
-    let config = readConfigFileSync();
     
     if (config && config !== null && config.customFlags) {
         


### PR DESCRIPTION
## Description
Optimized reading global config field when creating a window [ELECTRON-435](https://perzoinc.atlassian.net/browse/ELECTRON-435)


## Approach
How does this change address the problem?
#### Problem with the code:
 - Reading user config file for the fresh install throw error which ignored `isCustomTitleBar`
#### Fix:
 - Used already available global config data for `isCustomTitleBar`

## Spectron tests result
[Electron-435 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1991430/Electron-435.Spectron.pdf)


## Unit tests result
[Electron-435 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/1991438/Electron-435.Unit.Tests.pdf)


## Open Questions if any and Todos
- [X] Unit-Tests
- [X] Documentation
- [X] Automation-Tests
When solved, check the box and explain the answer.
