### PR TITLE
ELECTRON-491 (Fixes a Javascript error when pop-in a meeting)

### DIFF
--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -496,32 +496,35 @@ function doCreateMainWindow(initialUrl, initialBounds) {
      * @param webContents Web contents of the window
      */
     function handlePermissionRequests(webContents) {
-        
+
         let session = webContents.session;
-        
+
         getConfigField('permissions')
             .then((permissions) => {
-                
+
                 if (!permissions) {
                     log.send(logLevels.ERROR, 'permissions configuration is invalid, so, everything will be true by default!');
                     return;
                 }
-                
+
                 session.setPermissionRequestHandler((sessionWebContents, permission, callback) => {
-                    
+
                     function handleSessionPermissions(userPermission, message, cb) {
-                        
+
                         log.send(logLevels.INFO, 'permission is -> ' + userPermission);
-                        
+
                         if (!userPermission) {
                             let fullMessage = `Your administrator has disabled ${message}. Please contact your admin for help.`;
-                            electron.dialog.showMessageBox(BrowserWindow.fromWebContents(webContents), {type: 'error', title: 'Permission Denied!', message: fullMessage});
+                            const browserWindow = BrowserWindow.getFocusedWindow();
+                            if (browserWindow && !browserWindow.isDestroyed()) {
+                                electron.dialog.showMessageBox(browserWindow, {type: 'error', title: 'Permission Denied!', message: fullMessage});
+                            }
                         }
-                        
+
                         return cb(userPermission);
-                        
+
                     }
-                    
+
                     let PERMISSION_MEDIA = 'media';
                     let PERMISSION_LOCATION = 'geolocation';
                     let PERMISSION_NOTIFICATIONS = 'notifications';
@@ -529,40 +532,40 @@ function doCreateMainWindow(initialUrl, initialBounds) {
                     let PERMISSION_POINTER_LOCK = 'pointerLock';
                     let PERMISSION_FULL_SCREEN = 'fullscreen';
                     let PERMISSION_OPEN_EXTERNAL = 'openExternal';
-                    
+
                     switch (permission) {
-                        
+
                         case PERMISSION_MEDIA:
                             return handleSessionPermissions(permissions.media, 'sharing your camera, microphone, and speakers', callback);
-                        
+
                         case PERMISSION_LOCATION:
                             return handleSessionPermissions(permissions.geolocation, 'sharing your location', callback);
-                        
+
                         case PERMISSION_NOTIFICATIONS:
                             return handleSessionPermissions(permissions.notifications, 'notifications', callback);
-                        
+
                         case PERMISSION_MIDI_SYSEX:
                             return handleSessionPermissions(permissions.midiSysex, 'MIDI Sysex', callback);
-                        
+
                         case PERMISSION_POINTER_LOCK:
                             return handleSessionPermissions(permissions.pointerLock, 'Pointer Lock', callback);
-                        
+
                         case PERMISSION_FULL_SCREEN:
                             return handleSessionPermissions(permissions.fullscreen, 'Full Screen', callback);
-                        
+
                         case PERMISSION_OPEN_EXTERNAL:
                             return handleSessionPermissions(permissions.openExternal, 'Opening External App', callback);
-                        
+
                         default:
                             return callback(false);
                     }
-                    
+
                 });
-                
+
             }).catch((error) => {
                 log.send(logLevels.ERROR, 'unable to get permissions configuration, so, everything will be true by default! ' + error);
             })
-        
+
     }
 
 }


### PR DESCRIPTION
## Description
Change method to use getFocusedWindow instead of fromWebContents [ELECTRON-491](https://perzoinc.atlassian.net/browse/ELECTRON-491)


## Approach
How does this change address the problem?
#### Problem with the code:
 - Calling a `fromWebContents` method with undefined `webContents` throwing an error
 
![tng01_1](https://user-images.githubusercontent.com/13243259/40053999-e988c976-5860-11e8-997b-566a6e012078.png)

#### Fix:
 - Using `getFocusedWindow` for get the browser window access
 - Cleaned up spaces

## Spectron tests result
[Electron-491 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2004714/Electron-491.Spectron.pdf)


## Unit tests result
[Electron-491 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2004713/Electron-491.Unit.Tests.pdf)


## Open Questions if any and Todos
- [X] Unit-Tests
- [X] Documentation
- [X] Automation-Tests
When solved, check the box and explain the answer.
