### PR TITLE
ELECTRON-453: add functionality to ignore cert transparency checks

### DIFF
--- a/config/Symphony.config
+++ b/config/Symphony.config
@@ -7,6 +7,7 @@
     "whitelistUrl": "*",
     "isCustomTitleBar": true,
     "memoryRefresh": true,
+    "ctWhitelist": ["example.com", "hello.com"],
     "notificationSettings": {
         "position": "upper-right",
         "display": ""

--- a/config/Symphony.config
+++ b/config/Symphony.config
@@ -7,7 +7,7 @@
     "whitelistUrl": "*",
     "isCustomTitleBar": true,
     "memoryRefresh": true,
-    "ctWhitelist": ["example.com", "hello.com"],
+    "ctWhitelist": [],
     "notificationSettings": {
         "position": "upper-right",
         "display": ""

--- a/js/utils/whitelistHandler.js
+++ b/js/utils/whitelistHandler.js
@@ -158,6 +158,7 @@ function parseDomain(url) {
 
 module.exports = {
     isWhitelisted,
+    parseDomain,
 
     // items below here are only exported for testing, do NOT use!
     checkWhitelist

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -96,16 +96,14 @@ function getParsedUrl(appUrl) {
  * @param initialUrl
  */
 function createMainWindow(initialUrl) {
-    Promise.all([
-        getConfigField('mainWinPos'),
-        getConfigField('ctWhitelist')
-    ]).then((values) => {
-        ctWhitelist = values[1];
-        doCreateMainWindow(initialUrl, values[0]);
-    }).catch(() => {
-        // failed use default bounds and frame
-        doCreateMainWindow(initialUrl, null);
-    });
+    getConfigField('mainWinPos')
+        .then(winPos => {
+            doCreateMainWindow(initialUrl, winPos);
+        })
+        .catch(() => {
+            // failed use default bounds and frame
+            doCreateMainWindow(initialUrl, null);
+        });
 }
 
 /**
@@ -124,8 +122,12 @@ function doCreateMainWindow(initialUrl, initialBounds) {
         && typeof config.isCustomTitleBar === 'boolean'
         && config.isCustomTitleBar
         && isWindows10();
-
-    log.send(logLevels.INFO, 'creating main window url: ' + url);
+    log.send(logLevels.INFO, `we are configuring a custom title bar for windows -> ${isCustomTitleBarEnabled}`);
+    
+    ctWhitelist = config && config.ctWhitelist;
+    log.send(logLevels.INFO, `we are configuring certificate transparency whitelist for the domains -> ${ctWhitelist}`);
+    
+    log.send(logLevels.INFO, `creating main window for ${url}`);
     
     if (config && config !== null && config.customFlags) {
         


### PR DESCRIPTION
## Description
Some customers would like to ignore certificate transparency checks for specific domains. This PR implements the required functionality [ELECTRON-453](https://perzoinc.atlassian.net/browse/ELECTRON-453)

## Approach
How does this change address the problem?
- #### Problem with the code: Currently, there's no way to ignore certificate transparency checks
- #### Fix: Add a new listener for ignoring certificate transparency checks on a browser window. Compare this with the whitelist configured and take necessary action.

## Learning
N/A

#### Blog Posts
N/A

## Related PRs
N/A

## Open Questions if any and Todos
- [x] Unit-Tests
[ELECTRON-453 Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2021511/ELECTRON-453.Unit.Tests.pdf)
- [x] Documentation
- [x] Automation-Tests
[ELECTRON-453 Spectron Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2021512/ELECTRON-453.Spectron.Tests.pdf)