### PR TITLE
ELECTRON-513: upgrade electron framework to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "bluebird": "3.5.1",
     "browserify": "14.5.0",
     "cross-env": "3.2.4",
-    "electron": "2.0.0",
+    "electron": "2.0.1",
     "electron-builder": "20.10.0",
     "electron-builder-squirrel-windows": "12.3.0",
     "electron-chromedriver": "1.8.0",


### PR DESCRIPTION
## Description
Upgrade to the latest version of the electron framework [ELECTRON-513](https://perzoinc.atlassian.net/browse/ELECTRON-513)

## Approach
N/A

## Learning
N/A

#### Blog Posts
N/A

## Related PRs
N/A

## Open Questions if any and Todos
- [x] Unit-Tests
[ELECTRON-513 Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2021620/ELECTRON-513.Unit.Tests.pdf)
- [x] Documentation
- [x] Automation-Tests
[ELECTRON-513 Spectron Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2021622/ELECTRON-513.Spectron.Tests.pdf)