### PR TITLE
Electron-350 (Store/Restore maximized and fullscreen application state on launch)

### DIFF
--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -200,7 +200,7 @@ function doCreateMainWindow(initialUrl, initialBounds) {
         }
 
         // Sets the application to full-screen if previously set to full-screen
-        if (initialBounds.isFullScreen && isMac) {
+        if (isMac && initialBounds.isFullScreen) {
             mainWindow.setFullScreen(true);
         }
     }


### PR DESCRIPTION
## Description
Restore maximized and fullscreen application state on launch based on previous state [ELECTRON-350](https://perzoinc.atlassian.net/browse/ELECTRON-350)


## Approach
How does this change address the problem?
#### Problem with the code:
 - `Maximized` and `Fullscreen` state was not stored/handled
#### Fix:
 - Storing the `maximized` and `fullscreen` states in the user config and restoring on launch

## Before
![before_fullscreen](https://user-images.githubusercontent.com/13243259/40346835-acde5eb8-5dbb-11e8-84ec-c1155ba5ae43.gif)

![before_maximized](https://user-images.githubusercontent.com/13243259/40346836-ad1172f8-5dbb-11e8-8ef5-077474e24375.gif)

## After
![after_fullscreen](https://user-images.githubusercontent.com/13243259/40346851-bb5dc7c6-5dbb-11e8-86ab-3ea9d93e07aa.gif)
![after_maximized](https://user-images.githubusercontent.com/13243259/40346853-bb89a81e-5dbb-11e8-8b3d-536b38c8c7de.gif)


## Spectron tests result
[Electron-350 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2025358/Electron-350.Spectron.pdf)

## Unit tests result
[Electron-350 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2025403/Electron-350.Unit.Tests.pdf)



## Open Questions if any and Todos
- [X] Unit-Tests
- [X] Documentation
- [X] Automation-Tests
When solved, check the box and explain the answer.
