### PR TITLE
SEARCH-764-R52 (Rework "deleteIndexFolders" in the Electron Preload Script)

### DIFF
--- a/js/search/search.js
+++ b/js/search/search.js
@@ -79,7 +79,7 @@ class Search {
         // Deleting all the messages except 3 Months from now
         libSymphonySearch.symSEDeleteMessagesFromRAMIndex(null,
             searchConfig.MINIMUM_DATE, indexDateStartFrom.toString());
-        Search.deleteIndexFolders(searchConfig.FOLDERS_CONSTANTS.INDEX_PATH);
+        Search.deleteIndexFolders();
         this.isInitialized = true;
     }
 
@@ -134,7 +134,7 @@ class Search {
     memoryIndexToFSIndex() {
         return new Promise((resolve, reject) => {
 
-            Search.deleteIndexFolders(searchConfig.FOLDERS_CONSTANTS.INDEX_PATH);
+            Search.deleteIndexFolders();
             libSymphonySearch.symSEEnsureFolderExists(searchConfig.FOLDERS_CONSTANTS.INDEX_PATH);
 
             if (!fs.existsSync(searchConfig.FOLDERS_CONSTANTS.INDEX_PATH)) {
@@ -520,20 +520,22 @@ class Search {
 
     /**
      * Removing all the folders and files inside the data folder
-     * @param location
      */
-    static deleteIndexFolders(location) {
-        if (fs.existsSync(location)) {
-            fs.readdirSync(location).forEach((file) => {
-                let curPath = location + "/" + file;
-                if (fs.lstatSync(curPath).isDirectory()) {
-                    Search.deleteIndexFolders(curPath);
-                } else {
-                    fs.unlinkSync(curPath);
-                }
-            });
-            fs.rmdirSync(location);
+    static deleteIndexFolders() {
+        function removeFiles(filePath) {
+            if (fs.existsSync(filePath)) {
+                fs.readdirSync(filePath).forEach((file) => {
+                    let curPath = filePath + "/" + file;
+                    if (fs.lstatSync(curPath).isDirectory()) {
+                        removeFiles(curPath);
+                    } else {
+                        fs.unlinkSync(curPath);
+                    }
+                });
+                fs.rmdirSync(filePath);
+            }
         }
+        removeFiles(searchConfig.FOLDERS_CONSTANTS.INDEX_PATH);
     }
 
 }
@@ -548,7 +550,7 @@ function deleteIndexFolder(isEncryption) {
     if (!isEncryption) {
         libSymphonySearch.symSEDestroy();
     }
-    Search.deleteIndexFolders(searchConfig.FOLDERS_CONSTANTS.INDEX_PATH);
+    Search.deleteIndexFolders();
 }
 
 /**

--- a/tests/spectron/getVersionInfo.spectron.js
+++ b/tests/spectron/getVersionInfo.spectron.js
@@ -60,7 +60,7 @@ describe('Tests for getVersionInfo API', () => {
         ]).mapSeries((string) => {
             return app.client.getText(string)
         }).then((values) => {
-            expect(values[ 0 ]).toBe('1.0.0');
+            expect(values[ 0 ]).toBe('2.0.0');
             expect(values[ 1 ]).toBe('Electron');
             expect(values[ 2 ]).toBe(electronVersion);
             expect(values[ 3 ]).toBe(buildNumber);


### PR DESCRIPTION
## Description
Rework "deleteIndexFolders" in the Electron Preload Script
[SEARCH-764](https://perzoinc.atlassian.net/browse/SEARCH-764)


## Approach
How does this change address the problem?
- #### Problem with the code: Files can be deleted when creating an instance of Search class and calling the method 'deleteIndexFolders' with the path as the parameter
- #### Fix: Now the method won't accept any parameter and the path is hardcoded

## Learning
N/A

#### Blog Posts
N/A

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
SymphonyElectron-Dev | [link](https://github.com/symphonyoss/SymphonyElectron/pull/378)

## Unit Tests Result
[Test Results — Unit Tests-R52.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2030203/Test.Results.Unit.Tests-R52.pdf)


## Spectron Tests Result
[Test Results — Spectron-R52.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2030215/Test.Results.Spectron-R52.pdf)


## Open Questions if any and Todos
- [x] Unit-Tests
- [x] Documentation
- [x] Automation-Tests

@VikasShashidhar @VishwasShashidhar Please review. Thanks 😃 