### PR TITLE
ELECTRON-526: fix notification transparent window issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "bluebird": "3.5.1",
     "browserify": "14.5.0",
     "cross-env": "3.2.4",
-    "electron": "2.0.1",
+    "electron": "2.0.2",
     "electron-builder": "20.10.0",
     "electron-builder-squirrel-windows": "12.3.0",
     "electron-chromedriver": "1.8.0",


### PR DESCRIPTION
## Description
Due to a regression in the electron framework 2.0.1, notification windows were not being displayed properly. This PR fixes the issue by going with electron framework 2.0.2 which has fixed the transparent window issue. [ELECTRON-526](https://perzoinc.atlassian.net/browse/ELECTRON-526)
![screen shot 2018-05-24 at 5 39 54 pm](https://user-images.githubusercontent.com/5968790/40485495-4e9d3e06-5f7c-11e8-9bd6-9b990e196682.png)

## Approach
- #### Fix: Upgrade electron framework to 2.0.2

## Learning
https://github.com/electron/electron/issues/12989

#### Blog Posts
N/A

## Related PRs
N/A

## Open Questions if any and Todos
- [x] Unit-Tests
[ELECTRON-526 Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2035281/ELECTRON-526.Unit.Tests.pdf)
- [x] Documentation
- [x] Automation-Tests
[ELECTRON-526 Spectron Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2035284/ELECTRON-526.Spectron.Tests.pdf)