### PR TITLE
ELECTRON-508 (Fix security issue with getSource and getSources)

### DIFF
--- a/js/desktopCapturer/getSource.js
+++ b/js/desktopCapturer/getSource.js
@@ -44,7 +44,8 @@ function isValid(options) {
 function getSource(options, callback) {
     let captureScreen, captureWindow, id;
     if (!isValid(options)) {
-        return callback(new Error('Invalid options'));
+        callback(new Error('Invalid options'));
+        return;
     }
     captureWindow = includes.call(options.types, 'window');
     captureScreen = includes.call(options.types, 'screen');
@@ -71,7 +72,7 @@ function getSource(options, callback) {
     id = getNextId();
     ipcRenderer.send('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', captureWindow, captureScreen, updatedOptions.thumbnailSize, id);
 
-    return ipcRenderer.once('ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_' + id, function(event, sources) {
+    ipcRenderer.once('ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_' + id, function(event, sources) {
 
         ipcRenderer.send(apiName, {
             cmd: apiCmds.openScreenPickerWindow,

--- a/js/desktopCapturer/getSource.js
+++ b/js/desktopCapturer/getSource.js
@@ -12,7 +12,7 @@
 // renderer process, this will have to do.  See github issue posted here to
 // electron: https://github.com/electron/electron/issues/9312
 
-const { ipcRenderer, remote } = require('electron');
+const { ipcRenderer, remote, desktopCapturer } = require('electron');
 const apiEnums = require('../enums/api.js');
 const apiCmds = apiEnums.cmds;
 const apiName = apiEnums.apiName;
@@ -43,6 +43,7 @@ function isValid(options) {
  */
 function getSource(options, callback) {
     let captureScreen, captureWindow, id;
+    let sourceTypes = [];
     if (!isValid(options)) {
         callback(new Error('Invalid options'));
         return;
@@ -69,14 +70,24 @@ function getSource(options, callback) {
         captureWindow = remote.systemPreferences.isAeroGlassEnabled();
     }
 
-    id = getNextId();
-    ipcRenderer.send('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', captureWindow, captureScreen, updatedOptions.thumbnailSize, id);
+    if (captureWindow) {
+        sourceTypes.push('window')
+    }
+    if (captureScreen) {
+        sourceTypes.push('screen')
+    }
 
-    ipcRenderer.once('ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_' + id, function(event, sources) {
+    id = getNextId();
+    desktopCapturer.getSources({ types: sourceTypes, thumbnailSize: updatedOptions.thumbnailSize }, (event, sources) => {
+        const updatedSources = sources.map(source => {
+            return Object.assign({}, source, {
+                thumbnail: source.thumbnail.toDataURL()
+            });
+        });
 
         ipcRenderer.send(apiName, {
             cmd: apiCmds.openScreenPickerWindow,
-            sources: sources,
+            sources: updatedSources,
             id: id
         });
 

--- a/js/desktopCapturer/getSource.js
+++ b/js/desktopCapturer/getSource.js
@@ -71,10 +71,10 @@ function getSource(options, callback) {
     }
 
     if (captureWindow) {
-        sourceTypes.push('window')
+        sourceTypes.push('window');
     }
     if (captureScreen) {
-        sourceTypes.push('screen')
+        sourceTypes.push('screen');
     }
 
     id = getNextId();

--- a/js/desktopCapturer/getSources.js
+++ b/js/desktopCapturer/getSources.js
@@ -40,7 +40,8 @@ function isValid(options) {
 function getSources(options, callback) {
     let captureScreen, captureWindow, id;
     if (!isValid(options)) {
-        return callback(new Error('Invalid options'));
+        callback(new Error('Invalid options'));
+        return;
     }
     captureWindow = includes.call(options.types, 'window');
     captureScreen = includes.call(options.types, 'screen');
@@ -67,7 +68,7 @@ function getSources(options, callback) {
     id = getNextId();
     ipcRenderer.send('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', captureWindow, captureScreen, updatedOptions.thumbnailSize, id);
 
-    return ipcRenderer.once('ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_' + id, function(event, sources) {
+    ipcRenderer.once('ELECTRON_RENDERER_DESKTOP_CAPTURER_RESULT_' + id, function(event, sources) {
         let source;
         callback(null, (function() {
             let i, len, results;

--- a/js/desktopCapturer/getSources.js
+++ b/js/desktopCapturer/getSources.js
@@ -61,10 +61,10 @@ function getSources(options, callback) {
         captureWindow = remote.systemPreferences.isAeroGlassEnabled();
     }
     if (captureWindow) {
-        sourceTypes.push('window')
+        sourceTypes.push('window');
     }
     if (captureScreen) {
-        sourceTypes.push('screen')
+        sourceTypes.push('screen');
     }
 
     desktopCapturer.getSources({ types: sourceTypes, thumbnailSize: updatedOptions.thumbnailSize }, (event, sources) => {


### PR DESCRIPTION
## Description
Prevents exposing Electron's EventEmitter in the preload script [ELECTRON-508](https://perzoinc.atlassian.net/browse/ELECTRON-508)


## Approach
How does this change address the problem?
#### Problem with the code:
 - Electron's EventEmitter `ipcRenderer` was returned to the web app, which is capable of sending arbitrary IPC messages and interacting directly with the Node.js runtime.
#### Fix:
 - Removed the unnecessary return statement 

## Spectron tests result
[Electron-508 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2044044/Electron-508.Spectron.pdf)

## Unit tests result
[Electron-508 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2044045/Electron-508.Unit.Tests.pdf)


## Open Questions if any and Todos
- [X] Unit-Tests
- [X] Documentation
- [X] Automation-Tests
When solved, check the box and explain the answer.
