### PR TITLE
ELECTRON-508 (Change error and warn functions to prevent from exposing application path)

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -186,7 +186,7 @@
             }
 
             function snippetError(err) {
-                alert('error getting snippet' + err);
+                alert('error getting snippet' + err.message);
             }
         });
 

--- a/js/screenSnippet/index.js
+++ b/js/screenSnippet/index.js
@@ -166,24 +166,26 @@ function readResult(outputFileName, resolve, reject, childProcessErr) {
 /* eslint-disable class-methods-use-this */
 /**
  * Create an error object with the ERROR level
- * @param msg
- * @returns {Error}
+ * @param message
+ * @returns {{message: string, type: string}}
  */
-function createError(msg) {
-    let err = new Error(msg);
-    err.type = 'ERROR';
-    return err;
+function createError(message) {
+    return {
+        message,
+        type: 'ERROR',
+    };
 }
 
 /**
  * Create an error object with the WARN level
- * @param msg
- * @returns {Error}
+ * @param message
+ * @returns {{message: string, type: string}}
  */
-function createWarn(msg) {
-    let err = new Error(msg);
-    err.type = 'WARN';
-    return err;
+function createWarn(message) {
+    return {
+        message,
+        type: 'WARN',
+    };
 }
 /* eslint-enable class-methods-use-this */
 


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits. Describe the problem or feature in addition to a link to the [ELECTRON-508](https://perzoinc.atlassian.net/browse/ELECTRON-508)


## Approach
How does this change address the problem?
#### Problem with the code:
 - Throwing runtime expectation exposes application path
#### Fix:
 - Update error function to return simple object


## Spectron test results
[Electron-508 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2067263/Electron-508.Spectron.pdf)

## Unit test results
[Electron-508 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2067265/Electron-508.Unit.Tests.pdf)


## Open Questions if any and Todos
- [X] Unit-Tests
- [X] Documentation
- [X] Automation-Tests
When solved, check the box and explain the answer.
