### PR TITLE
SEARCH-767 (Rework "path" in Electron Preload Script)

### DIFF
--- a/js/search/searchUtils.js
+++ b/js/search/searchUtils.js
@@ -10,6 +10,9 @@ const { isMac } = require('../utils/misc.js');
 /*eslint class-methods-use-this: ["error", { "exceptMethods": ["checkFreeSpace"] }] */
 class SearchUtils {
 
+    constructor() {
+        this.indexVersion = searchConfig.INDEX_VERSION;
+    }
     /**
      * This function returns true if the available disk space
      * is more than the constant MINIMUM_DISK_SPACE
@@ -118,7 +121,7 @@ function createUserConfigFile(userId, data) {
     let createStream = fs.createWriteStream(searchConfig.FOLDERS_CONSTANTS.USER_CONFIG_FILE);
     if (userData) {
         if (!userData.indexVersion) {
-            userData.indexVersion = searchConfig.INDEX_VERSION;
+            userData.indexVersion = this.indexVersion;
         }
         try {
             userData = JSON.stringify(userData);
@@ -144,7 +147,7 @@ function updateConfig(userId, data, resolve, reject) {
     let userData = data;
 
     if (userData && !userData.indexVersion) {
-        userData.indexVersion = searchConfig.INDEX_VERSION;
+        userData.indexVersion = this.indexVersion;
     }
 
     let configPath = searchConfig.FOLDERS_CONSTANTS.USER_CONFIG_FILE;


### PR DESCRIPTION
## Description
`constructor` was removed as part of SEARCH-767 which caused the isEmpty check to fail.
[SEARCH-767](https://perzoinc.atlassian.net/browse/SEARCH-767)


## Approach
How does this change address the problem?
- #### Problem with the code: Without the constructor, the isEmpty check to fail
- #### Fix: Adds constructor


## Learning
N/A

#### Blog Posts
N/A

## Related PRs
N/A

## Unit Tests Result
[Test Results — Unit-Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2079509/Test.Results.Unit-Tests.pdf)


## Spectron Tests Result
[Test Results — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2079505/Test.Results.Spectron.pdf)

## Open Questions if any and Todos
- [x] Unit-Tests
- [x] Documentation
- [x] Automation-Tests