### PR TITLE
ELECTRON-445 (Adds memory refresh menu item)

### DIFF
--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -26,6 +26,7 @@ let minimizeOnClose = false;
 let launchOnStartup = false;
 let isAlwaysOnTop = false;
 let bringToFront = false;
+let memoryRefresh = false;
 let titleBarStyle = titleBarStyles.CUSTOM;
 
 let symphonyAutoLauncher;
@@ -333,6 +334,22 @@ function getTemplate(app) {
         }
     });
 
+    // Window/View menu -> separator
+    template[index].submenu.push({
+        type: 'separator',
+    });
+
+    // Window - View menu -> memoryRefresh
+    template[index].submenu.push({
+        label: 'Memory Refresh',
+        type: 'checkbox',
+        checked: memoryRefresh,
+        click: function(item) {
+            memoryRefresh = item.checked;
+            updateConfigField('memoryRefresh', memoryRefresh);
+        }
+    });
+
     if (!isMac) {
 
         if (isWindows10()) {
@@ -422,6 +439,9 @@ function setCheckboxValues() {
                                 break;
                             case 'isCustomTitleBar':
                                 titleBarStyle = configData[key] ? titleBarStyles.CUSTOM : titleBarStyles.NATIVE_WITH_CUSTOM;
+                                break;
+                            case 'memoryRefresh':
+                                memoryRefresh = configData[key];
                                 break;
                             default:
                                 break;

--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -341,7 +341,7 @@ function getTemplate(app) {
 
     // Window - View menu -> memoryRefresh
     template[index].submenu.push({
-        label: 'Memory Refresh',
+        label: 'Refresh app when idle',
         type: 'checkbox',
         checked: memoryRefresh,
         click: function(item) {


### PR DESCRIPTION
## Description
Adds a menu item where users can enable or disable memory refresh functionality

## Menu Item
![screen shot 2018-06-08 at 2 24 20 pm](https://user-images.githubusercontent.com/13243259/41148870-a9470c22-6b27-11e8-9bff-1cec71e80dc0.png)

## Spectron tests result
[Electron-445 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2083683/Electron-445.Spectron.pdf)

## Unit tests result
[Electron-445 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2083687/Electron-445.Unit.Tests.pdf)


## Open Questions if any and Todos
- [ ] Unit-Tests
- [ ] Documentation
- [ ] Automation-Tests