### PR TITLE
ELECTRON-549: support not quitting app on mac upon closing window

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -169,7 +169,9 @@ app.on('ready', () => {
  * In which case we quit the app
  */
 app.on('window-all-closed', function() {
-    app.quit();
+    if (!isMac) {
+        app.quit();
+    }
 });
 
 /**

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -289,7 +289,9 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
             e.preventDefault();
             mainWindow.minimize();
         } else {
-            app.quit();
+            if (!isMac) {
+                app.quit();
+            }
         }
     });
 


### PR DESCRIPTION
## Description
By default, macOS dictates that when the "x" button on a window is clicked, the app is not supposed to be quit. This behaviour should apply to Symphony as well. This PR applies that logic. [ELECTRON-549](https://perzoinc.atlassian.net/browse/ELECTRON-549)

## Approach
How does this change address the problem?
- #### Problem with the code: When the app quit event is triggered, we are not checking if the platform is macOS and quitting the app.
- #### Fix: Add checks to ensure that the app is not quit if the platform is macOS.


## Learning
N/A

#### Blog Posts
N/A

## Related PRs
N/A

## Open Questions if any and Todos
- [x] Unit-Tests
[ELECTRON-549 Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2086814/ELECTRON-549.Unit.Tests.pdf)
- [x] Documentation
[ELECTRON-549 Spectron Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2086815/ELECTRON-549.Spectron.Tests.pdf)
- [x] Automation-Tests