### PR TITLE
SEARCH-767 (Fix constructor in R52)

### DIFF
--- a/js/search/searchUtils.js
+++ b/js/search/searchUtils.js
@@ -10,6 +10,10 @@ const { isMac } = require('../utils/misc.js');
 /*eslint class-methods-use-this: ["error", { "exceptMethods": ["checkFreeSpace"] }] */
 class SearchUtils {
 
+    constructor() {
+        this.indexVersion = searchConfig.INDEX_VERSION;
+    }
+
     /**
      * This function returns true if the available disk space
      * is more than the constant MINIMUM_DISK_SPACE


### PR DESCRIPTION
## Description
isEmpty check fails if the constructor is not passed.
[SEARCH-767](https://perzoinc.atlassian.net/browse/SEARCH-767)

## Approach
How does this change address the problem?
- #### Problem with the code: If the constructor is not passed the isEmpty check fails
- #### Fix: Passing the constructor.


## Learning
N/A

#### Blog Posts
N/A

## Related PRs
N/A

## Open Questions if any and Todos
- [x] Unit-Tests
- [x] Documentation
- [] Automation-Tests