### PR TITLE
ELECTRON-530: add chrome flag to disable background timer throttling

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -148,7 +148,7 @@ function setChromeFlags() {
 
     }
     
-    app.commandLine.appendSwitch("--disable-background-timer-throttling", true);
+    app.commandLine.appendSwitch("disable-background-timer-throttling", true);
 }
 
 // Set the chrome flags

--- a/js/main.js
+++ b/js/main.js
@@ -118,15 +118,13 @@ if (isMac) {
  */
 function setChromeFlags() {
 
-    log.send(logLevels.INFO, 'checking if we need to set custom chrome flags!');
+    log.send(logLevels.INFO, 'setting chrome flags!');
 
     // Read the config parameters synchronously
     let config = readConfigFileSync();
 
     // If we cannot find any config, just skip setting any flags
     if (config && config !== null && config.customFlags) {
-
-        log.send(logLevels.INFO, 'Chrome flags config found!');
 
         if (config.customFlags.authServerWhitelist && config.customFlags.authServerWhitelist !== "") {
             log.send(logLevels.INFO, 'Setting auth server whitelist flag');
@@ -149,6 +147,8 @@ function setChromeFlags() {
         }
 
     }
+    
+    app.commandLine.appendSwitch("--disable-background-timer-throttling", true);
 }
 
 // Set the chrome flags


### PR DESCRIPTION
## Description
Starting Chrome 57, chrome throttles background tabs (in Electron's case, background / minimised Windows). This PR disables throttling so Electron can perform better during the client app bootstrap. [ELECTRON-530](https://perzoinc.atlassian.net/browse/ELECTRON-530)

### Throttling Enabled
<img width="806" alt="screen shot 2018-06-12 at 13 28 49" src="https://user-images.githubusercontent.com/5968790/41278915-be9de680-6e48-11e8-8df1-3c5cebcc249c.png">

### Throttling Disabled
<img width="801" alt="screen shot 2018-06-12 at 13 24 49" src="https://user-images.githubusercontent.com/5968790/41278891-a94463ae-6e48-11e8-9fab-64b3dab1ba55.png">

## Approach
How does this change address the problem?
- #### Problem with the code: N/A
- #### Fix: Add the `--disable-background-timer-throttling` flag to chrome.


## Learning
N/A

#### Blog Posts
N/A

## Related PRs
N/A

## Open Questions if any and Todos
- [x] Unit-Tests
[ELECTRON-530 Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2093208/ELECTRON-530.Unit.Tests.pdf)
- [x] Documentation
- [x] Automation-Tests
[ELECTRON-530 Spectron Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2093218/ELECTRON-530.Spectron.Tests.pdf)
