### PR TITLE
Electron 549: fix main window show javascript error issues

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -169,7 +169,9 @@ app.on('ready', () => {
  * In which case we quit the app
  */
 app.on('window-all-closed', function() {
-    app.quit();
+    if (!isMac) {
+        app.quit();
+    }
 });
 
 /**

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -289,7 +289,9 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
             e.preventDefault();
             mainWindow.minimize();
         } else {
-            app.quit();
+            if (!isMac) {
+                app.quit();
+            }
         }
     });
 

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -679,7 +679,9 @@ function getWindowSizeAndPosition(window) {
  * Shows the main window
  */
 function showMainWindow() {
-    mainWindow.show();
+    if (mainWindow) {
+        mainWindow.show();
+    }
 }
 
 /**


### PR DESCRIPTION
## Description
When we click on the app icon before the app is fully launched, we get a javascript error that the main window is not initialised. This PR adds an extra check to ensure the main window is initialised before showing it. [ELECTRON-549](https://perzoinc.atlassian.net/browse/ELECTRON-549)

## Approach
- #### Problem with the code: There's no check to see if the mainWindow object is initalized
- #### Fix: Add a condition to check if the mainWindow object is initialized and then show the main window.

## Learning
N/A

#### Blog Posts
N/A

## Related PRs
N/A

## Open Questions if any and Todos
- [x] Unit-Tests
[ELECTRON-549 Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2093391/ELECTRON-549.Unit.Tests.pdf)
- [x] Documentation
- [x] Automation-Tests
[ELECTRON-549 Spectron Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2093399/ELECTRON-549.Spectron.Tests.pdf)