### PR TITLE
ELECTRON-563: fix main window close issue on macOS

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -169,9 +169,7 @@ app.on('ready', () => {
  * In which case we quit the app
  */
 app.on('window-all-closed', function() {
-    if (!isMac) {
-        app.quit();
-    }
+    app.quit();
 });
 
 /**

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -288,10 +288,11 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
         if (getMinimizeOnClose()) {
             e.preventDefault();
             mainWindow.minimize();
+        } else if (isMac) {
+            e.preventDefault();
+            mainWindow.hide();
         } else {
-            if (!isMac) {
-                app.quit();
-            }
+            app.quit();
         }
     });
 


### PR DESCRIPTION
## Description
On macOS, if the main window is closed using the “x” button, the main window is being destroyed and upon activation, we are seeing javascript errors because the main window is null. This PR fixes the issue [ELECTRON-563](https://perzoinc.atlassian.net/browse/ELECTRON-563)

## Approach
- #### Problem with the code: In windowMgr, we are not checking for platform and simply destroying the main window regardless of the platform
- #### Fix: Add check to see if the platform is macOS and hide the main window rather than destroy it

## Learning
N/A

#### Blog Posts
N/A

## Related PRs
N/A

## Open Questions if any and Todos
- [x] Unit-Tests
[ELECTRON-563 Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2097936/ELECTRON-563.Unit.Tests.pdf)

- [x] Documentation
- [x] Automation-Tests
[ELECTRON-563 Spectron Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2097937/ELECTRON-563.Spectron.Tests.pdf)
