### PR TITLE
ELECTRON-510: Insecure Download Manager Functionality

### DIFF
--- a/js/downloadManager/dmPreload.js
+++ b/js/downloadManager/dmPreload.js
@@ -1,0 +1,232 @@
+'use strict';
+
+const { ipcRenderer } = require('electron');
+const apiEnums = require('../enums/api.js');
+const apiCmds = apiEnums.cmds;
+const apiName = apiEnums.apiName;
+
+const local = {
+    ipcRenderer: ipcRenderer,
+    downloadItems: []
+};
+
+// Listen for file download complete event
+local.ipcRenderer.on('downloadCompleted', (event, arg) => {
+    createDOM(arg);
+});
+
+// Listen for file download progress event
+local.ipcRenderer.on('downloadProgress', () => {
+    initiate();
+});
+
+/**
+ * Open file in default app.
+ * @param id
+ */
+function openFile(id) {
+    local.ipcRenderer.send(apiName, {
+        cmd: apiCmds.openFile,
+        id: id
+    });
+}
+
+/**
+ * Show downloaded file in explorer or finder.
+ * @param id
+ */
+function showInFinder(id) {
+    local.ipcRenderer.send(apiName, {
+        cmd: apiCmds.showInFinder,
+        id: id
+    });
+}
+
+function clearDownloadData() {
+    local.downloadItems = [];
+
+    local.ipcRenderer.send(apiName, {
+        cmd: apiCmds.clearDownloadData
+    });
+}
+
+/**
+ * Create the document object model
+ * @param arg
+ */
+function createDOM(arg) {
+
+    if (arg && arg._id) {
+        let fileDisplayName = getFileDisplayName(arg.fileName);
+        let downloadItemKey = arg._id;
+
+        local.downloadItems.push(arg);
+
+        let ul = document.getElementById('download-main');
+        if (ul) {
+            let li = document.createElement('li');
+            li.id = downloadItemKey;
+            li.classList.add('download-element');
+            ul.insertBefore(li, ul.childNodes[0]);
+
+            let itemDiv = document.createElement('div');
+            itemDiv.classList.add('download-item');
+            itemDiv.id = 'dl-item';
+            li.appendChild(itemDiv);
+            let openMainFile = document.getElementById('dl-item');
+            openMainFile.addEventListener('click', () => {
+                let id = openMainFile.parentNode.id;
+                openFile(id);
+            });
+
+            let fileDetails = document.createElement('div');
+            fileDetails.classList.add('file');
+            itemDiv.appendChild(fileDetails);
+
+            let downProgress = document.createElement('div');
+            downProgress.id = 'download-progress';
+            downProgress.classList.add('download-complete');
+            downProgress.classList.add('flash');
+            setTimeout(() => {
+                downProgress.classList.remove('flash');
+            }, 4000);
+            fileDetails.appendChild(downProgress);
+
+            let fileIcon = document.createElement('span');
+            fileIcon.classList.add('tempo-icon');
+            fileIcon.classList.add('tempo-icon--download');
+            fileIcon.classList.add('download-complete-color');
+            setTimeout(() => {
+                fileIcon.classList.remove('download-complete-color');
+                fileIcon.classList.remove('tempo-icon--download');
+                fileIcon.classList.add('tempo-icon--document');
+            }, 4000);
+            downProgress.appendChild(fileIcon);
+
+            let fileNameDiv = document.createElement('div');
+            fileNameDiv.classList.add('downloaded-filename');
+            itemDiv.appendChild(fileNameDiv);
+
+            let h2FileName = document.createElement('h2');
+            h2FileName.classList.add('text-cutoff');
+            h2FileName.innerHTML = fileDisplayName;
+            h2FileName.title = fileDisplayName;
+            fileNameDiv.appendChild(h2FileName);
+
+            let fileProgressTitle = document.createElement('span');
+            fileProgressTitle.id = 'per';
+            fileProgressTitle.innerHTML = arg.total + ' Downloaded';
+            fileNameDiv.appendChild(fileProgressTitle);
+
+            let caret = document.createElement('div');
+            caret.id = 'menu';
+            caret.classList.add('caret');
+            caret.classList.add('tempo-icon');
+            caret.classList.add('tempo-icon--dropdown');
+            li.appendChild(caret);
+
+            let actionMenu = document.createElement('div');
+            actionMenu.id = 'download-action-menu';
+            actionMenu.classList.add('download-action-menu');
+            caret.appendChild(actionMenu);
+
+            let caretUL = document.createElement('ul');
+            caretUL.id = downloadItemKey;
+            actionMenu.appendChild(caretUL);
+
+            let caretLiOpen = document.createElement('li');
+            caretLiOpen.id = 'download-open';
+            caretLiOpen.innerHTML = 'Open';
+            caretUL.appendChild(caretLiOpen);
+            let openFileDocument = document.getElementById('download-open');
+            openFileDocument.addEventListener('click', () => {
+                let id = openFileDocument.parentNode.id;
+                local.ipcRenderer.send(apiName, {
+                    cmd: apiCmds.openFile,
+                    count: 1
+                });
+                openFile(id);
+            });
+
+            let caretLiShow = document.createElement('li');
+            caretLiShow.id = 'download-show-in-folder';
+            caretLiShow.innerHTML = 'Show in Folder';
+            caretUL.appendChild(caretLiShow);
+            let showInFinderDocument = document.getElementById('download-show-in-folder');
+            showInFinderDocument.addEventListener('click', () => {
+                let id = showInFinderDocument.parentNode.id;
+                showInFinder(id);
+            });
+        }
+    }
+}
+
+/**
+ * Initiate the download manager
+ */
+function initiate() {
+    let mainFooter = document.getElementById('footer');
+    let mainDownloadDiv = document.getElementById('download-manager-footer');
+
+    if (mainDownloadDiv) {
+
+        mainFooter.classList.remove('hidden');
+
+        let ulFind = document.getElementById('download-main');
+
+        if (!ulFind) {
+            let uList = document.createElement('ul');
+            uList.id = 'download-main';
+            mainDownloadDiv.appendChild(uList);
+        }
+
+        let closeSpanFind = document.getElementById('close-download-bar');
+
+        if (!closeSpanFind) {
+            let closeSpan = document.createElement('span');
+            closeSpan.id = 'close-download-bar';
+            closeSpan.classList.add('close-download-bar');
+            closeSpan.classList.add('tempo-icon');
+            closeSpan.classList.add('tempo-icon--close');
+            mainDownloadDiv.appendChild(closeSpan);
+        }
+
+        let closeDownloadManager = document.getElementById('close-download-bar');
+        if (closeDownloadManager) {
+            closeDownloadManager.addEventListener('click', () => {
+                clearDownloadData();
+                document.getElementById('footer').classList.add('hidden');
+                document.getElementById('download-main').innerHTML = '';
+            });
+        }
+    }
+}
+
+/**
+ * Return a file display name for the download item
+ */
+function getFileDisplayName(fileName) {
+    let fileList = local.downloadItems;
+    let fileNameCount = 0;
+    let fileDisplayName = fileName;
+    
+    /* Check if a file with the same name exists
+     * (akin to the user downloading a file with the same name again)
+     * in the download bar
+     */
+    for (let i = 0; i < fileList.length; i++) {
+        if (fileName === fileList[i].fileName) {
+            fileNameCount++;
+        }
+    }
+    
+    /* If it exists, add a count to the name like how Chrome does */
+    if (fileNameCount) {
+        let extLastIndex = fileDisplayName.lastIndexOf('.');
+        let fileCount = ' (' + fileNameCount + ')';
+        
+        fileDisplayName = fileDisplayName.slice(0, extLastIndex) + fileCount + fileDisplayName.slice(extLastIndex);
+    }
+    
+    return fileDisplayName;
+}

--- a/js/downloadManager/index.js
+++ b/js/downloadManager/index.js
@@ -1,229 +1,66 @@
 'use strict';
 
-const { ipcRenderer, remote } = require('electron');
+const electron = require('electron');
+let downloadItems = [];
 
-const local = {
-    ipcRenderer: ipcRenderer,
-    downloadItems: []
-};
-
-// listen for file download complete event
-local.ipcRenderer.on('downloadCompleted', (event, arg) => {
-    createDOM(arg);
-});
-
-// listen for file download progress event
-local.ipcRenderer.on('downloadProgress', () => {
-    initiate();
-});
-
-/**
- * Open file in default app.
- * @param id
- */
 function openFile(id) {
-    let fileIndex = local.downloadItems.findIndex((item) => {
+    let fileIndex = downloadItems.findIndex((item) => {
         return item._id === id;
     });
+
     if (fileIndex !== -1) {
-        let openResponse = remote.shell.openExternal(`file:///${local.downloadItems[fileIndex].savedPath}`);
-        let focusedWindow = remote.BrowserWindow.getFocusedWindow();
-        if (!openResponse && focusedWindow && !focusedWindow.isDestroyed()) {
-            remote.dialog.showMessageBox(focusedWindow, {type: 'error', title: 'File not found', message: 'The file you are trying to open cannot be found in the specified path.'});
-        }
+        electron.dialog.showMessageBox({
+            type: 'warning',
+            buttons: ['Cancel', 'Proceed'],
+            defaultId: 1,
+            cancelId: 0,
+            title: 'Open File',
+            message: 'This file type may not be safe to open. Are you sure you want to open it?'
+        }, function (index) {
+            if (index === 1) {
+                let openResponse = electron.shell.openExternal(`file:///${downloadItems[fileIndex].savedPath}`);
+                let focusedWindow = electron.BrowserWindow.getFocusedWindow();
+                if (!openResponse && focusedWindow && !focusedWindow.isDestroyed()) {
+                    electron.dialog.showMessageBox(focusedWindow, {
+                        type: 'error',
+                        title: 'File not found',
+                        message: 'The file you are trying to open cannot be found in the specified path.'
+                    });
+                }
+            }
+        });
     }
 }
 
-/**
- * Show downloaded file in explorer or finder.
- * @param id
- */
 function showInFinder(id) {
-    let showFileIndex = local.downloadItems.findIndex((item) => {
+    let fileIndex = downloadItems.findIndex((item) => {
         return item._id === id;
     });
-    if (showFileIndex !== -1) {
-        let showResponse = remote.shell.showItemInFolder(local.downloadItems[showFileIndex].savedPath);
-        let focusedWindow = remote.BrowserWindow.getFocusedWindow();
+
+    if (fileIndex !== -1) {
+        let showResponse = electron.shell.showItemInFolder(downloadItems[fileIndex].savedPath);
+        let focusedWindow = electron.BrowserWindow.getFocusedWindow();
         if (!showResponse && focusedWindow && !focusedWindow.isDestroyed()) {
-            remote.dialog.showMessageBox(focusedWindow, {type: 'error', title: 'File not found', message: 'The file you are trying to open cannot be found in the specified path.'});
-        }
-    }
-}
-
-/**
- * Create the document object model
- * @param arg
- */
-function createDOM(arg) {
-
-    if (arg && arg._id) {
-        let fileDisplayName = getFileDisplayName(arg.fileName);
-        let downloadItemKey = arg._id;
-
-        local.downloadItems.push(arg);
-
-        let ul = document.getElementById('download-main');
-        if (ul) {
-            let li = document.createElement('li');
-            li.id = downloadItemKey;
-            li.classList.add('download-element');
-            ul.insertBefore(li, ul.childNodes[0]);
-
-            let itemDiv = document.createElement('div');
-            itemDiv.classList.add('download-item');
-            itemDiv.id = 'dl-item';
-            li.appendChild(itemDiv);
-            let openMainFile = document.getElementById('dl-item');
-            openMainFile.addEventListener('click', () => {
-                let id = openMainFile.parentNode.id;
-                openFile(id);
-            });
-
-            let fileDetails = document.createElement('div');
-            fileDetails.classList.add('file');
-            itemDiv.appendChild(fileDetails);
-
-            let downProgress = document.createElement('div');
-            downProgress.id = 'download-progress';
-            downProgress.classList.add('download-complete');
-            downProgress.classList.add('flash');
-            setTimeout(() => {
-                downProgress.classList.remove('flash');
-            }, 4000);
-            fileDetails.appendChild(downProgress);
-
-            let fileIcon = document.createElement('span');
-            fileIcon.classList.add('tempo-icon');
-            fileIcon.classList.add('tempo-icon--download');
-            fileIcon.classList.add('download-complete-color');
-            setTimeout(() => {
-                fileIcon.classList.remove('download-complete-color');
-                fileIcon.classList.remove('tempo-icon--download');
-                fileIcon.classList.add('tempo-icon--document');
-            }, 4000);
-            downProgress.appendChild(fileIcon);
-
-            let fileNameDiv = document.createElement('div');
-            fileNameDiv.classList.add('downloaded-filename');
-            itemDiv.appendChild(fileNameDiv);
-
-            let h2FileName = document.createElement('h2');
-            h2FileName.classList.add('text-cutoff');
-            h2FileName.innerHTML = fileDisplayName;
-            h2FileName.title = fileDisplayName;
-            fileNameDiv.appendChild(h2FileName);
-
-            let fileProgressTitle = document.createElement('span');
-            fileProgressTitle.id = 'per';
-            fileProgressTitle.innerHTML = arg.total + ' Downloaded';
-            fileNameDiv.appendChild(fileProgressTitle);
-
-            let caret = document.createElement('div');
-            caret.id = 'menu';
-            caret.classList.add('caret');
-            caret.classList.add('tempo-icon');
-            caret.classList.add('tempo-icon--dropdown');
-            li.appendChild(caret);
-
-            let actionMenu = document.createElement('div');
-            actionMenu.id = 'download-action-menu';
-            actionMenu.classList.add('download-action-menu');
-            caret.appendChild(actionMenu);
-
-            let caretUL = document.createElement('ul');
-            caretUL.id = downloadItemKey;
-            actionMenu.appendChild(caretUL);
-
-            let caretLiOpen = document.createElement('li');
-            caretLiOpen.id = 'download-open';
-            caretLiOpen.innerHTML = 'Open';
-            caretUL.appendChild(caretLiOpen);
-            let openFileDocument = document.getElementById('download-open');
-            openFileDocument.addEventListener('click', () => {
-                let id = openFileDocument.parentNode.id;
-                openFile(id);
-            });
-
-            let caretLiShow = document.createElement('li');
-            caretLiShow.id = 'download-show-in-folder';
-            caretLiShow.innerHTML = 'Show in Folder';
-            caretUL.appendChild(caretLiShow);
-            let showInFinderDocument = document.getElementById('download-show-in-folder');
-            showInFinderDocument.addEventListener('click', () => {
-                let id = showInFinderDocument.parentNode.id;
-                showInFinder(id);
+            electron.dialog.showMessageBox(focusedWindow, {
+                type: 'error',
+                title: 'File not found',
+                message: 'The file you are trying to open cannot be found in the specified path.'
             });
         }
     }
 }
 
-/**
- * Initiate the download manager
- */
-function initiate() {
-    let mainFooter = document.getElementById('footer');
-    let mainDownloadDiv = document.getElementById('download-manager-footer');
-
-    if (mainDownloadDiv) {
-
-        mainFooter.classList.remove('hidden');
-
-        let ulFind = document.getElementById('download-main');
-
-        if (!ulFind) {
-            let uList = document.createElement('ul');
-            uList.id = 'download-main';
-            mainDownloadDiv.appendChild(uList);
-        }
-
-        let closeSpanFind = document.getElementById('close-download-bar');
-
-        if (!closeSpanFind) {
-            let closeSpan = document.createElement('span');
-            closeSpan.id = 'close-download-bar';
-            closeSpan.classList.add('close-download-bar');
-            closeSpan.classList.add('tempo-icon');
-            closeSpan.classList.add('tempo-icon--close');
-            mainDownloadDiv.appendChild(closeSpan);
-        }
-
-        let closeDownloadManager = document.getElementById('close-download-bar');
-        if (closeDownloadManager) {
-            closeDownloadManager.addEventListener('click', () => {
-                local.downloadItems = [];
-                document.getElementById('footer').classList.add('hidden');
-                document.getElementById('download-main').innerHTML = '';
-            });
-        }
-    }
+function setDownloadData(data) {
+    downloadItems.push(data);
 }
 
-/**
- * Return a file display name for the download item
- */
-function getFileDisplayName(fileName) {
-    let fileList = local.downloadItems;
-    let fileNameCount = 0;
-    let fileDisplayName = fileName;
-    
-    /* Check if a file with the same name exists
-     * (akin to the user downloading a file with the same name again)
-     * in the download bar
-     */
-    for (let i = 0; i < fileList.length; i++) {
-        if (fileName === fileList[i].fileName) {
-            fileNameCount++;
-        }
-    }
-    
-    /* If it exists, add a count to the name like how Chrome does */
-    if (fileNameCount) {
-        let extLastIndex = fileDisplayName.lastIndexOf('.');
-        let fileCount = ' (' + fileNameCount + ')';
-        
-        fileDisplayName = fileDisplayName.slice(0, extLastIndex) + fileCount + fileDisplayName.slice(extLastIndex);
-    }
-    
-    return fileDisplayName;
+function clearDownloadData() {
+    downloadItems = [];
 }
+
+module.exports = {
+    openFile: openFile,
+    showInFinder: showInFinder,
+    setDownloadData: setDownloadData,
+    clearDownloadData: clearDownloadData
+};

--- a/js/enums/api.js
+++ b/js/enums/api.js
@@ -21,7 +21,10 @@ const cmds = keyMirror({
     openScreenPickerWindow: null,
     popupMenu: null,
     optimizeMemoryConsumption: null,
-    setIsInMeeting: null
+    setIsInMeeting: null,
+    openFile: null,
+    showInFinder: null,
+    clearDownloadData: null,
 });
 
 module.exports = {

--- a/js/mainApiMgr.js
+++ b/js/mainApiMgr.js
@@ -18,6 +18,7 @@ const eventEmitter = require('./eventEmitter');
 const { isMac } = require('./utils/misc');
 const { openScreenPickerWindow } = require('./desktopCapturer');
 const { optimizeMemory, setIsInMeeting } = require('./memoryMonitor');
+const { openFile, showInFinder, clearDownloadData } = require('./downloadManager');
 
 const apiEnums = require('./enums/api.js');
 const apiCmds = apiEnums.cmds;
@@ -157,6 +158,19 @@ electron.ipcMain.on(apiName, (event, arg) => {
             if (typeof arg.isInMeeting === 'boolean') {
                 setIsInMeeting(arg.isInMeeting);
             }
+            break;
+        case apiCmds.openFile:
+            if (typeof arg.id === 'string') {
+                openFile(arg.id);
+            }
+            break;
+        case apiCmds.showInFinder:
+            if (typeof arg.id === 'string') {
+                showInFinder(arg.id);
+            }
+            break;
+        case apiCmds.clearDownloadData:
+            clearDownloadData();
             break;
         default:
     }

--- a/js/preload/preloadMain.js
+++ b/js/preload/preloadMain.js
@@ -23,7 +23,7 @@ const { TitleBar, updateContentHeight } = require('../windowsTitlebar');
 const titleBar = new TitleBar();
 const { buildNumber } = require('../../package.json');
 
-require('../downloadManager');
+require('../downloadManager/dmPreload');
 
 // bug in electron preventing us from using spellchecker in pop outs
 // https://github.com/electron/electron/issues/4025

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -321,13 +321,13 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
 
                 let domData = {
                     _id: fileId,
-                    total: filesize(item.getTotalBytes() ? item.getTotalBytes() : 0),
-                    fileName: item.getFilename() ? item.getFilename() : 'No name'
+                    total: filesize(item.getTotalBytes() || 0),
+                    fileName: item.getFilename() || 'No name'
                 };
 
                 let localData = {
                     _id: fileId,
-                    savedPath: item.getSavePath() ? item.getSavePath() : ''
+                    savedPath: item.getSavePath() || ''
                 };
 
                 webContents.send('downloadCompleted', domData);

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -25,6 +25,7 @@ const { isMac, isNodeEnv, isWindows10, isWindowsOS } = require('./utils/misc');
 const { deleteIndexFolder } = require('./search/search.js');
 const { isWhitelisted, parseDomain } = require('./utils/whitelistHandler');
 const { initCrashReporterMain, initCrashReporterRenderer } = require('./crashReporter.js');
+const { setDownloadData } = require('./downloadManager');
 
 // show dialog when certificate errors occur
 require('./dialogs/showCertError.js');
@@ -316,13 +317,21 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
         // Send file path when download is complete
         item.once('done', (e, state) => {
             if (state === 'completed') {
-                let data = {
-                    _id: getGuid(),
-                    savedPath: item.getSavePath() ? item.getSavePath() : '',
+                let fileId = getGuid();
+
+                let domData = {
+                    _id: fileId,
                     total: filesize(item.getTotalBytes() ? item.getTotalBytes() : 0),
                     fileName: item.getFilename() ? item.getFilename() : 'No name'
                 };
-                webContents.send('downloadCompleted', data);
+
+                let localData = {
+                    _id: fileId,
+                    savedPath: item.getSavePath() ? item.getSavePath() : ''
+                };
+
+                webContents.send('downloadCompleted', domData);
+                setDownloadData(localData);
             }
         });
     });

--- a/tests/DownloadManager.test.js
+++ b/tests/DownloadManager.test.js
@@ -1,4 +1,4 @@
-const downloadManager = require('../js/downloadManager');
+const downloadManager = require('../js/downloadManager/dmPreload');
 const electron = require('./__mocks__/electron');
 
 describe('download manager', function() {


### PR DESCRIPTION
## Description
Modifies the logic of Download Manager and asks the user for a confirmation before opening non-allowed file types [JIRA-ticket](https://perzoinc.atlassian.net/browse/ELECTRON-510)


## Approach
How does this change address the problem?
- #### Problem with the code:
The Download Manager was entirely controlled from the remote site being loaded. So, if the remote site was compromised, there was potential for an RCA combined with other security issues.
- #### Fix:
1. Adds a confirmation dialog before the user can open a file. This confirmation dialog is initiated from the main process.
2. Moves the logic of opening a file from the preload script (no more access
 to a remote site on this logic)
3. Moves the logic of showing a file in the explorer/finder from the preload script (no more access to a remote site on this logic)
4. Creates a few APIs to manage the above
5. Doesn't anymore store the path of a file in the `downloadItems` array in the preload script, preventing information disclosure.
6. Adds a method to add downloads data and clear it from the `downloadItems` array.


## Learning
N/A


#### Blog Posts
N/A


## Related PRs
N/A


## Open Questions if any and Todos
- [x] Unit-Tests
<img width="1264" alt="screen shot 2018-06-18 at 3 27 35 pm" src="https://user-images.githubusercontent.com/27778544/41529909-2d3b5402-730c-11e8-8184-debf535ff8d7.png">

- [x] Documentation
- [] Automation-Tests