### PR TITLE
ELECTRON-568 (Enable applications tab only if it is passed in the types)

### DIFF
--- a/js/desktopCapturer/getSource.js
+++ b/js/desktopCapturer/getSource.js
@@ -59,7 +59,7 @@ function getSource(options, callback) {
         };
     }
 
-    if (isWindowsOS) {
+    if (isWindowsOS && captureWindow) {
         /**
          * Sets the captureWindow to false if Desktop composition
          * is disabled otherwise true

--- a/js/desktopCapturer/getSources.js
+++ b/js/desktopCapturer/getSources.js
@@ -50,7 +50,7 @@ function getSources(options, callback) {
         };
     }
 
-    if (isWindowsOS) {
+    if (isWindowsOS && captureWindow) {
         /**
          * Sets the captureWindow to false if Desktop composition
          * is disabled otherwise true


### PR DESCRIPTION
## Description
Added a missing check that returns applications only if the window is passed as `types` and `isAeroGlassEnabled`  [ELECTRON-568](https://perzoinc.atlassian.net/browse/ELECTRON-568)


## Approach
How does this change address the problem?
#### Problem with the code:
 - Always returns the applications if `isAeroGlassEnabled` is enabled no matter window is passed in the `types`
#### Fix:
 - Added a check that first validate for `types`

## Spectron tests result
[ELECTRON-568 — Spectron.pdf]
[ELECTRON-568-r52 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2117871/ELECTRON-568-r52.Spectron.pdf)


## Unit tests result
[ELECTRON-568 — Unit Tests.pdf]
[ELECTRON-568-r52 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2117872/ELECTRON-568-r52.Unit.Tests.pdf)



## Open Questions if any and Todos
- [X] Unit-Tests
- [X] Documentation
- [X] Automation-Tests