### PR TITLE
ELECTRON-535 (Add support for screen snippet localization)

### DIFF
--- a/js/screenSnippet/index.js
+++ b/js/screenSnippet/index.js
@@ -11,6 +11,7 @@ const { isMac, isDevEnv } = require('../utils/misc.js');
 const log = require('../log.js');
 const logLevels = require('../enums/logLevels.js');
 const eventEmitter = require('.././eventEmitter');
+const { getLanguage } = require('../translation/i18n');
 
 // static ref to child process, only allow one screen snippet at time, so
 // hold ref to prev, so can kill before starting next snippet.
@@ -77,7 +78,7 @@ class ScreenSnippet {
                     }
                 }
 
-                captureUtilArgs = [outputFileName];
+                captureUtilArgs = [outputFileName, getLanguage()];
             }
 
             log.send(logLevels.INFO, 'ScreenSnippet: starting screen capture util: ' + captureUtil + ' with args=' + captureUtilArgs);

--- a/js/translation/i18n.js
+++ b/js/translation/i18n.js
@@ -16,7 +16,16 @@ const setLanguage = function(lng) {
     loadedTranslations = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', 'locale', language + '.json'), 'utf8'));
 };
 
+/**
+ * Returns the current locale
+ * @return {*|string}
+ */
+const getLanguage = function() {
+    return language || 'en-US';
+};
+
 module.exports = {
     setLanguage: setLanguage,
-    getMessageFor: getMessageFor
+    getMessageFor: getMessageFor,
+    getLanguage: getLanguage,
 };

--- a/js/translation/i18n.js
+++ b/js/translation/i18n.js
@@ -1,5 +1,11 @@
+const electron = require('electron');
+const app = electron.app;
 const path = require("path");
 const fs = require('fs');
+
+const log = require('../log.js');
+const logLevels = require('../enums/logLevels.js');
+
 let language;
 let loadedTranslations = {};
 
@@ -21,7 +27,13 @@ const setLanguage = function(lng) {
  * @return {*|string}
  */
 const getLanguage = function() {
-    return language || 'en-US';
+    let sysLocale;
+    try {
+        sysLocale = app.getLocale();
+    } catch (err) {
+        log.send(logLevels.WARN, `i18n: Failed to fetch app.getLocale with an ${err}`);
+    }
+    return language || sysLocale || 'en-US';
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "winreg": "1.2.4"
   },
   "optionalDependencies": {
-    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.1",
+    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.2",
     "electron-utils": "git+https://github.com/symphonyoss/electron-utils.git#v1.0.5"
   }
 }


### PR DESCRIPTION
## Description
Bump screen snippet version to 1.0.2 and add support for screen snippet localization [ELECTRON-535](https://perzoinc.atlassian.net/browse/ELECTRON-535)


## Approach
How does this change address the problem?
#### Fix:
 - Bump screen snippet version to 1.0.2
 - Add support for screen snippet localization by passing locale arg as the second arg

## How it works
![2018-06-20 12 18 15](https://user-images.githubusercontent.com/13243259/41642195-3f49d61c-7485-11e8-85be-af8a256cebe7.gif)



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
ScreenSnippet | [link](https://github.com/symphonyoss/ScreenSnippet/pull/4)


## Open Questions if any and Todos
- [ ] Unit-Tests
- [ ] Documentation
- [ ] Automation-Tests