### PR TITLE
ELECTRON-573 (Disable automatic detection of language and set system locale)

### DIFF
--- a/js/spellChecker/index.js
+++ b/js/spellChecker/index.js
@@ -16,6 +16,7 @@ class SpellCheckHelper {
      * Method to initialize spell checker
      */
     initializeSpellChecker() {
+        this.spellCheckHandler.automaticallyIdentifyLanguages = false;
         this.spellCheckHandler.attachToInput();
 
         // This is only for window as in mac the
@@ -24,7 +25,8 @@ class SpellCheckHelper {
         // In windows we need to implement RxJS observable
         // in order to switch language dynamically
         if (!isMac) {
-            this.spellCheckHandler.switchLanguage('en-US');
+            const sysLocale = remote.app.getLocale() || 'en-US';
+            this.spellCheckHandler.switchLanguage(sysLocale);
         }
 
         const contextMenuBuilder = new ContextMenuBuilder(this.spellCheckHandler, null, false, SpellCheckHelper.processMenu);


### PR DESCRIPTION
## Description
Disable automatically detection of language for Windows OS [ELECTRON-573](https://perzoinc.atlassian.net/browse/ELECTRON-573)


## Approach
How does this change address the problem?
#### Problem with the code:
 - Automatic detection of language requires input HTML tags as it is currently not supported for RTE
#### Fix:
 - Disable automatic detection of language and set the default language to the system locale


## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
SymphonyElectron(master) | [link](https://github.com/symphonyoss/SymphonyElectron/pull/411)


## Spectron tests result
[ELECTRON-573 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2130594/ELECTRON-573.Spectron.pdf)

## Unit tests result
[ELECTRON-573 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2130595/ELECTRON-573.Unit.Tests.pdf)


## Open Questions if any and Todos
- [X] Unit-Tests
- [X] Documentation
- [X] Automation-Tests