### PR TITLE
ELECTRON-512 (Create API only if the location.origin matches with whitelist or pod URL)

### DIFF
--- a/config/Symphony.config
+++ b/config/Symphony.config
@@ -4,7 +4,7 @@
     "launchOnStartup" : true,
     "alwaysOnTop" : false,
     "bringToFront": false,
-    "whitelistUrl": "*",
+    "whitelistUrl": "",
     "isCustomTitleBar": true,
     "memoryRefresh": true,
     "ctWhitelist": [],

--- a/config/Symphony.config
+++ b/config/Symphony.config
@@ -4,7 +4,7 @@
     "launchOnStartup" : true,
     "alwaysOnTop" : false,
     "bringToFront": false,
-    "whitelistUrl": "",
+    "whitelistUrl": "*",
     "isCustomTitleBar": true,
     "memoryRefresh": true,
     "ctWhitelist": [],

--- a/js/enums/api.js
+++ b/js/enums/api.js
@@ -23,6 +23,7 @@ const cmds = keyMirror({
     optimizeMemoryConsumption: null,
     setIsInMeeting: null,
     setLocale: null,
+    originCheck: null,
 });
 
 module.exports = {

--- a/js/mainApiMgr.js
+++ b/js/mainApiMgr.js
@@ -18,6 +18,7 @@ const eventEmitter = require('./eventEmitter');
 const { isMac } = require('./utils/misc');
 const { openScreenPickerWindow } = require('./desktopCapturer');
 const { optimizeMemory, setIsInMeeting } = require('./memoryMonitor');
+const originCheck = require('./originCheck');
 
 const apiEnums = require('./enums/api.js');
 const apiCmds = apiEnums.cmds;
@@ -162,6 +163,11 @@ electron.ipcMain.on(apiName, (event, arg) => {
         case apiCmds.setLocale:
             if (typeof arg.locale === 'string') {
                 eventEmitter.emit('language-changed', { language: arg.locale });
+            }
+            break;
+        case apiCmds.originCheck:
+            if (typeof arg.origin === 'string') {
+                originCheck(event.sender, arg.origin);
             }
             break;
         default:

--- a/js/originCheck.js
+++ b/js/originCheck.js
@@ -1,0 +1,33 @@
+const { isWhitelisted, matchDomains, parseDomain } = require('./utils/whitelistHandler');
+const { getGlobalConfigField } = require('./config');
+const { isDevEnv } = require('./utils/misc');
+
+/**
+ * Validate whitelist and location.origin
+ * @param eventSender
+ * @param origin {String} location.origin
+ * @return {Promise<T>}
+ */
+function originCheck(eventSender, origin) {
+
+    if (isDevEnv) {
+        eventSender.send('initialize-api');
+        return null;
+    }
+
+    return isWhitelisted(origin)
+        .then(() => {
+            eventSender.send('initialize-api', true);
+        })
+        .catch(() => {
+            getGlobalConfigField('url')
+                .then((configUrl) => {
+                    if (matchDomains(parseDomain(origin), parseDomain(configUrl))) {
+                        eventSender.send('initialize-api', true);
+                    }
+                });
+        });
+
+}
+
+module.exports = originCheck;

--- a/js/originCheck.js
+++ b/js/originCheck.js
@@ -1,6 +1,6 @@
 const { isWhitelisted, matchDomains, parseDomain } = require('./utils/whitelistHandler');
 const { getGlobalConfigField } = require('./config');
-const { isDevEnv } = require('./utils/misc');
+const { isDevEnv, isNodeEnv } = require('./utils/misc');
 
 /**
  * Validate whitelist and location.origin
@@ -10,7 +10,7 @@ const { isDevEnv } = require('./utils/misc');
  */
 function originCheck(eventSender, origin) {
 
-    if (isDevEnv) {
+    if (isDevEnv || isNodeEnv) {
         eventSender.send('initialize-api');
         return null;
     }

--- a/js/originCheck.js
+++ b/js/originCheck.js
@@ -6,16 +6,15 @@ const { isDevEnv, isNodeEnv } = require('./utils/misc');
  * Validate whitelist and location.origin
  * @param eventSender
  * @param origin {String} location.origin
- * @return {Promise<T>}
  */
 function originCheck(eventSender, origin) {
 
     if (isDevEnv || isNodeEnv) {
         eventSender.send('initialize-api');
-        return null;
+        return;
     }
 
-    return isWhitelisted(origin)
+    isWhitelisted(origin)
         .then(() => {
             eventSender.send('initialize-api', true);
         })

--- a/js/preload/preloadMain.js
+++ b/js/preload/preloadMain.js
@@ -83,7 +83,17 @@ setInterval(() => {
     });
 }, memoryMonitorInterval);
 
-createAPI();
+// Create API only on an allowed origin
+local.ipcRenderer.once('initialize-api', () => {
+    createAPI();
+});
+
+setTimeout(() => {
+    local.ipcRenderer.send(apiName, {
+        cmd: apiCmds.originCheck,
+        origin: location.origin,
+    });
+}, 0);
 
 // creates API exposed from electron.
 // wrapped in a function so we can abort early in function coming from an iframe

--- a/js/utils/whitelistHandler.js
+++ b/js/utils/whitelistHandler.js
@@ -159,6 +159,7 @@ function parseDomain(url) {
 module.exports = {
     isWhitelisted,
     parseDomain,
+    matchDomains,
 
     // items below here are only exported for testing, do NOT use!
     checkWhitelist


### PR DESCRIPTION
## Description
Safety to protect from exposing `window.ssf` API to an unknown origin [ELECTRON-512](https://perzoinc.atlassian.net/browse/ELECTRON-512)

## Solution Approach
Emitting origin check event to the main process whenever the preload script is loaded
The main process receives the event published by the renderer process and validates the origin 
if the origin is valid the main process emits an event to the renderer process which then creates the API

## Documentation
N/A

## QA Checklist
- [X] Unit-Tests
[ELECTRON-512 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2174816/ELECTRON-512.Unit.Tests.pdf)

- [X] Automation-Tests
[Electron-512 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2174818/Electron-512.Spectron.pdf)
