### PR TITLE
ELECTRON-378 (Focus the correct module with protocol actions)

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -389,6 +389,14 @@ function handleProtocolAction(uri) {
         // app is opened by the protocol url, cache the protocol url to be used later
         protocolHandler.setProtocolUrl(uri);
     } else {
+        // This is needed for mac OS as it brings pop-outs to foreground
+        // (if it has been previously focused) instead of main window
+        if (isMac) {
+            const mainWindow = windowMgr.getMainWindow();
+            if (mainWindow && !mainWindow.isDestroyed()) {
+                windowMgr.activate(mainWindow.winName);
+            }
+        }
         // app is already open, so, just trigger the protocol action method
         log.send(logLevels.INFO, `App opened by protocol url ${uri}`);
         protocolHandler.processProtocolAction(uri);


### PR DESCRIPTION
## Description
This is needed for Mac OS as it brings pop-outs to the foreground (if it has been previously focused) instead of the main window [ELECTRON-378](https://perzoinc.atlassian.net/browse/ELECTRON-378)

## Solution Approach
Bring the main window to the foreground whenever the protocol actions are used

## Documentation
https://perzoinc.atlassian.net/wiki/spaces/DES/pages/143731901/Electron+Feature+-+Protocol+Handler

## Before
![electron-378 before](https://user-images.githubusercontent.com/13243259/42496000-66926320-8442-11e8-8e97-c769f2234ff9.gif)

## After
![electron-378 after](https://user-images.githubusercontent.com/13243259/42496012-6b4ac484-8442-11e8-96cc-d79170e10c03.gif)


## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
SFE-Client-App | [link](https://github.com/SymphonyOSF/SFE-Client-App/pull/10455)

## QA Checklist
- [X] Unit-Tests
[Electron-378 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2179421/Electron-378.Unit.Tests.pdf)
- [X] Automation-Tests
[Electron-378 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2179422/Electron-378.Spectron.pdf)
