### PR TITLE
ELECTRON-492 (Disable screen share when media permissions are disabled)

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -58,6 +58,11 @@
         </p>
         <br>
         <hr>
+        <p>Change language:<p>
+            <button id='set-locale-en-US'>Change language to English - US</button>
+            <button id='set-locale-ja-JP'>Change language to Japanese</button>
+            <br>
+        <hr>
         <p>Badge Count:<p>
         <button id='inc-badge'>increment badge count</button>
         <br>
@@ -260,6 +265,17 @@
                 buildNumber.innerText = verInfo.buildNumber;
                 searchApiVer.innerText = verInfo.searchApiVer;
             });
+        });
+
+        var setLocaleToEn = document.getElementById('set-locale-en-US');
+        setLocaleToEn.addEventListener('click', function () {
+            ssf.setLocale('en-US');
+            document.location.reload();
+        });
+        var setLocaleToJa = document.getElementById('set-locale-ja-JP');
+        setLocaleToJa.addEventListener('click', function () {
+            ssf.setLocale('ja-JP');
+            document.location.reload();
         });
 
     </script>

--- a/js/desktopCapturer/getSources.js
+++ b/js/desktopCapturer/getSources.js
@@ -17,6 +17,8 @@ const { isWindowsOS } = require('../utils/misc');
 
 let includes = [].includes;
 let screenShareArgv;
+let isScreenShareEnabled = false;
+let dialogContent;
 
 /**
  * Checks if the options and their types are valid
@@ -68,6 +70,21 @@ function getSources(options, callback) {
         sourceTypes.push('screen');
     }
 
+    // displays a dialog if media permissions are disable
+    if (!isScreenShareEnabled) {
+        let focusedWindow = remote.BrowserWindow.getFocusedWindow();
+        if (focusedWindow && !focusedWindow.isDestroyed()) {
+            remote.dialog.showMessageBox(focusedWindow, dialogContent ||
+                {
+                    type: 'error',
+                    title: 'Permission Denied!',
+                    message: 'Your administrator has disabled screen share. Please contact your admin for help'
+                });
+            callback(new Error('Permission Denied'));
+            return;
+        }
+    }
+
     desktopCapturer.getSources({ types: sourceTypes, thumbnailSize: updatedOptions.thumbnailSize }, (event, sources) => {
 
         if (screenShareArgv) {
@@ -111,6 +128,14 @@ function getSources(options, callback) {
 ipcRenderer.once('screen-share-argv', (event, arg) => {
     if (typeof arg === 'string') {
         screenShareArgv = arg;
+    }
+});
+
+// event that updates screen share permission
+ipcRenderer.on('is-screen-share-enabled', (event, screenShare, content) => {
+    dialogContent = content;
+    if (typeof screenShare === 'boolean' && screenShare) {
+        isScreenShareEnabled = true;
     }
 });
 

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -276,6 +276,13 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
         if (screenShareArg && typeof screenShareArg === 'string') {
             mainWindow.webContents.send('screen-share-argv', screenShareArg);
         }
+
+        if (config && config.permissions) {
+            const permission = ' screen sharing';
+            const fullMessage = i18n.getMessageFor('Your administrator has disabled') + permission + '. ' + i18n.getMessageFor('Please contact your admin for help');
+            const dialogContent = { type: 'error', title: i18n.getMessageFor('Permission Denied') + '!', message: fullMessage };
+            mainWindow.webContents.send('is-screen-share-enabled', config.permissions.media, dialogContent);
+        }
     });
 
     mainWindow.webContents.on('did-fail-load', function (event, errorCode,
@@ -602,10 +609,10 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
                         log.send(logLevels.INFO, 'permission is -> ' + userPermission);
 
                         if (!userPermission) {
-                            let fullMessage = i18n.getMessageFor('Your administrator has disabled') + message + '. ' + i18n.getMessageFor('Please contact your admin for help');
+                            const fullMessage = `${i18n.getMessageFor('Your administrator has disabled')} ${message}. ${i18n.getMessageFor('Please contact your admin for help')}`;
                             const browserWindow = BrowserWindow.getFocusedWindow();
                             if (browserWindow && !browserWindow.isDestroyed()) {
-                                electron.dialog.showMessageBox(browserWindow, {type: 'error', title: i18n.getMessageFor('Permission Denied') + '!', message: fullMessage});
+                                electron.dialog.showMessageBox(browserWindow, {type: 'error', title: `${i18n.getMessageFor('Permission Denied')}!`, message: fullMessage});
                             }
                         }
 


### PR DESCRIPTION
## Description
Disable screen share when media permissions are disabled [ELECTRON-492](https://perzoinc.atlassian.net/browse/ELECTRON-492)

## Solution Approach
Read `permision.media` from global config and disable showing the screen picker modal

![2018-07-13 13 40 15](https://user-images.githubusercontent.com/13243259/42680472-c336809a-86a2-11e8-95c4-2fd9346af237.gif)


## QA Checklist
- [X] Unit-Tests
[ELECTRON-492 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2191882/ELECTRON-492.Unit.Tests.pdf)

- [X] Automation-Tests
[Electron-492 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2191884/Electron-492.Spectron.pdf)
