### PR TITLE
ELECTRON-591 (Add logic to close up child windows whenever parent window is navigated or reloaded)

### DIFF
--- a/js/mainApiMgr.js
+++ b/js/mainApiMgr.js
@@ -67,6 +67,8 @@ function sanitize(windowName) {
         if (!isMac) {
             eventEmitter.emit('killScreenSnippet');
         }
+        // Closes all the child windows
+        windowMgr.cleanUpChildWindows();
     }
 }
 

--- a/js/preload/preloadMain.js
+++ b/js/preload/preloadMain.js
@@ -498,7 +498,7 @@ function createAPI() {
     function sanitize() {
         local.ipcRenderer.send(apiName, {
             cmd: apiCmds.sanitize,
-            windowName: window.name
+            windowName: window.name || 'main'
         });
     }
 

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -1102,6 +1102,27 @@ function handleKeyPress(keyCode) {
     }
 }
 
+/**
+ * Finds all the child window and closes it
+ */
+function cleanUpChildWindows() {
+    const browserWindows = BrowserWindow.getAllWindows();
+    notify.resetAnimationQueue();
+    if (browserWindows && browserWindows.length) {
+        browserWindows.forEach(browserWindow => {
+            // Closes only child windows
+            if (browserWindow && !browserWindow.isDestroyed() && browserWindow.winName !== 'main') {
+                // clean up notification windows
+                if (browserWindow.winName === 'notification-window') {
+                    notify.closeAll();
+                } else {
+                    browserWindow.close();
+                }
+            }
+        });
+    }
+}
+
 
 module.exports = {
     createMainWindow: createMainWindow,
@@ -1115,5 +1136,6 @@ module.exports = {
     verifyDisplays: verifyDisplays,
     getMenu: getMenu,
     setIsAutoReload: setIsAutoReload,
-    handleKeyPress: handleKeyPress
+    handleKeyPress: handleKeyPress,
+    cleanUpChildWindows: cleanUpChildWindows,
 };

--- a/tests/spectron/closePopOutsOnReload.spectron.js
+++ b/tests/spectron/closePopOutsOnReload.spectron.js
@@ -1,0 +1,90 @@
+const Application = require('./spectronSetup');
+const path = require('path');
+
+let app = new Application({});
+
+describe('Tests for pop outs reload scenario', () => {
+
+    let originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = Application.getTimeOut();
+
+    beforeAll((done) => {
+        return app.startApplication().then((startedApp) => {
+            app = startedApp;
+            done();
+        }).catch((err) => {
+            console.error(`Unable to start application: ${err}`);
+            expect(err).toBeNull();
+            done();
+        });
+    });
+
+    afterAll((done) => {
+        if (app && app.isRunning()) {
+            jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+            app.stop().then(() => {
+                done();
+            }).catch((err) => {
+                done();
+            });
+        }
+    });
+
+    it('should launch the app', (done) => {
+        return app.client.waitUntilWindowLoaded().then(() => {
+            return app.client.getWindowCount().then((count) => {
+                expect(count === 1).toBeTruthy();
+                done();
+            }).catch((err) => {
+                expect(err).toBeNull();
+            });
+        }).catch((err) => {
+            expect(err).toBeNull();
+        });
+    });
+
+    it('should load the demo page', () => {
+        return app.client.url('file:///' + path.join(__dirname, '..', '..', 'demo/index.html'));
+    });
+
+    it('should open a new window and verify', function (done) {
+        app.client.waitForExist('#open-win', 2000);
+        app.client.moveToObject('#open-win', 10, 10);
+        app.client.leftClick('#open-win', 10, 10);
+
+        setTimeout(() => {
+            app.client.getWindowCount().then((count) => {
+                expect(count === 2).toBeTruthy();
+                done();
+            });
+        }, 2000);
+    });
+
+    it('should open a child window from pop-out and verify', function (done) {
+        return app.client.windowByIndex(1).then(() => {
+            app.client.waitForExist('#open-win', 2000);
+            app.client.moveToObject('#open-win', 10, 10);
+            app.client.leftClick('#open-win', 10, 10);
+
+            setTimeout(() => {
+                app.client.getWindowCount().then((count) => {
+                    expect(count === 3).toBeTruthy();
+                    done();
+                });
+            }, 2000);
+        });
+    });
+
+    it('should close pop-out window when main window is reloaded', function (done) {
+        return app.client.windowByIndex(0).then(() => {
+            app.browserWindow.reload();
+
+            setTimeout(() => {
+                app.client.getWindowCount().then((count) => {
+                    expect(count === 1).toBeTruthy();
+                    done();
+                });
+            }, 2000);
+        });
+    });
+});


### PR DESCRIPTION
## Description
Add logic to close up child windows whenever parent window is navigated or reloaded [ELECTRON-591](https://perzoinc.atlassian.net/browse/ELECTRON-591)

## Solution Approach
Invoke a function whenever the main window is navigated/reloaded and close the child windows


## QA Checklist
- [X] Unit-Tests
[ELECTRON-591 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2244192/ELECTRON-591.Unit.Tests.pdf)

- [X] Automation-Tests
[ELECTRON-591 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2244193/ELECTRON-591.Spectron.pdf)