### PR TITLE
ELECTRON-670 (Remove setting menu to null for pop-out)

### DIFF
--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -465,11 +465,6 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
                         if (browserWin) {
                             log.send(logLevels.INFO, 'loaded pop-out window url: ' + newWinParsedUrl);
 
-                            if (!isMac) {
-                                // Removes the menu bar from the pop-out window
-                                // setMenu is currently only supported on Windows and Linux
-                                browserWin.setMenu(null);
-                            }
                             browserWin.webContents.send('on-page-load');
                             // applies styles required for snack bar
                             browserWin.webContents.insertCSS(fs.readFileSync(path.join(__dirname, '/snackBar/style.css'), 'utf8').toString());


### PR DESCRIPTION
## Description
Hide menu instead of setting it to `null` [ELECTRON-670](https://perzoinc.atlassian.net/browse/ELECTRON-670)

## Solution Approach
Setting the menu to `null` will remove keyboard shortcuts, so hide it will solve the issue

## Related PRs
List related PRs against other branches / repositories:

branch | PR
------ | ------
SymphonyElectron | [link](https://github.com/symphonyoss/SymphonyElectron/pull/451)

## QA Checklist
- [X] Unit-Tests
[ELECTRON-670 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2270935/ELECTRON-670.Unit.Tests.pdf)

- [X] Automation-Tests
[ELECTRON-670 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2270936/ELECTRON-670.Spectron.pdf)