### PR TITLE
ELECTRON-665 (Localize custom title bar buttons for Windows 10)

### DIFF
--- a/js/preload/preloadMain.js
+++ b/js/preload/preloadMain.js
@@ -484,6 +484,19 @@ function createAPI() {
 
     /**
      * an event triggered by the main process when
+     * the locale is changed
+     * @param dataObj {Object} - locale content
+     */
+    local.ipcRenderer.on('locale-changed', (event, dataObj) => {
+        if (dataObj && typeof dataObj === 'object') {
+            if (dataObj.titleBar) {
+                titleBar.updateLocale(dataObj.titleBar);
+            }
+        }
+    });
+
+    /**
+     * an event triggered by the main process when
      * the window enters full screen
      */
     local.ipcRenderer.on('window-enter-full-screen', (event, arg) => {

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -985,6 +985,12 @@ function setLocale(browserWindow, opts) {
 
         if (isWindows10()) {
             browserWindow.setMenuBarVisibility(false);
+
+            // update locale for custom title bar
+            if (isCustomTitleBarEnabled) {
+                const titleBarContent = i18n.getMessageFor('TitleBar');
+                browserWindow.webContents.send('locale-changed', { titleBar: titleBarContent });
+            }
         }
     }
 

--- a/js/windowsTitleBar/index.js
+++ b/js/windowsTitleBar/index.js
@@ -60,6 +60,11 @@ class TitleBar {
             default:
                 break;
         }
+        this.hamburgerMenuButton = document.getElementById('hamburger-menu-button');
+        this.minimizeButton = document.getElementById('title-bar-minimize-button');
+        this.maximizeButton = document.getElementById('title-bar-maximize-button');
+        this.closeButton = document.getElementById('title-bar-close-button');
+
         this.initiateEventListeners();
     }
 
@@ -67,16 +72,22 @@ class TitleBar {
      * Method that attaches Event Listeners for elements
      */
     initiateEventListeners() {
-        const hamburgerMenuButton = document.getElementById('hamburger-menu-button');
-        const minimizeButton = document.getElementById('title-bar-minimize-button');
-        const maximizeButton = document.getElementById('title-bar-maximize-button');
-        const closeButton = document.getElementById('title-bar-close-button');
-
         attachEventListeners(this.titleBar, 'dblclick', this.maximizeOrUnmaximize.bind(this));
-        attachEventListeners(hamburgerMenuButton, 'click', this.popupMenu.bind(this));
-        attachEventListeners(closeButton, 'click', this.closeWindow.bind(this));
-        attachEventListeners(maximizeButton, 'click', this.maximizeOrUnmaximize.bind(this));
-        attachEventListeners(minimizeButton, 'click', this.minimize.bind(this));
+        attachEventListeners(this.hamburgerMenuButton, 'click', this.popupMenu.bind(this));
+        attachEventListeners(this.closeButton, 'click', this.closeWindow.bind(this));
+        attachEventListeners(this.maximizeButton, 'click', this.maximizeOrUnmaximize.bind(this));
+        attachEventListeners(this.minimizeButton, 'click', this.minimize.bind(this));
+    }
+
+    /**
+     * Update button's title w.r.t current locale
+     * @param content {Object}
+     */
+    updateLocale(content) {
+        this.hamburgerMenuButton.title = content.Menu || 'Menu';
+        this.minimizeButton.title = content.Minimize || 'Minimize';
+        this.maximizeButton.title = content.Maximize || 'Maximize';
+        this.closeButton.title = content.Close || 'Close';
     }
 
     /**

--- a/locale/en-US.json
+++ b/locale/en-US.json
@@ -102,6 +102,12 @@
   "Start Speaking": "Start Speaking",
   "Stop Speaking": "Stop Speaking",
   "Symphony Help": "Symphony Help",
+  "TitleBar": {
+    "Close": "Close",
+    "Maximize": "Maximize",
+    "Menu": "Menu",
+    "Minimize": "Minimize"
+  },
   "Title Bar Style": "Title Bar Style",
   "Toggle Full Screen": "Toggle Full Screen",
   "Troubleshooting": "Troubleshooting",

--- a/locale/en.json
+++ b/locale/en.json
@@ -100,6 +100,12 @@
   "Start Speaking": "Start Speaking",
   "Stop Speaking": "Stop Speaking",
   "Symphony Help": "Symphony Help",
+  "TitleBar": {
+    "Close": "Close",
+    "Maximize": "Maximize",
+    "Menu": "Menu",
+    "Minimize": "Minimize"
+  },
   "Title Bar Style": "Title Bar Style",
   "Toggle Full Screen": "Toggle Full Screen",
   "Troubleshooting": "Troubleshooting",

--- a/locale/ja-JP.json
+++ b/locale/ja-JP.json
@@ -102,6 +102,12 @@
   "Start Speaking": "スピーチを開始",
   "Stop Speaking": "スピーチを終了",
   "Symphony Help": "Symphonyのヘルプ",
+  "TitleBar": {
+    "Close": "閉じる",
+    "Maximize": "最大化する",
+    "Menu": "メニュー",
+    "Minimize": "最小化する"
+  },
   "Title Bar Style": "タイトルバーのスタイル",
   "Toggle Full Screen": "画面表示を切り替え",
   "Troubleshooting": "トラブルシューティング",

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -100,6 +100,12 @@
   "Start Speaking": "スピーチを開始",
   "Stop Speaking": "スピーチを終了",
   "Symphony Help": "Symphonyのヘルプ",
+  "TitleBar": {
+    "Close": "閉じる",
+    "Maximize": "最大化する",
+    "Menu": "メニュー",
+    "Minimize": "最小化する"
+  },
   "Title Bar Style": "タイトルバーのスタイル",
   "Toggle Full Screen": "画面表示を切り替え",
   "Troubleshooting": "トラブルシューティング",


### PR DESCRIPTION
## Description
Localize custom title bar buttons for Windows 10 [ELECTRON-665](https://perzoinc.atlassian.net/browse/ELECTRON-665)

## Solution Approach
Listen for locale changed event and update respectively

## Screen shots
![screen shot 2018-08-14 at 7 05 12 pm](https://user-images.githubusercontent.com/13243259/44095009-549c5558-9ff5-11e8-9a6b-98389fd4fd99.png)
![screen shot 2018-08-14 at 7 05 43 pm](https://user-images.githubusercontent.com/13243259/44095010-54c5528c-9ff5-11e8-8832-c2dfb1ad1279.png)


## QA Checklist
- [X] Unit-Tests
[ELECTRON-665 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2287089/ELECTRON-665.Unit.Tests.pdf)

- [X] Automation-Tests
[ELECTRON-665 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2287090/ELECTRON-665.Spectron.pdf)

