### PR TITLE
ELECTRON-651 (Assign focused window to the screen picker) [Windows]

### DIFF
--- a/js/desktopCapturer/index.js
+++ b/js/desktopCapturer/index.js
@@ -79,6 +79,10 @@ function openScreenPickerWindow(eventSender, sources, id) {
             windowConfig.x = Math.round(centerX - (windowWidth / 2.0));
             windowConfig.y = Math.round(centerY - (windowHeight / 2.0));
         }
+
+        if (isWindowsOS) {
+            windowConfig.parent = focusedWindow;
+        }
     }
 
     // Store the window ref to send event

--- a/tests/__mocks__/electron.js
+++ b/tests/__mocks__/electron.js
@@ -70,11 +70,11 @@ const ipcRenderer = {
 };
 
 module.exports = {
-  require: jest.genMockFunction(),
-  match: jest.genMockFunction(),
-  app: jest.genMockFunction(),
+  require: jest.fn(),
+  match: jest.fn(),
+  app: jest.fn(),
   ipcMain: ipcMain,
   ipcRenderer: ipcRenderer,
-  remote: jest.genMockFunction(),
-  dialog: jest.genMockFunction()
+  remote: jest.fn(),
+  dialog: jest.fn()
 };

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -270,7 +270,7 @@ describe('read/write config tests', function() {
 
             return updateConfigField('url2', 'hello world')
                 .catch(function (err) {
-                    expect(err).toThrow(err);
+                    expect(err.message).toBe('Path must be a string. Received null');
                 });
 
         });
@@ -309,7 +309,7 @@ describe('read/write config tests', function() {
 
             return saveUserConfig('url2', 'hello world')
                 .catch(function (err) {
-                    expect(err).toThrow(err);
+                    expect(err.message).toBe('Path must be a string. Received null');
                 });
         });
 

--- a/tests/jest_unit.json
+++ b/tests/jest_unit.json
@@ -1,6 +1,6 @@
 {
     "testMatch": ["**/*.test.js"],
     "verbose": true,
-    "testResultsProcessor": "./node_modules/jest-html-reporter"
+    "testResultsProcessor": "../node_modules/jest-html-reporter"
   }
   


### PR DESCRIPTION
## Description
Assign focused window to the screen picker to make it a modal window which disables user interaction with the content below [ELECTRON-651](https://perzoinc.atlassian.net/browse/ELECTRON-651)

- Updated unit test

## Solution Approach
Assigning focused window to the screen picker window fixes the issue


## QA Checklist
- [X] Unit-Tests
[ELECTRON-651 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2301670/Test.Results.Unit.Tests.pdf)

- [X] Automation-Tests
[ELECTRON-651 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2301668/ELECTRON-651.Spectron.pdf)
