### PR TITLE
ELECTRON-694 (Send activity only if network status is online)

### DIFF
--- a/js/activityDetection/index.js
+++ b/js/activityDetection/index.js
@@ -4,12 +4,14 @@ const systemIdleTime = require('@paulcbetts/system-idle-time');
 const throttle = require('../utils/throttle');
 const log = require('../log.js');
 const logLevels = require('../enums/logLevels.js');
-const { getIsOnline } = require('../windowMgr');
 
-let setIsAutoReload;
+let setIsAutoReloadFnc;
+let getIsOnlineFnc;
 if (!process.env.ELECTRON_QA) {
     /* eslint-disable global-require */
-    setIsAutoReload = require('../windowMgr').setIsAutoReload;
+    const { getIsOnline, setIsAutoReload } = require('../windowMgr');
+    getIsOnlineFnc = getIsOnline;
+    setIsAutoReloadFnc = setIsAutoReload;
     /* eslint-enable global-require */
 }
 
@@ -56,11 +58,11 @@ function monitorUserActivity() {
     intervalId = setInterval(monitor, 1000);
 
     function monitor() {
-        if (systemIdleTime.getIdleTime() < maxIdleTime && getIsOnline()) {
+        if (systemIdleTime.getIdleTime() < maxIdleTime && typeof getIsOnlineFnc === 'function' && getIsOnlineFnc()) {
             // If system is active, send an update to the app bridge and clear the timer
             sendActivity();
-            if (typeof setIsAutoReload === 'function') {
-                setIsAutoReload(false);
+            if (typeof setIsAutoReloadFnc === 'function') {
+                setIsAutoReloadFnc(false);
             }
             clearInterval(intervalId);
             intervalId = undefined;

--- a/js/activityDetection/index.js
+++ b/js/activityDetection/index.js
@@ -4,6 +4,7 @@ const systemIdleTime = require('@paulcbetts/system-idle-time');
 const throttle = require('../utils/throttle');
 const log = require('../log.js');
 const logLevels = require('../enums/logLevels.js');
+const { getIsOnline } = require('../windowMgr');
 
 let setIsAutoReload;
 if (!process.env.ELECTRON_QA) {
@@ -55,7 +56,7 @@ function monitorUserActivity() {
     intervalId = setInterval(monitor, 1000);
 
     function monitor() {
-        if (systemIdleTime.getIdleTime() < maxIdleTime) {
+        if (systemIdleTime.getIdleTime() < maxIdleTime && getIsOnline()) {
             // If system is active, send an update to the app bridge and clear the timer
             sendActivity();
             if (typeof setIsAutoReload === 'function') {

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -846,6 +846,14 @@ function setIsOnline(status) {
 }
 
 /**
+ * Returns user's online status
+ * @return {boolean}
+ */
+function getIsOnline() {
+    return isOnline;
+}
+
+/**
  * Tries finding a window we have created with given name.  If found, then
  * brings to front and gives focus.
  * @param  {String} windowName   Name of target window. Note: main window has
@@ -1200,4 +1208,5 @@ module.exports = {
     handleKeyPress: handleKeyPress,
     cleanUpChildWindows: cleanUpChildWindows,
     setLocale: setLocale,
+    getIsOnline: getIsOnline,
 };


### PR DESCRIPTION
## Description
Send activity only if network status is online [ELECTRON-694](https://perzoinc.atlassian.net/browse/ELECTRON-694)

## Solution Approach
Prevent from sending activity status to the web app when the network status is offline.

## QA Checklist
- [X] Unit-Tests
[ELECTRON-694 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2305103/ELECTRON-694.Unit.Tests.pdf)

- [X] Automation-Tests
[ELECTRON-694 — Spectron.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2305102/ELECTRON-694.Spectron.pdf)