### PR TITLE
SEARCH-915 - Use N-API version of ffi to support Node > v10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,6 @@
   },
   "optionalDependencies": {
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.2",
-    "swift-search": "1.0.5"
+    "swift-search": "2.0.0-r53"
   }
 }


### PR DESCRIPTION
## Description
Useing N-API version of ffi to support Node > v10.0.0
[SEARCH-915](https://perzoinc.atlassian.net/browse/SEARCH-915)

## Solution Approach
node-ffi is still not yet supported node version > v10.0.0 so using the N-API version of node-ffi

## Documentation
N/A

## Related PRs
List related PRs against other branches / repositories:

branch | PR
------ | ------
Swift-Search | [link](https://github.com/symphonyoss/SwiftSearch/releases/tag/v2.0.0-r53)

## Unit Tests Result
[Test Results — Unit-Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2305182/Test.Results.Unit-Tests.pdf)


## QA Checklist
- [x] Unit-Tests
- [x] Automation-Tests