### PR TITLE
ELECTRON-655: implement dynamic chrome command line flags logic

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -177,13 +177,19 @@ function setChromeFlagsFromCommandLine() {
             continue;
         }
 
+        if (!flags[key]) {
+            return;
+        }
+
         let flagArray = flags[key].split(':');
 
-        let chromeFlagKey = flagArray[0];
-        let chromeFlagValue = flagArray[1];
+        if (flagArray && Array.isArray(flagArray) && flagArray.length > 0) {
+            let chromeFlagKey = flagArray[0];
+            let chromeFlagValue = flagArray[1];
+            log.send(logLevels.INFO, `Setting chrome flag ${chromeFlagKey} to ${chromeFlagValue}`);
+            app.commandLine.appendSwitch(chromeFlagKey, chromeFlagValue);
+        }
 
-        log.send(logLevels.INFO, `Setting chrome flag ${chromeFlagKey} to ${chromeFlagValue}`);
-        app.commandLine.appendSwitch(chromeFlagKey, chromeFlagValue);
     }
 
 }


### PR DESCRIPTION
## Description
To support development use cases, we allow developers to set chrome flags via command line arguments [ELECTRON-655](https://perzoinc.atlassian.net/browse/ELECTRON-655)

**Note**: This is only applicable for a development environment.

## Solution Approach
Parse the command line arguments passed and set chrome flags accordingly

## Documentation
https://perzoinc.atlassian.net/wiki/spaces/DES/pages/414810426/Electron+Feature+-+Command+Line+Arguments

## Related PRs
N/A

## QA Checklist
- [x] Unit-Tests
[ELECTRON-655 Unit Tests Results.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2306238/ELECTRON-655.Unit.Tests.Results.pdf)
- [x] Automation-Tests