### PR TITLE
ELECTRON-695 (master)- Fixing hover close button on notification

### DIFF
--- a/js/notify/electron-notify-preload.js
+++ b/js/notify/electron-notify-preload.js
@@ -89,6 +89,7 @@ function setContents(event, notificationObj) {
     let messageDoc = notiDoc.getElementById('message');
     let imageDoc = notiDoc.getElementById('image');
     let closeButton = notiDoc.getElementById('close');
+    closeButton.title = notificationObj.i18n.close;
 
     if (notificationObj.color) {
         container.style.backgroundColor = notificationObj.color;

--- a/js/notify/electron-notify.js
+++ b/js/notify/electron-notify.js
@@ -19,7 +19,7 @@ const ipc = electron.ipcMain;
 const { isMac, isNodeEnv } = require('../utils/misc');
 const log = require('../log.js');
 const logLevels = require('../enums/logLevels.js');
-
+const i18n = require('../translation/i18n');
 // maximum number of notifications that can be queued, after limit is
 // reached then error func callback will be invoked.
 const MAX_QUEUE_SIZE = 30;
@@ -464,11 +464,15 @@ function setNotificationContents(notfWindow, notfObj) {
     } else {
         delete updatedNotificationWindow.electronNotifyOnCloseFunc;
     }
+    // Set strings about i18n
+    const translation = {};
+    translation.close = i18n.getMessageFor('Close');
 
     const windowId = notfWindow.id;
+
     // Set contents, ...
     updatedNotificationWindow.webContents.send('electron-notify-set-contents',
-        Object.assign({ windowId: windowId}, notfObj));
+        Object.assign({ windowId: windowId, i18n: translation}, notfObj));
     // Show window
     updatedNotificationWindow.showInactive();
 


### PR DESCRIPTION
## Description
Close tooltip is not displayed when hovering over on Close button
Describe the problem or feature in addition to a link to the [ELECTRON-695](https://perzoinc.atlassian.net/browse/ELECTRON-695)

## Fixing
- After fixing
![electron-695](https://user-images.githubusercontent.com/9887288/44595449-53a8a500-a79f-11e8-8882-848514e73084.png)
![electron-695-2](https://user-images.githubusercontent.com/9887288/44595450-55726880-a79f-11e8-873d-b1f65af038bb.png)

## Related PRs
List related PRs against other branches / repositories:

branch | PR
------ | ------
ELECTRON-695-r53 | [link](https://github.com/symphonyoss/SymphonyElectron/pull/476)

## QA Checklist
- [x] Unit-Tests
- [ ] Automation-Tests

Attach unit & spectron tests results in PDF format against the above task lists for this branch