### PR TITLE
ELECTRON-669: add japanese localisation for download manager actions

### DIFF
--- a/js/downloadManager/index.js
+++ b/js/downloadManager/index.js
@@ -7,6 +7,9 @@ const local = {
     downloadItems: []
 };
 
+let showInFolderText = "Show in Folder";
+let openText = "Open";
+
 // listen for file download complete event
 local.ipcRenderer.on('downloadCompleted', (event, arg) => {
     createDOM(arg);
@@ -15,6 +18,20 @@ local.ipcRenderer.on('downloadCompleted', (event, arg) => {
 // listen for file download progress event
 local.ipcRenderer.on('downloadProgress', () => {
     initiate();
+});
+
+// listen for locale change and update
+local.ipcRenderer.on('locale-changed', (event, data) => {
+
+    if (data && typeof data === 'object') {
+
+        if (data.downloadManager) {
+            showInFolderText = data.downloadManager['Show in Folder'];
+            openText = data.downloadManager.Open;
+        }
+
+    }
+
 });
 
 /**
@@ -137,7 +154,7 @@ function createDOM(arg) {
 
             let caretLiOpen = document.createElement('li');
             caretLiOpen.id = 'download-open';
-            caretLiOpen.innerHTML = 'Open';
+            caretLiOpen.innerHTML = openText;
             caretUL.appendChild(caretLiOpen);
             let openFileDocument = document.getElementById('download-open');
             openFileDocument.addEventListener('click', () => {
@@ -147,7 +164,7 @@ function createDOM(arg) {
 
             let caretLiShow = document.createElement('li');
             caretLiShow.id = 'download-show-in-folder';
-            caretLiShow.innerHTML = 'Show in Folder';
+            caretLiShow.innerHTML = showInFolderText;
             caretUL.appendChild(caretLiShow);
             let showInFinderDocument = document.getElementById('download-show-in-folder');
             showInFinderDocument.addEventListener('click', () => {

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -1008,6 +1008,12 @@ function setLocale(browserWindow, opts) {
         }
 
         localeContent.contextMenu = i18n.getMessageFor('ContextMenu');
+
+        localeContent.downloadManager = i18n.getMessageFor('DownloadManager');
+        if (isMac) {
+            localeContent.downloadManager['Show in Folder'] = localeContent.downloadManager['Reveal in Finder'];
+        }
+
         browserWindow.webContents.send('locale-changed', localeContent);
     }
 

--- a/locale/en-US.json
+++ b/locale/en-US.json
@@ -32,6 +32,11 @@
     "Reload": "Reload",
     "Search with Google": "Search with Google"
   },
+  "DownloadManager": {
+    "Show in Folder": "Show in Folder",
+    "Reveal in Finder": "Reveal in Finder",
+    "Open": "Open"
+  },
   "Copy": "Copy",
   "Custom": "Custom",
   "Cut": "Cut",

--- a/locale/en.json
+++ b/locale/en.json
@@ -32,6 +32,11 @@
     "Reload": "Reload",
     "Search with Google": "Search with Google"
   },
+  "DownloadManager": {
+    "Show in Folder": "Show in Folder",
+    "Reveal in Finder": "Reveal in Finder",
+    "Open": "Open"
+  },
   "Copy": "Copy",
   "Custom": "Custom",
   "Cut": "Cut",

--- a/locale/ja-JP.json
+++ b/locale/ja-JP.json
@@ -32,6 +32,11 @@
     "Reload": "リロード",
     "Search with Google": "Googleで検索"
   },
+  "DownloadManager": {
+    "Show in Folder": "フォルダで見て",
+    "Reveal in Finder": "Finderで明らかにする",
+    "Open": "開いた"
+  },
   "Copy": "コピー",
   "Custom": "カスタム",
   "Cut": "切り取り",

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -32,6 +32,11 @@
     "Reload": "リロード",
     "Search with Google": "Googleで検索"
   },
+  "DownloadManager": {
+    "Show in Folder": "フォルダで見て",
+    "Reveal in Finder": "Finderで明らかにする",
+    "Open": "開いた"
+  },
   "Copy": "コピー",
   "Custom": "カスタム",
   "Cut": "切り取り",


### PR DESCRIPTION
## Description
Currently, the actions "Open" & "Show in Folder" are not localised as part of the download manager. This commit adds japanese localisation for the above two actions.

Along with the above, we also add a better UX by using the string "Reveal in Finder" for macOS users.

[ELECTRON-669](https://perzoinc.atlassian.net/browse/ELECTRON-669)

<img width="1440" alt="screen shot 2018-08-27 at 12 43 50" src="https://user-images.githubusercontent.com/5968790/44645905-fad34980-a9f6-11e8-8345-1de4c7e8ae99.png">

## Solution Approach
An IPC event (`locale-changed`) is triggered upon language change. We add localisation for download manager actions by listening on this IPC event.

## Documentation
N/A

## Related PRs
N/A

## QA Checklist
- [x] Unit-Tests
[ELECTRON-669 Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2322799/ELECTRON-669.Unit.Tests.pdf)
