### PR TITLE
ELECTRON-592 (Prevent custom title bar buttons from taking focus)

### DIFF
--- a/js/windowsTitleBar/index.js
+++ b/js/windowsTitleBar/index.js
@@ -77,6 +77,11 @@ class TitleBar {
         attachEventListeners(this.closeButton, 'click', this.closeWindow.bind(this));
         attachEventListeners(this.maximizeButton, 'click', this.maximizeOrUnmaximize.bind(this));
         attachEventListeners(this.minimizeButton, 'click', this.minimize.bind(this));
+
+        attachEventListeners(this.hamburgerMenuButton, 'mousedown', TitleBar.handleMouseDown.bind(this));
+        attachEventListeners(this.closeButton, 'mousedown', TitleBar.handleMouseDown.bind(this));
+        attachEventListeners(this.maximizeButton, 'mousedown', TitleBar.handleMouseDown.bind(this));
+        attachEventListeners(this.minimizeButton, 'mousedown', TitleBar.handleMouseDown.bind(this));
     }
 
     /**
@@ -211,6 +216,14 @@ class TitleBar {
      */
     isValidWindow() {
         return !!(this.window && !this.window.isDestroyed());
+    }
+
+    /**
+     * Prevent default to make sure buttons don't take focus
+     * @param e
+     */
+    static handleMouseDown(e) {
+        e.preventDefault();
     }
 }
 


### PR DESCRIPTION
## Description
Prevent custom title bar buttons from taking focus [ELECTRON-592](https://perzoinc.atlassian.net/browse/ELECTRON-592)

## Solution Approach
`preventDefault` for mouse down event for the custom title bar buttons

## QA Checklist
- [X] Unit-Tests
[ELECTRON-592 Unit Test Result.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2322995/ELECTRON-592.Unit.Test.Result.pdf)

- [X] Automation-Tests
