### PR TITLE
SEARCH-915 - Activate electron window undocks the application to default size and position on windows.

### DIFF
--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -880,7 +880,7 @@ function activate(windowName, shouldFocus = true) {
                 return window.restore();
             }
 
-            return window.show();
+            return window.focus();
         }
     }
     return null;


### PR DESCRIPTION
## Description
Activate electron window undocks the application to default size and position on windows.
[SEARCH-915](https://perzoinc.atlassian.net/browse/SEARCH-915)

## Before
![before](https://user-images.githubusercontent.com/596478/44657892-2a487d00-aa1c-11e8-8d79-832af6af59eb.gif)

## After
![after](https://user-images.githubusercontent.com/596478/44657903-316f8b00-aa1c-11e8-888b-20d7c78fa1b0.gif)


## Solution Approach
Changes from show to focus
win.show() - Shows and gives focus to the window.
win.focus() - Focuses on the window.


## Documentation
N/A

## Related PRs
N/A

## Unit Tests Result
[Test Results — Unit-Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2323725/Test.Results.Unit-Tests.pdf)

## QA Checklist
- [x] Unit-Tests
- [ ] Automation-Tests