### PR TITLE
ELECTRON-602: fix the pre-install script on macOS installation / upgrade cases

### DIFF
--- a/installer/mac/preinstall.sh
+++ b/installer/mac/preinstall.sh
@@ -1,3 +1,60 @@
 #!/usr/bin/env bash
+
+# Kill the existing running instance
 sudo killall Symphony
-sudo rm -rf /Applications/Symphony.app
+
+compare_versions()
+{
+    # Get the installer version:
+    CURRENT_VERSION=3.1.0
+
+    # Get the currently installed version:
+    INSTALLED_VERSION=$(plutil -p /Applications/Symphony.app/Contents/Info.plist | awk '/CFBundleShortVersionString/ {print substr($3, 2, length($3)-2)}')
+
+    # If there are no versions installed, just exit the script
+    if [ -z "$INSTALLED_VERSION" -a "$INSTALLED_VERSION" != " " ]; then
+        echo "No version installed, so, exiting without version checks"
+        exit 0
+    fi
+
+    echo "This version is ${CURRENT_VERSION}"
+    echo "Installed version is ${INSTALLED_VERSION}"
+
+    # First, we replace the dots by blank spaces, like this:
+    VERSION=${CURRENT_VERSION//./ }
+    INSTALLED_VERSION=${INSTALLED_VERSION//./ }
+
+    # If you have a "v" in front of your versions, you can get rid of it like this:
+    VERSION=${VERSION//v/}
+    INSTALLED_VERSION=${INSTALLED_VERSION//v/}
+
+    # So, we just need to extract each number:
+    patch1=$(echo ${VERSION} | awk '{print $3}')
+    minor1=$(echo ${VERSION} | awk '{print $2}')
+    major1=$(echo ${VERSION} | awk '{print $1}')
+
+    patch2=$(echo ${INSTALLED_VERSION} | awk '{print $3}')
+    minor2=$(echo ${INSTALLED_VERSION} | awk '{print $2}')
+    major2=$(echo ${INSTALLED_VERSION} | awk '{print $1}')
+
+    # And now, we can simply compare the variables:
+    if [ ${major1} -lt ${major2} ]; then
+        echo "Installed version is newer than this version, exiting installation"
+        exit 1
+    fi
+
+    if [ ${minor1} -lt ${minor2} ]; then
+        echo "Installed version is newer than this version, exiting installation"
+        exit 1
+    fi
+
+    if [ ${patch1} -lt ${patch2} ]; then
+        echo "Installed version is newer than this version, exiting installation"
+        exit 1
+    fi
+
+    # Delete the installed version only if it is older than the installing version
+    sudo rm -rf /Applications/Symphony.app
+}
+
+compare_versions

--- a/installer/mac/version_handler.sh
+++ b/installer/mac/version_handler.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Read the actual version from package.json
+VERSION=$(sed -n 's/\"version\"[[:space:]]*\:[[:space:]]*\"\([^}]*\)\",/\1/p' package.json)
+
+# Trim trailing and leading spaces
+VERSION=$(echo ${VERSION} | xargs)
+
+# Replace the current version variable in the pre-install script
+sed -i '' -e "s/CURRENT_VERSION=.*/CURRENT_VERSION=${VERSION}/g" ./installer/mac/preinstall.sh

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "demo-win": "npm run prebuild && cross-env ELECTRON_DEV=true electron . --url=file:///demo/index.html",
     "demo-mac": "npm run prebuild && cross-env ELECTRON_DEV=true electron . --url=file://$(pwd)/demo/index.html",
     "unpacked-mac": "npm run prebuild && npm run test && build --mac --dir",
-    "packed-mac": "npm run unpacked-mac && packagesbuild -v installer/mac/symphony-mac-packager.pkgproj",
+    "packed-mac": "sh installer/mac/version_handler.sh && npm run unpacked-mac && packagesbuild -v installer/mac/symphony-mac-packager.pkgproj",
     "unpacked-win": "npm run prebuild && npm run test && build --win --x64 --dir",
     "unpacked-win-x86": "npm run prebuild && npm run test && build --win --ia32 --dir"
   },


### PR DESCRIPTION
## Description
Currently, when we try to install a version that is lower than the currently installed version, the pre install script deletes the existing version and the new version is not installed either. This is because of how macOS handles upgrades. 
[ELECTRON-602](https://perzoinc.atlassian.net/browse/ELECTRON-602)

## Solution Approach
So, we add a version check function that exits the script if we have a new version already installed on the system rather than deleting the existing version installed on the system

## Documentation
N/A

## Related PRs
N/A

## QA Checklist
- [x] Unit-Tests
[ELECTRON-602 Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2327259/ELECTRON-602.Unit.Tests.pdf)
