### PR TITLE
ELECTRON-729 - Accessibility color fix for customizing toast notifications

### DIFF
--- a/js/notify/electron-notify-preload.js
+++ b/js/notify/electron-notify-preload.js
@@ -98,8 +98,8 @@ function setContents(event, notificationObj) {
         if (notificationObj.color.match(whiteColorRegExp)) {
             logo.src = './assets/symphony-logo-black.png';
         } else {
-            messageDoc.style.color = '#ffffff';
-            titleDoc.style.color = '#ffffff';
+            messageDoc.style.color = '#000000';
+            titleDoc.style.color = '#000000';
             companyDoc.style.color = notificationObj.color;
             logo.src = './assets/symphony-logo-white.png';
         }


### PR DESCRIPTION
## Description
Change the color of notification text from white to black  [ELECTRON-729](https://perzoinc.atlassian.net/browse/ELECTRON-729)

## Fix
- Before 
![example-before](https://user-images.githubusercontent.com/9887288/44809529-4fb4c280-aba5-11e8-8aac-3627d6eefb99.png)

- After 
![example-after](https://user-images.githubusercontent.com/9887288/44809534-53484980-aba5-11e8-8d3c-c10308fd1e26.png)



## QA Checklist
- [x] Unit-Tests
- [ ] Automation-Tests