### PR TITLE
ELECTRON-685: upgrade electron framework version to 3.0.0-beta.8

### DIFF
--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -41,7 +41,7 @@ let boundsChangeWindow;
 let alwaysOnTop = false;
 let position = 'lower-right';
 let display;
-let sandboxed = true;
+let sandboxed = false;
 let isAutoReload = false;
 let devToolsEnabled = true;
 let isCustomTitleBarEnabled = true;

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "browserify": "16.2.2",
     "chromedriver": "2.40.0",
     "cross-env": "5.2.0",
-    "electron": "3.0.0-beta.6",
+    "electron": "3.0.0-beta.8",
     "electron-builder": "20.28.1",
     "electron-builder-squirrel-windows": "12.3.0",
     "electron-chromedriver": "2.0.0",


### PR DESCRIPTION
## Description
Electron framework v3.0.0-beta.8 fixes remote object count issue due to which we had to turn on sandboxing which lead to spell checker and right click actions not working. 
[ELECTRON-685](https://perzoinc.atlassian.net/browse/ELECTRON-685)

## Solution Approach
Upgrade the Electron version to beta8 and disable sandboxing.

## Documentation
N/A

## Related PRs
N/A

## QA Checklist
- [x] Unit-Tests
[ELECTRON-685 Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2334880/ELECTRON-685.Unit.Tests.pdf)
