### PR TITLE
ELECTRON-719 - Relaunch Application displays many times when selecting Native/ Custom

### DIFF
--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -549,8 +549,7 @@ function titleBarActions(app) {
         message: i18n.getMessageFor('Updating Title bar style requires Symphony to relaunch'),
         buttons: ['Relaunch', 'Cancel']
     };
-
-    electron.dialog.showMessageBox(options, function (index) {
+    electron.dialog.showMessageBox(electron.BrowserWindow.getFocusedWindow(), options, function (index) {
         if (index === 0) {
             app.relaunch();
             app.exit();


### PR DESCRIPTION
## Description

"Relaunch Application" windows displays many times when selecting Native/ Custom

[ELECTRON-719](https://perzoinc.atlassian.net/browse/ELECTRON-719)

## Fix
![electron-719](https://user-images.githubusercontent.com/9887288/44870817-86531180-ac67-11e8-84f0-d5cb83880137.gif)

## QA Checklist
- [x] Unit-Tests
- [ ] Automation-Tests

Attach unit & spectron tests results in PDF format against the above task lists for this branch