### PR TITLE
ELECTRON-718: localise the relaunch and cancel strings,

### DIFF
--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -94,103 +94,104 @@ function getTemplate(app) {
         role: 'help',
         label: i18n.getMessageFor('Help'),
         submenu:
-        [
-            {
-                label: i18n.getMessageFor('Symphony Help'),
-                click() {
-                    electron.shell.openExternal('https://support.symphony.com');
-                }
-            },
-            {
-                label: i18n.getMessageFor('Learn More'),
-                click() {
-                    electron.shell.openExternal('https://www.symphony.com');
-                }
-            },
-            {
-                label: i18n.getMessageFor('Troubleshooting'),
-                submenu: [
-                    {
-                        label: isMac ? i18n.getMessageFor('Show Logs in Finder') : i18n.getMessageFor('Show Logs in Explorer'),
-                        click(item, focusedWindow) {
-
-                            const FILE_EXTENSIONS = ['.log'];
-                            const MAC_LOGS_PATH = '/Library/Logs/Symphony/';
-                            const WINDOWS_LOGS_PATH = '\\AppData\\Roaming\\Symphony\\logs';
-
-                            let logsPath = isMac ? MAC_LOGS_PATH : WINDOWS_LOGS_PATH;
-                            let source = electron.app.getPath('home') + logsPath;
-
-                            if (!fs.existsSync(source) && focusedWindow && !focusedWindow.isDestroyed()) {
-                                electron.dialog.showMessageBox(focusedWindow, {
-                                    type: 'error',
-                                    title: i18n.getMessageFor('Failed!'),
-                                    message: i18n.getMessageFor('No logs are available to share')
-                                });
-                                return;
-                            }
-
-                            let destPath = isMac ? '/logs_symphony_' : '\\logs_symphony_';
-                            let timestamp = new Date().getTime();
-
-                            let destination = electron.app.getPath('downloads') + destPath + timestamp + '.zip';
-
-                            archiveHandler.generateArchiveForDirectory(source, destination, FILE_EXTENSIONS)
-                                .then(() => {
-                                    electron.shell.showItemInFolder(destination);
-                                })
-                                .catch((err) => {
-                                    if (focusedWindow && !focusedWindow.isDestroyed()) {
-                                        electron.dialog.showMessageBox(focusedWindow, {
-                                            type: 'error',
-                                            title: i18n.getMessageFor('Failed!'),
-                                            message: i18n.getMessageFor('Unable to generate logs due to ') + err
-                                        });
-                                    }
-                                });
-
-                        }
-                    },
-                    {
-                        label: isMac ? i18n.getMessageFor('Show crash dump in Finder') : i18n.getMessageFor('Show crash dump in Explorer'),
-                        click(item, focusedWindow) {
-                            const FILE_EXTENSIONS = isMac ? ['.dmp'] : ['.dmp', '.txt'];
-                            const crashesDirectory = electron.crashReporter.getCrashesDirectory();
-                            let source = isMac ? crashesDirectory + '/completed' : crashesDirectory;
-
-                            // TODO: Add support to get diagnostic reports from ~/Library/Logs/DiagnosticReports
-                            if (!fs.existsSync(source) || fs.readdirSync(source).length === 0 && focusedWindow && !focusedWindow.isDestroyed()) {
-                                electron.dialog.showMessageBox(focusedWindow, {
-                                    type: 'error',
-                                    title: i18n.getMessageFor('Failed!'),
-                                    message: i18n.getMessageFor('No crashes available to share')
-                                });
-                                return;
-                            }
-
-                            let destPath = isMac ? '/crashes_symphony_' : '\\crashes_symphony_';
-                            let timestamp = new Date().getTime();
-
-                            let destination = electron.app.getPath('downloads') + destPath + timestamp + '.zip';
-
-                            archiveHandler.generateArchiveForDirectory(source, destination, FILE_EXTENSIONS)
-                                .then(() => {
-                                    electron.shell.showItemInFolder(destination);
-                                })
-                                .catch((err) => {
-                                    if (focusedWindow && !focusedWindow.isDestroyed()) {
-                                        electron.dialog.showMessageBox(focusedWindow, {
-                                            type: 'error',
-                                            title: i18n.getMessageFor('Failed!'),
-                                            message: i18n.getMessageFor('Unable to generate crash reports due to ') + err
-                                        });
-                                    }
-                                });
-                        }
+            [
+                {
+                    label: i18n.getMessageFor('Symphony Help'),
+                    click() {
+                        let helpUrl = i18n.getMessageFor('Help Url');
+                        electron.shell.openExternal(helpUrl);
                     }
-                ]
-            }
-        ]
+                },
+                {
+                    label: i18n.getMessageFor('Learn More'),
+                    click() {
+                        electron.shell.openExternal('https://www.symphony.com');
+                    }
+                },
+                {
+                    label: i18n.getMessageFor('Troubleshooting'),
+                    submenu: [
+                        {
+                            label: isMac ? i18n.getMessageFor('Show Logs in Finder') : i18n.getMessageFor('Show Logs in Explorer'),
+                            click(item, focusedWindow) {
+
+                                const FILE_EXTENSIONS = ['.log'];
+                                const MAC_LOGS_PATH = '/Library/Logs/Symphony/';
+                                const WINDOWS_LOGS_PATH = '\\AppData\\Roaming\\Symphony\\logs';
+
+                                let logsPath = isMac ? MAC_LOGS_PATH : WINDOWS_LOGS_PATH;
+                                let source = electron.app.getPath('home') + logsPath;
+
+                                if (!fs.existsSync(source) && focusedWindow && !focusedWindow.isDestroyed()) {
+                                    electron.dialog.showMessageBox(focusedWindow, {
+                                        type: 'error',
+                                        title: i18n.getMessageFor('Failed!'),
+                                        message: i18n.getMessageFor('No logs are available to share')
+                                    });
+                                    return;
+                                }
+
+                                let destPath = isMac ? '/logs_symphony_' : '\\logs_symphony_';
+                                let timestamp = new Date().getTime();
+
+                                let destination = electron.app.getPath('downloads') + destPath + timestamp + '.zip';
+
+                                archiveHandler.generateArchiveForDirectory(source, destination, FILE_EXTENSIONS)
+                                    .then(() => {
+                                        electron.shell.showItemInFolder(destination);
+                                    })
+                                    .catch((err) => {
+                                        if (focusedWindow && !focusedWindow.isDestroyed()) {
+                                            electron.dialog.showMessageBox(focusedWindow, {
+                                                type: 'error',
+                                                title: i18n.getMessageFor('Failed!'),
+                                                message: i18n.getMessageFor('Unable to generate logs due to ') + err
+                                            });
+                                        }
+                                    });
+
+                            }
+                        },
+                        {
+                            label: isMac ? i18n.getMessageFor('Show crash dump in Finder') : i18n.getMessageFor('Show crash dump in Explorer'),
+                            click(item, focusedWindow) {
+                                const FILE_EXTENSIONS = isMac ? ['.dmp'] : ['.dmp', '.txt'];
+                                const crashesDirectory = electron.crashReporter.getCrashesDirectory();
+                                let source = isMac ? crashesDirectory + '/completed' : crashesDirectory;
+
+                                // TODO: Add support to get diagnostic reports from ~/Library/Logs/DiagnosticReports
+                                if (!fs.existsSync(source) || fs.readdirSync(source).length === 0 && focusedWindow && !focusedWindow.isDestroyed()) {
+                                    electron.dialog.showMessageBox(focusedWindow, {
+                                        type: 'error',
+                                        title: i18n.getMessageFor('Failed!'),
+                                        message: i18n.getMessageFor('No crashes available to share')
+                                    });
+                                    return;
+                                }
+
+                                let destPath = isMac ? '/crashes_symphony_' : '\\crashes_symphony_';
+                                let timestamp = new Date().getTime();
+
+                                let destination = electron.app.getPath('downloads') + destPath + timestamp + '.zip';
+
+                                archiveHandler.generateArchiveForDirectory(source, destination, FILE_EXTENSIONS)
+                                    .then(() => {
+                                        electron.shell.showItemInFolder(destination);
+                                    })
+                                    .catch((err) => {
+                                        if (focusedWindow && !focusedWindow.isDestroyed()) {
+                                            electron.dialog.showMessageBox(focusedWindow, {
+                                                type: 'error',
+                                                title: i18n.getMessageFor('Failed!'),
+                                                message: i18n.getMessageFor('Unable to generate crash reports due to ') + err
+                                            });
+                                        }
+                                    });
+                            }
+                        }
+                    ]
+                }
+            ]
     }
     ];
 
@@ -547,7 +548,7 @@ function titleBarActions(app) {
         type: 'question',
         title: i18n.getMessageFor('Relaunch Application'),
         message: i18n.getMessageFor('Updating Title bar style requires Symphony to relaunch'),
-        buttons: ['Relaunch', 'Cancel']
+        buttons: [i18n.getMessageFor('Relaunch'), i18n.getMessageFor('Cancel')]
     };
     electron.dialog.showMessageBox(electron.BrowserWindow.getFocusedWindow(), options, function (index) {
         if (index === 0) {

--- a/locale/en-US.json
+++ b/locale/en-US.json
@@ -17,6 +17,7 @@
   "Bring to Front on Notifications": "Bring to Front on Notifications",
   "Certificate Error": "Certificate Error",
   "Close": "Close",
+  "Cancel": "Cancel",
   "ContextMenu": {
     "Add to Dictionary": "Add to Dictionary",
     "Copy": "Copy",
@@ -51,6 +52,7 @@
   "Failed!": "Failed!",
   "Flash Notification in Taskbar": "Flash Notification in Taskbar",
   "Help": "Help",
+  "Help Url": "https://support.symphony.com",
   "Hide Others": "Hide Others",
   "Hide Symphony": "Hide Symphony",
   "Learn More": "Learn More",
@@ -85,6 +87,7 @@
   "Redo": "Redo",
   "Refresh app when idle": "Refresh app when idle",
   "Relaunch Application": "Relaunch Application",
+  "Relaunch": "Relaunch",
   "Reload": "Reload",
   "Renderer Process Crashed": "Renderer Process Crashed",
   "ScreenPicker": {

--- a/locale/en.json
+++ b/locale/en.json
@@ -17,6 +17,7 @@
   "Bring to Front on Notifications": "Bring to Front on Notifications",
   "Certificate Error": "Certificate Error",
   "Close": "Close",
+  "Cancel": "Cancel",
   "ContextMenu": {
     "Add to Dictionary": "Add to Dictionary",
     "Copy": "Copy",
@@ -49,6 +50,7 @@
   "Failed!": "Failed!",
   "Flash Notification in Taskbar": "Flash Notification in Taskbar",
   "Help": "Help",
+  "Help Url": "https://support.symphony.com",
   "Hide Others": "Hide Others",
   "Hide Symphony": "Hide Symphony",
   "Learn More": "Learn More",
@@ -83,6 +85,7 @@
   "Redo": "Redo",
   "Refresh app when idle": "Refresh app when idle",
   "Relaunch Application": "Relaunch Application",
+  "Relaunch": "Relaunch",
   "Reload": "Reload",
   "Renderer Process Crashed": "Renderer Process Crashed",
   "ScreenPicker": {

--- a/locale/ja-JP.json
+++ b/locale/ja-JP.json
@@ -17,6 +17,7 @@
   "Bring to Front on Notifications": "通知時に前面に表示",
   "Certificate Error": "証明書のエラー",
   "Close": "閉じる",
+  "Cancel": "キャンセル",
   "ContextMenu": {
     "Add to Dictionary": "辞書に追加",
     "Copy": "コピー",
@@ -51,6 +52,7 @@
   "Failed!": "問題が起きました！",
   "Flash Notification in Taskbar": "タスクバーの通知を点滅",
   "Help": "ヘルプ",
+  "Help Url": "https://support.symphony.com/hc/ja",
   "Hide Others": "他を隠す",
   "Hide Symphony": "Symphonyを隠す",
   "Learn More": "詳細",
@@ -85,6 +87,7 @@
   "Redo": "やり直し",
   "Refresh app when idle": "アイドル時にアプリを再表示",
   "Relaunch Application": "アプリケーションの再起動",
+  "Relaunch": "起動",
   "Reload": "再読み込み",
   "Renderer Process Crashed": "レンダラープロセスがクラッシュしました",
   "ScreenPicker": {

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -17,6 +17,7 @@
   "Bring to Front on Notifications": "通知時に前面に表示",
   "Certificate Error": "証明書のエラー",
   "Close": "閉じる",
+  "Cancel": "キャンセル",
   "ContextMenu": {
     "Add to Dictionary": "辞書に追加",
     "Copy": "コピー",
@@ -49,6 +50,7 @@
   "Failed!": "問題が起きました！",
   "Flash Notification in Taskbar": "タスクバーの通知を点滅",
   "Help": "ヘルプ",
+  "Help Url": "https://support.symphony.com/hc/ja",
   "Hide Others": "他を隠す",
   "Hide Symphony": "Symphonyを隠す",
   "Learn More": "詳細",
@@ -83,6 +85,7 @@
   "Redo": "やり直し",
   "Refresh app when idle": "アイドル時にアプリを再表示",
   "Relaunch Application": "アプリケーションの再起動",
+  "Relaunch": "起動",
   "Reload": "再読み込み",
   "Renderer Process Crashed": "レンダラープロセスがクラッシュしました",
   "ScreenPicker": {


### PR DESCRIPTION
## Description
- Localise "Relaunch" and "Cancel" strings in the menu dialog
- Also point users to the Japanese support site if the user is using Japanese as the language
[ELECTRON-718](https://perzoinc.atlassian.net/browse/ELECTRON-718)
[ELECTRON-707](https://perzoinc.atlassian.net/browse/ELECTRON-707)

## Solution Approach
Add new strings to the messages file

## Documentation
N/A

## Related PRs
N/A

## QA Checklist
- [x] Unit-Tests
[ELECTRON-718 Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2339011/ELECTRON-718.Unit.Tests.pdf)
