### PR TITLE
ELECTRON-676 - Fixing Developer Tools window flashes before the popup

### DIFF
--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -554,10 +554,6 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
                             if (!isDevEnv) {
                                 browserWin.webContents.session.setCertificateVerifyProc(handleCertificateTransparencyChecks);
                             }
-
-                            browserWin.webContents.on('devtools-opened', () => {
-                                handleDevTools(browserWin);
-                            });
                         }
                     });
                 } else {
@@ -598,10 +594,6 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
             });
     });
 
-    mainWindow.webContents.on('devtools-opened', () => {
-        handleDevTools(mainWindow);
-    });
-
     /**
      * Register shortcuts for the app
      */
@@ -610,8 +602,20 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
         function devTools() {
             const focusedWindow = BrowserWindow.getFocusedWindow();
 
+            
             if (focusedWindow && !focusedWindow.isDestroyed()) {
-                focusedWindow.webContents.toggleDevTools();
+                if (devToolsEnabled) {
+                    focusedWindow.webContents.toggleDevTools();
+                } else {
+                    log.send(logLevels.INFO, `dev tools disabled for ${focusedWindow.winName} window`);
+                    focusedWindow.webContents.closeDevTools();
+                    electron.dialog.showMessageBox(focusedWindow, {
+                        type: 'warning',
+                        buttons: ['Ok'],
+                        title: i18n.getMessageFor('Dev Tools disabled'),
+                        message: i18n.getMessageFor('Dev Tools has been disabled! Please contact your system administrator to enable it!'),
+                    });
+                }
             }
         }
 
@@ -721,21 +725,6 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
         }
 
         return callback(-2);
-    }
-
-    function handleDevTools(browserWindow) {
-
-        if (!devToolsEnabled) {
-            log.send(logLevels.INFO, `dev tools disabled for ${browserWindow.winName} window`);
-            browserWindow.webContents.closeDevTools();
-            electron.dialog.showMessageBox(browserWindow, {
-                type: 'warning',
-                buttons: ['Ok'],
-                title: i18n.getMessageFor('Dev Tools disabled'),
-                message: i18n.getMessageFor('Dev Tools has been disabled! Please contact your system administrator to enable it!'),
-            });
-        }
-
     }
 
 }


### PR DESCRIPTION
## Description
"Developer Tools" window flashes briefly before "Dev Tools disabled" pop-up displays [ELECTRON-676](https://perzoinc.atlassian.net/browse/ELECTRON-676)

Expected Result:
"Developer Tools" window should not flashes when displaying "Dev Tools disabled" pop-up

## Fixing
- Before
![electron-676-2](https://user-images.githubusercontent.com/9887288/44932910-8c1b2680-ad3d-11e8-8c00-ec433c4f385a.gif)

- After 
![electron-676](https://user-images.githubusercontent.com/9887288/44932718-ef588900-ad3c-11e8-8c1f-2daa3c8125f9.gif)

## QA Checklist
- [x] Unit-Tests
- [ ] Automation-Tests

Attach unit & spectron tests results in PDF format against the above task lists for this branch