### PR TITLE
ELECTRON-710 - Fix Always on top: notification does not show on top

### DIFF
--- a/js/notify/electron-notify.js
+++ b/js/notify/electron-notify.js
@@ -422,6 +422,14 @@ function setNotificationContents(notfWindow, notfObj) {
     // Display time per notification basis.
     let displayTime = notfObj.displayTime ? notfObj.displayTime : config.displayTime;
 
+    let browserWindows = BrowserWindow.getAllWindows();
+    const mainWindow = browserWindows.find((window) => { return window.winName === 'main' });
+    if (mainWindow && !mainWindow.isDestroyed()) {
+        if (mainWindow.isAlwaysOnTop()) {
+            notfWindow.setAlwaysOnTop(true);
+        }
+    }
+
     if (notfWindow.displayTimer) {
         clearTimeout(notfWindow.displayTimer);
     }


### PR DESCRIPTION
## Description
Electron - Always on top - Toast notification does not show on top (front) of the Electron if close toast notification before
 [JIRA-ticket](https://perzoinc.atlassian.net/browse/JIRA-ticket)

## Fix
![electron-710](https://user-images.githubusercontent.com/9887288/44998956-15c23280-af90-11e8-87eb-1d9037db47b7.gif)


## QA Checklist
- [x] Unit-Tests
- [ ] Automation-Tests

Attach unit & spectron tests results in PDF format against the above task lists for this branch