### PR TITLE
ELECTRON-756 - About Symphony: Window shows at top-left corner after fullscreen

### DIFF
--- a/js/aboutApp/index.js
+++ b/js/aboutApp/index.js
@@ -20,6 +20,7 @@ let windowConfig = {
     autoHideMenuBar: true,
     titleBarStyle: true,
     resizable: false,
+    fullscreenable: false,
     webPreferences: {
         preload: path.join(__dirname, 'renderer.js'),
         sandbox: true,


### PR DESCRIPTION
## Description
Window shows at top-left corner without header (About Symphony title/Minimize/Maximize/Close) after some steps 
[ELECTRON-756](https://perzoinc.atlassian.net/browse/ELECTRON-756)

## Fix
- Before
![electron-756-before](https://user-images.githubusercontent.com/9887288/45885487-fa776580-bd8c-11e8-9d5f-e490f9f3d83b.gif)

- After
![electron-756](https://user-images.githubusercontent.com/9887288/45885295-6efdd480-bd8c-11e8-9667-3f489763d851.gif)

## Links

Setting window to fullscreen, when resizing is disabled, breaks fullscreen functionality [8166](https://github.com/electron/electron/issues/8166)
Fix full screen when resizable is set to true [9814](https://github.com/electron/electron/pull/9814)

## QA Checklist
- [x] Unit-Tests
- [ ] Automation-Tests

Attach unit & spectron tests results in PDF format against the above task lists for this branch