### PR TITLE
ELECTRON-788: add clear cache functionality

### DIFF
--- a/js/cacheHandler/index.js
+++ b/js/cacheHandler/index.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const nodePath = require('path');
+const electron = require('electron');
+
+const log = require('../log.js');
+const logLevels = require('../enums/logLevels.js');
+
+const cacheCheckFilename = 'CacheCheck';
+const cacheCheckFilePath = nodePath.join(electron.app.getPath('userData'), cacheCheckFilename);
+
+function handleCacheFailureCheckOnStartup() {
+
+    return new Promise((resolve) => {
+
+        if (fs.existsSync(cacheCheckFilePath)) {
+            log.send(logLevels.INFO, `Cache check file exists, so not clearing cache!`);
+            fs.unlinkSync(cacheCheckFilePath);
+            resolve();
+        } else {
+            log.send(logLevels.INFO, `Cache check file does not exist, we are clearing the cache!`);
+            electron.session.defaultSession.clearCache(() => {
+                log.send(logLevels.INFO, `Cleared cache!`);
+                resolve();
+            });
+        }
+
+    });
+
+}
+
+function handleCacheFailureCheckOnExit() {
+    log.send(logLevels.INFO, `Clean exit! Creating cache check file!`);
+    fs.writeFileSync(cacheCheckFilePath, "");
+}
+
+module.exports = {
+    handleCacheFailureCheckOnStartup: handleCacheFailureCheckOnStartup,
+    handleCacheFailureCheckOnExit: handleCacheFailureCheckOnExit
+};

--- a/js/main.js
+++ b/js/main.js
@@ -183,19 +183,28 @@ setChromeFlags();
 app.on('ready', () => {
     handleCacheFailureCheckOnStartup()
         .then(() => {
-            electron.powerMonitor.on('lock-screen', () => {
-                eventEmitter.emit('sys-locked');
-            });
-            electron.powerMonitor.on('unlock-screen', () => {
-                eventEmitter.emit('sys-unlocked');
-            });
-            checkFirstTimeLaunch()
-                .then(readConfigThenOpenMainWindow)
-                .catch(readConfigThenOpenMainWindow);
+            initiateApp();
         })
         .catch((err) => {
             log.send(logLevels.INFO, `Couldn't clear cache and refresh -> ${err}`);
+            initiateApp();
         });
+
+    function initiateApp() {
+
+        electron.powerMonitor.on('lock-screen', () => {
+            eventEmitter.emit('sys-locked');
+        });
+
+        electron.powerMonitor.on('unlock-screen', () => {
+            eventEmitter.emit('sys-unlocked');
+        });
+
+        checkFirstTimeLaunch()
+            .then(readConfigThenOpenMainWindow)
+            .catch(readConfigThenOpenMainWindow);
+
+    }
 });
 
 /**

--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -375,6 +375,18 @@ function getTemplate(app) {
         }
     });
 
+    // Window - View menu -> Clear Cache
+    template[index].submenu.push({
+        label: i18n.getMessageFor('Clear cache and Reload'),
+        click: function (item, focusedWindow) {
+            if (focusedWindow && !focusedWindow.isDestroyed()) {
+                electron.session.defaultSession.clearCache(() => {
+                    focusedWindow.reload();
+                });
+            }
+        }
+    });
+
     if (!isMac) {
         /* eslint-disable no-param-reassign */
         template[index].submenu.push({

--- a/locale/en-US.json
+++ b/locale/en-US.json
@@ -89,6 +89,7 @@
   "Quit Symphony": "Quit Symphony",
   "Redo": "Redo",
   "Refresh app when idle": "Refresh app when idle",
+  "Clear cache and Reload": "Clear cache and Reload",
   "Relaunch Application": "Relaunch Application",
   "Relaunch": "Relaunch",
   "Reload": "Reload",

--- a/locale/en.json
+++ b/locale/en.json
@@ -87,6 +87,7 @@
   "Quit Symphony": "Quit Symphony",
   "Redo": "Redo",
   "Refresh app when idle": "Refresh app when idle",
+  "Clear cache and Reload": "Clear cache and Reload",
   "Relaunch Application": "Relaunch Application",
   "Relaunch": "Relaunch",
   "Reload": "Reload",

--- a/locale/ja-JP.json
+++ b/locale/ja-JP.json
@@ -89,6 +89,7 @@
   "Quit Symphony": "Symphonyを終了",
   "Redo": "やり直し",
   "Refresh app when idle": "アイドル時にアプリを再表示",
+  "Clear cache and Reload": "キャッシュをクリアしてリロードする",
   "Relaunch Application": "アプリケーションの再起動",
   "Relaunch": "「リスタート」",
   "Reload": "再読み込み",

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -87,6 +87,7 @@
   "Quit Symphony": "Symphonyを終了",
   "Redo": "やり直し",
   "Refresh app when idle": "アイドル時にアプリを再表示",
+  "Clear cache and Reload": "キャッシュをクリアしてリロードする",
   "Relaunch Application": "アプリケーションの再起動",
   "Relaunch": "「リスタート」",
   "Reload": "再読み込み",


### PR DESCRIPTION
## Description

A few customers have reported that the cache gets corrupted when the app is not exited cleanly. And, upon the next start, we get cache_read_failures.

[ELECTRON-788](https://perzoinc.atlassian.net/browse/ELECTRON-788)

## Solution Approach
This fix adds an extra check during startup and exit to check if the app was exited cleanly and clears the corrupted cache accordingly during startup.

Also adds a new menu item for users to manually clear cache and reload the app.

## Documentation
N/A

## Related PRs
N/A

## QA Checklist
- [x] Unit-Tests
[ELECTRON-788 Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2410701/ELECTRON-788.Unit.Tests.pdf)
