### PR TITLE
ELECTRON-795, ELECTRON-789: localise download manager messages

### DIFF
--- a/js/downloadManager/index.js
+++ b/js/downloadManager/index.js
@@ -7,8 +7,11 @@ const local = {
     downloadItems: []
 };
 
-let showInFolderText = "Show in Folder";
-let openText = "Open";
+let showInFolderText = 'Show in Folder';
+let openText = 'Open';
+let downloadedText = 'Downloaded';
+let fileNotFoundTitle = 'File not Found';
+let fileNotFoundMessage = 'The file you are trying to open cannot be found in the specified path.';
 
 // listen for file download complete event
 local.ipcRenderer.on('downloadCompleted', (event, arg) => {
@@ -26,8 +29,12 @@ local.ipcRenderer.on('locale-changed', (event, data) => {
     if (data && typeof data === 'object') {
 
         if (data.downloadManager) {
-            showInFolderText = data.downloadManager['Show in Folder'];
             openText = data.downloadManager.Open;
+            downloadedText = data.downloadManager.Downloaded;
+
+            showInFolderText = data.downloadManager['Show in Folder'];
+            fileNotFoundTitle = data.downloadManager['File not Found'];
+            fileNotFoundMessage = data.downloadManager['The file you are trying to open cannot be found in the specified path.'];
         }
 
     }
@@ -46,7 +53,7 @@ function openFile(id) {
         let openResponse = remote.shell.openExternal(`file:///${local.downloadItems[fileIndex].savedPath}`);
         let focusedWindow = remote.BrowserWindow.getFocusedWindow();
         if (!openResponse && focusedWindow && !focusedWindow.isDestroyed()) {
-            remote.dialog.showMessageBox(focusedWindow, {type: 'error', title: 'File not found', message: 'The file you are trying to open cannot be found in the specified path.'});
+            remote.dialog.showMessageBox(focusedWindow, {type: 'error', title: fileNotFoundTitle, message: fileNotFoundMessage});
         }
     }
 }
@@ -63,7 +70,7 @@ function showInFinder(id) {
         let showResponse = remote.shell.showItemInFolder(local.downloadItems[showFileIndex].savedPath);
         let focusedWindow = remote.BrowserWindow.getFocusedWindow();
         if (!showResponse && focusedWindow && !focusedWindow.isDestroyed()) {
-            remote.dialog.showMessageBox(focusedWindow, {type: 'error', title: 'File not found', message: 'The file you are trying to open cannot be found in the specified path.'});
+            remote.dialog.showMessageBox(focusedWindow, {type: 'error', title: fileNotFoundTitle, message: fileNotFoundMessage});
         }
     }
 }
@@ -133,7 +140,7 @@ function createDOM(arg) {
 
             let fileProgressTitle = document.createElement('span');
             fileProgressTitle.id = 'per';
-            fileProgressTitle.innerHTML = arg.total + ' Downloaded';
+            fileProgressTitle.innerHTML = `${arg.total} ${downloadedText}`;
             fileNameDiv.appendChild(fileProgressTitle);
 
             let caret = document.createElement('div');

--- a/locale/en-US.json
+++ b/locale/en-US.json
@@ -36,7 +36,10 @@
   "DownloadManager": {
     "Show in Folder": "Show in Folder",
     "Reveal in Finder": "Reveal in Finder",
-    "Open": "Open"
+    "Open": "Open",
+    "Downloaded": "Downloaded",
+    "File not Found": "File not Found",
+    "The file you are trying to open cannot be found in the specified path.": "The file you are trying to open cannot be found in the specified path."
   },
   "Copy": "Copy",
   "Custom": "Custom",

--- a/locale/en.json
+++ b/locale/en.json
@@ -36,7 +36,10 @@
   "DownloadManager": {
     "Show in Folder": "Show in Folder",
     "Reveal in Finder": "Reveal in Finder",
-    "Open": "Open"
+    "Open": "Open",
+    "Downloaded": "Downloaded",
+    "File not Found": "File not Found",
+    "The file you are trying to open cannot be found in the specified path.": "The file you are trying to open cannot be found in the specified path."
   },
   "Copy": "Copy",
   "Custom": "Custom",

--- a/locale/ja-JP.json
+++ b/locale/ja-JP.json
@@ -36,7 +36,10 @@
   "DownloadManager": {
     "Show in Folder": "フォルダで見て",
     "Reveal in Finder": "Finderで明らかにする",
-    "Open": "開いた"
+    "Open": "開いた",
+    "Downloaded": "ダウンロード済み",
+    "File not Found": "ファイルが見つかりません",
+    "The file you are trying to open cannot be found in the specified path.": "開こうとしているファイルが指定されたパスに見つかりません."
   },
   "Copy": "コピー",
   "Custom": "カスタム",

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -36,7 +36,10 @@
   "DownloadManager": {
     "Show in Folder": "フォルダで見て",
     "Reveal in Finder": "Finderで明らかにする",
-    "Open": "開いた"
+    "Open": "開いた",
+    "Downloaded": "ダウンロード済み",
+    "File not Found": "ファイルが見つかりません",
+    "The file you are trying to open cannot be found in the specified path.": "開こうとしているファイルが指定されたパスに見つかりません."
   },
   "Copy": "コピー",
   "Custom": "カスタム",


### PR DESCRIPTION
## Description
The messages "Downloaded" and "File not found" were not localised in Japanese, this PR adds localisation to those messages.
[ELECTRON-795](https://perzoinc.atlassian.net/browse/ELECTRON-795)
[ELECTRON-789](https://perzoinc.atlassian.net/browse/ELECTRON-789)

## Solution Approach
Add appropriate strings to the localisation files.
<img width="1439" alt="screenshot 2018-09-26 at 15 37 25" src="https://user-images.githubusercontent.com/5968790/46073886-c09aca80-c1a3-11e8-94d7-9931149ec2c0.png">
<img width="472" alt="screenshot 2018-09-26 at 15 37 49" src="https://user-images.githubusercontent.com/5968790/46073908-cabcc900-c1a3-11e8-94d5-5d947fe8db74.png">

## Documentation
N/A

## Related PRs
N/A

## QA Checklist
- [x] Unit-Tests
[ELECTRON-795 Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2419273/ELECTRON-795.Unit.Tests.pdf)
