### PR TITLE
ELECTRON-790: add japanese localisation support for "Learn more" menu item

### DIFF
--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -105,7 +105,8 @@ function getTemplate(app) {
                 {
                     label: i18n.getMessageFor('Learn More'),
                     click() {
-                        electron.shell.openExternal('https://www.symphony.com');
+                        let symUrl = i18n.getMessageFor('Symphony Url');
+                        electron.shell.openExternal(symUrl);
                     }
                 },
                 {

--- a/locale/en-US.json
+++ b/locale/en-US.json
@@ -58,6 +58,7 @@
   "Flash Notification in Taskbar": "Flash Notification in Taskbar",
   "Help": "Help",
   "Help Url": "https://support.symphony.com",
+  "Symphony Url": "https://symphony.com/en-US",
   "Hide Others": "Hide Others",
   "Hide Symphony": "Hide Symphony",
   "Learn More": "Learn More",

--- a/locale/en.json
+++ b/locale/en.json
@@ -56,6 +56,7 @@
   "Flash Notification in Taskbar": "Flash Notification in Taskbar",
   "Help": "Help",
   "Help Url": "https://support.symphony.com",
+  "Symphony Url": "https://symphony.com/en-US",
   "Hide Others": "Hide Others",
   "Hide Symphony": "Hide Symphony",
   "Learn More": "Learn More",

--- a/locale/ja-JP.json
+++ b/locale/ja-JP.json
@@ -58,6 +58,7 @@
   "Flash Notification in Taskbar": "タスクバーの通知を点滅",
   "Help": "ヘルプ",
   "Help Url": "https://support.symphony.com/hc/ja",
+  "Symphony Url": "https://symphony.com/ja",
   "Hide Others": "他を隠す",
   "Hide Symphony": "Symphonyを隠す",
   "Learn More": "詳細",

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -56,6 +56,7 @@
   "Flash Notification in Taskbar": "タスクバーの通知を点滅",
   "Help": "ヘルプ",
   "Help Url": "https://support.symphony.com/hc/ja",
+  "Symphony Url": "https://symphony.com/ja",
   "Hide Others": "他を隠す",
   "Hide Symphony": "Symphonyを隠す",
   "Learn More": "詳細",


### PR DESCRIPTION
## Description
The menu item "Learn More" under the "Help" menu doesn't take a user to the appropriate page when Japanese is set as the user's language. This fixes the issue

[ELECTRON-790](https://perzoinc.atlassian.net/browse/ELECTRON-790)

## Solution Approach
Add appropriate links in the localisation files

## Documentation
N/A

## Related PRs
N/A

## QA Checklist
- [x] Unit-Tests
[ELECTRON-790 Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2422734/ELECTRON-790.Unit.Tests.pdf)
