### PR TITLE
ELECTRON-758 (Change network request implementation to use electron's API)

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -26,6 +26,7 @@ const log = require('./log.js');
 const logLevels = require('./enums/logLevels.js');
 const autoLaunch = require('./autoLaunch');
 const { handleCacheFailureCheckOnStartup, handleCacheFailureCheckOnExit} = require('./cacheHandler');
+const { monitorNetworkRequest } = require('./memoryMonitor');
 
 require('electron-dl')();
 
@@ -199,7 +200,8 @@ app.on('ready', () => {
         electron.powerMonitor.on('unlock-screen', () => {
             eventEmitter.emit('sys-unlocked');
         });
-
+        // Keeps track of active network request
+        monitorNetworkRequest();
         checkFirstTimeLaunch()
             .then(readConfigThenOpenMainWindow)
             .catch(readConfigThenOpenMainWindow);

--- a/js/mainApiMgr.js
+++ b/js/mainApiMgr.js
@@ -154,9 +154,8 @@ electron.ipcMain.on(apiName, (event, arg) => {
         case apiCmds.optimizeMemoryConsumption:
             if (typeof arg.memory === 'object'
                 && typeof arg.cpuUsage === 'object'
-                && typeof arg.memory.workingSetSize === 'number'
-                && typeof arg.activeRequests === 'number') {
-                setPreloadMemoryInfo(arg.memory, arg.cpuUsage, arg.activeRequests);
+                && typeof arg.memory.workingSetSize === 'number') {
+                setPreloadMemoryInfo(arg.memory, arg.cpuUsage);
             }
             break;
         case apiCmds.optimizeMemoryRegister:

--- a/js/preload/preloadMain.js
+++ b/js/preload/preloadMain.js
@@ -366,18 +366,6 @@ function createAPI() {
                 throttledSetLocale(locale);
             }
         },
-
-        /**
-         * Allows JS to register activeRequests that can be used by electron to
-         * get the active network request from the client
-         *
-         * @param activeRequests
-         */
-        registerActiveRequests: function (activeRequests) {
-            if (typeof activeRequests === 'function') {
-                local.activeRequests = activeRequests;
-            }
-        },
     };
 
     // add support for both ssf and SYM_API name-space.
@@ -530,12 +518,10 @@ function createAPI() {
         if (window.name === 'main') {
             const memory = process.getProcessMemoryInfo();
             const cpuUsage = process.getCPUUsage();
-            const activeRequests = local.activeRequests();
             local.ipcRenderer.send(apiName, {
                 cmd: apiCmds.optimizeMemoryConsumption,
                 memory,
                 cpuUsage,
-                activeRequests,
             });
         }
     });


### PR DESCRIPTION
## Description
Change the active network request logic to use the one available in the electron framework instead of client API [ELECTRON-758](https://perzoinc.atlassian.net/browse/ELECTRON-758)

## Solution Approach
Using the electron's session object `WebRequest` to detect the active network request


## Related PRs
List related PRs against other branches / repositories:

branch | PR
------ | ------
SymphonyElectron - Related | [#494](https://github.com/symphonyoss/SymphonyElectron/pull/494)

## QA Checklist
- [X] Unit-Tests
[ELECTRON-758 — Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2423152/ELECTRON-758.Unit.Tests.pdf)

- [ ] Automation-Tests
