### PR TITLE
ELECTRON-736 (Show menu at 0,0 cord if the window is in full-screen mode)

### DIFF
--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -1194,7 +1194,8 @@ function cleanUpChildWindows() {
 function popupMenu() {
     const focusedWindow = BrowserWindow.getFocusedWindow();
     if (mainWindow && !mainWindow.isDestroyed() && isMainWindow(focusedWindow)) {
-        const popupOpts = { browserWin: mainWindow, x: 10, y: -20 };
+        const { x, y } = mainWindow.isFullScreen() ? { x: 0, y: 0 } : { x: 10, y: -20 };
+        const popupOpts = { browserWin: mainWindow, x, y };
         getMenu().popup(popupOpts);
     }
 }

--- a/tests/utils/getRegistry.test.js
+++ b/tests/utils/getRegistry.test.js
@@ -57,7 +57,7 @@ describe('Tests for getRegistry', function() {
 
                 function reject(err) {
                     expect(err).toBeTruthy();
-                    expect(err).toBe('Cannot find PodUrl Registry. Using default url.');
+                    expect(err.message).toBe('Cannot find PodUrl Registry. Using default url.');
                     done();
                 }
 


### PR DESCRIPTION
## Description
Show menu at 0,0 cord if the window is in full-screen mode [ELECTRON-736](https://perzoinc.atlassian.net/browse/ELECTRON-736)

## Solution Approach
Display popup menu at cord 0,0 if the window is in full-screen mode

## Before
![screenshot 2018-10-02 at 4 48 40 pm](https://user-images.githubusercontent.com/13243259/46345752-57afc880-c663-11e8-8b49-0b76afda85a9.png)

## After
![screenshot 2018-10-02 at 3 38 44 pm](https://user-images.githubusercontent.com/13243259/46345762-5d0d1300-c663-11e8-8fa2-104b9ccd75f6.png)


## QA Checklist
- [X] Unit-Tests
[ELECTRON-736 Test Result.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2437616/ELECTRON-736.Test.Result.pdf)

- [ ] Automation-Tests