### PR TITLE
ELECTRON-720 (Set the menu to null for about, basic auth & configure notification windows)

### DIFF
--- a/js/aboutApp/index.js
+++ b/js/aboutApp/index.js
@@ -9,6 +9,7 @@ const logLevels = require('../enums/logLevels.js');
 const { version, clientVersion, buildNumber } = require('../../package.json');
 const { initCrashReporterMain, initCrashReporterRenderer } = require('../crashReporter.js');
 const i18n = require('../translation/i18n');
+const { isMac } = require('../utils/misc');
 
 let aboutWindow;
 
@@ -88,6 +89,10 @@ function openAboutWindow(windowName) {
         initCrashReporterMain({ process: 'about app window' });
         initCrashReporterRenderer(aboutWindow, { process: 'render | about app window' });
         aboutWindow.webContents.send('versionInfo', { version, clientVersion, buildNumber });
+        if (!isMac) {
+            // prevents from displaying menu items when "alt" key is pressed
+            aboutWindow.setMenu(null);
+        }
     });
 
     aboutWindow.webContents.on('crashed', function () {

--- a/js/basicAuth/index.js
+++ b/js/basicAuth/index.js
@@ -105,6 +105,10 @@ function openBasicAuthWindow(windowName, hostname, isValidCredentials, clearSett
         initCrashReporterRenderer(basicAuthWindow, { process: 'render | basic auth window' });
         basicAuthWindow.webContents.send('hostname', hostname);
         basicAuthWindow.webContents.send('isValidCredentials', isValidCredentials);
+        if (!isMac) {
+            // prevents from displaying menu items when "alt" key is pressed
+            basicAuthWindow.setMenu(null);
+        }
     });
 
     basicAuthWindow.webContents.on('crashed', function () {

--- a/js/notify/settings/configure-notification-position.js
+++ b/js/notify/settings/configure-notification-position.js
@@ -12,6 +12,7 @@ const notify = require('./../electron-notify');
 const eventEmitter = require('./../../eventEmitter');
 const { updateConfigField } = require('../../config');
 const i18n = require('../../translation/i18n');
+const { isMac } = require('../../utils/misc');
 
 let configurationWindow;
 let screens;
@@ -129,6 +130,10 @@ function openConfigurationWindow(windowName) {
             configurationWindow.webContents.send('screens', screens);
         }
         configurationWindow.webContents.send('notificationSettings', {position: position, display: display});
+        if (!isMac) {
+            // prevents from displaying menu items when "alt" key is pressed
+            configurationWindow.setMenu(null);
+        }
     });
 
     configurationWindow.on('close', () => {


### PR DESCRIPTION
## Description
Set the menu to null for about, basic auth & configure notification windows [ELECTRON-720](https://perzoinc.atlassian.net/browse/ELECTRON-720)

## Solution Approach
Setting the menu to null will prevent from showing the menu on Windows

## Documentation
https://github.com/electron/electron/blob/master/docs/api/browser-window.md#winsetmenumenu-linux-windows


## QA Checklist
- [X] Unit-Tests
[ELECTRON-720 Test Result.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2437721/ELECTRON-720.Test.Result.pdf)

- [ ] Automation-Tests