### PR TITLE
ELECTRON-870 (Remove process.getCPUUsage from renderer process due to sandbox)

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -9,7 +9,6 @@ const shellPath = require('shell-path');
 const urlParser = require('url');
 const nodePath = require('path');
 const compareSemVersions = require('./utils/compareSemVersions.js');
-const eventEmitter = require('./eventEmitter');
 
 // Local Dependencies
 const {
@@ -195,15 +194,6 @@ app.on('ready', () => {
         });
 
     function initiateApp() {
-
-        electron.powerMonitor.on('lock-screen', () => {
-            eventEmitter.emit('sys-locked');
-        });
-
-        electron.powerMonitor.on('unlock-screen', () => {
-            eventEmitter.emit('sys-unlocked');
-        });
-
         checkFirstTimeLaunch()
             .then(readConfigThenOpenMainWindow)
             .catch(readConfigThenOpenMainWindow);

--- a/js/mainApiMgr.js
+++ b/js/mainApiMgr.js
@@ -153,10 +153,10 @@ electron.ipcMain.on(apiName, (event, arg) => {
         }
         case apiCmds.optimizeMemoryConsumption:
             if (typeof arg.memory === 'object'
-                && typeof arg.cpuUsage === 'object'
                 && typeof arg.memory.workingSetSize === 'number'
                 && typeof arg.activeRequests === 'number') {
-                setPreloadMemoryInfo(arg.memory, arg.cpuUsage, arg.activeRequests);
+                log.send(logLevels.INFO, 'Received memory info from renderer');
+                setPreloadMemoryInfo(arg.memory, arg.activeRequests);
             }
             break;
         case apiCmds.optimizeMemoryRegister:

--- a/js/memoryMonitor.js
+++ b/js/memoryMonitor.js
@@ -10,7 +10,7 @@ const { getConfigField } = require('./config');
 const maxMemory = 800;
 const memoryRefreshThreshold = 60 * 60 * 1000;
 const maxIdleTime = 4 * 60 * 60 * 1000;
-const memoryRefreshInterval = 1000;
+const memoryRefreshInterval = 60 * 60 * 1000;
 const cpuUsageThreshold = 5;
 
 let isInMeeting = false;

--- a/js/preload/preloadMain.js
+++ b/js/preload/preloadMain.js
@@ -505,12 +505,10 @@ function createAPI() {
     local.ipcRenderer.on('memory-info-request', () => {
         if (window.name === 'main') {
             const memory = process.getProcessMemoryInfo();
-            const cpuUsage = process.getCPUUsage();
-            const activeRequests = local.activeRequests();
+            const activeRequests = typeof local.activeRequests === 'function' ? local.activeRequests() : 0;
             local.ipcRenderer.send(apiName, {
                 cmd: apiCmds.optimizeMemoryConsumption,
                 memory,
-                cpuUsage,
                 activeRequests,
             });
         }

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -214,12 +214,6 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
         // event sent to renderer process to remove snack bar
         mainWindow.webContents.send('window-leave-full-screen');
     });
-    mainWindow.on('minimize', () => {
-        eventEmitter.emit('appMinimized');
-    });
-    mainWindow.on('restore', () => {
-        eventEmitter.emit('appRestored');
-    });
 
     if (initialBounds) {
         // maximizes the application if previously maximized


### PR DESCRIPTION
## Description
`process.getCPUUsage` method cannot be accessed if sandboxed [ELECTRON-870](https://perzoinc.atlassian.net/browse/ELECTRON-870)

## Solution Approach
Accessing the CPU usage in from the main process fixes the issue

## Related PRs
List related PRs against other branches / repositories:

branch | PR
------ | ------
R53 | [link](https://github.com/symphonyoss/SymphonyElectron/pull/520)

## QA Checklist
- [X] Unit-Tests
![screenshot 2018-10-25 at 10 00 39 am](https://user-images.githubusercontent.com/13243259/47476187-dcde6580-d83c-11e8-8456-6db2bfec1d4b.png)
- [ ] Automation-Tests