### PR TITLE
ELECTRON-874 (Change version numbering 1.53-3.4.0)

### DIFF
--- a/js/aboutApp/index.js
+++ b/js/aboutApp/index.js
@@ -6,7 +6,7 @@ const path = require('path');
 const fs = require('fs');
 const log = require('../log.js');
 const logLevels = require('../enums/logLevels.js');
-const buildNumber = require('../../package.json').buildNumber;
+const { version, clientVersion, buildNumber } = require('../../package.json');
 const { initCrashReporterMain, initCrashReporterRenderer } = require('../crashReporter.js');
 const i18n = require('../translation/i18n');
 
@@ -87,7 +87,7 @@ function openAboutWindow(windowName) {
         // initialize crash reporter
         initCrashReporterMain({ process: 'about app window' });
         initCrashReporterRenderer(aboutWindow, { process: 'render | about app window' });
-        aboutWindow.webContents.send('buildNumber', buildNumber || '0');
+        aboutWindow.webContents.send('versionInfo', { version, clientVersion, buildNumber });
     });
 
     aboutWindow.webContents.on('crashed', function () {

--- a/js/aboutApp/renderer.js
+++ b/js/aboutApp/renderer.js
@@ -17,12 +17,12 @@ function renderDom() {
     });
 }
 
-ipcRenderer.on('buildNumber', (event, buildNumber) => {
-    let versionText = document.getElementById('version');
-    const version = remote.app.getVersion();
+ipcRenderer.on('versionInfo', (event, versionInfo) => {
+    const versionText = document.getElementById('version');
+    const { version, clientVersion, buildNumber } = versionInfo;
 
     if (versionText) {
-        versionText.innerHTML = version ? `Version ${version} (${version}.${buildNumber})` : 'N/A';
+        versionText.innerHTML = version ? `Version ${clientVersion}-${version} (${buildNumber})` : 'N/A';
     }
 });
 

--- a/js/main.js
+++ b/js/main.js
@@ -9,6 +9,7 @@ const shellPath = require('shell-path');
 const urlParser = require('url');
 const nodePath = require('path');
 const compareSemVersions = require('./utils/compareSemVersions.js');
+const { version, clientVersion, buildNumber } = require('../package.json');
 
 // Local Dependencies
 const {
@@ -230,6 +231,8 @@ app.on('activate', function () {
 // because electron leaves registry traces upon uninstallation
 if (isMac) {
     app.setAsDefaultProtocolClient('symphony');
+    // Sets application version info that will be displayed in about app panel
+    app.setAboutPanelOptions({ applicationVersion: `${clientVersion}-${version}`, version: buildNumber });
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "Symphony",
   "productName": "Symphony",
   "version": "3.4.0",
+  "clientVersion": "1.53",
   "buildNumber": "0",
   "description": "Symphony desktop app (Foundation ODP)",
   "author": "Symphony",


### PR DESCRIPTION
## Description
Change app version numbering to include client version number [JIRA-ticket](https://perzoinc.atlassian.net/browse/ELECTRON-874)

Version numbering Format **(clientVersion-SymphonyElectron) (Build Number) - 1.53-3.4.0 (16)**

## Solution Approach
Add a new field `clientVersion` in the package.json file.

## Screenshots
### Mac
![screenshot 2018-10-26 at 11 43 05 am](https://user-images.githubusercontent.com/13243259/47548167-bd673b80-d915-11e8-9b44-ffd4f8d1d0e2.png)


### Windows
<img alt="windows_about_app" src="https://user-images.githubusercontent.com/13243259/47548691-606c8500-d917-11e8-8fe9-e542efb43b6c.png " width="285">


## QA Checklist
- [X] Unit-Tests
![screenshot 2018-10-26 at 11 53 51 am](https://user-images.githubusercontent.com/13243259/47548195-d5d75600-d915-11e8-8def-4691005e4cea.png)

- [ ] Automation-Tests