### PR TITLE
ELECTRON-906 (Fix copy image context menu)

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "auto-launch": "5.0.5",
     "electron-dl": "1.12.0",
     "electron-log": "2.2.17",
-    "electron-spellchecker": "git+https://github.com/KiranNiranjan/electron-spellchecker.git#v3.0.5",
+    "electron-spellchecker": "git+https://github.com/KiranNiranjan/electron-spellchecker.git#v3.0.6",
     "ffi": "git+https://github.com/keerthi16/node-ffi.git#v1.2.8",
     "filesize": "3.6.1",
     "keymirror": "0.1.1",


### PR DESCRIPTION
## Description
Fix and error in copy image context menu [ELECTRON-906](https://perzoinc.atlassian.net/browse/ELECTRON-906)

## Solution Approach
Use `request` module to fetch and convert images to dataUrl and write it to the clipboard

### Working Screencast
![2018-11-15 11 41 05](https://user-images.githubusercontent.com/13243259/48533690-7e505880-e8cb-11e8-9396-d94eb0290063.gif)


## QA Checklist
- [X] Unit-Tests
![screenshot 2018-11-15 at 11 21 03 am](https://user-images.githubusercontent.com/13243259/48532970-9377b800-e8c8-11e8-972c-dbab522e043c.png)

- [ ] Automation-Tests