### PR TITLE
ELECTRON-884 - Enable screen snippet in zip build

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,14 @@
       "config/Symphony.config",
       "library/libsymphonysearch.dylib",
       "library/cryptoLib.dylib",
-      "library/lz4.exec"
+      "library/lz4.exec",
+      {
+        "from": "./node_modules/screen-snippet/bin/Release/",
+        "to": ".",
+        "filter": [
+          "!ScreenSnippet.pdb"
+        ]
+      }
     ],
     "appId": "com.symphony.electron-desktop",
     "mac": {


### PR DESCRIPTION
## Description
HSBC Prod: Unable to take screenshots [ELECTRON-884](https://perzoinc.atlassian.net/browse/ELECTRON-884)

When the user tried to use screen snippet the functionality didn't work, because the files about it were not found. This only happens in the zip build.

You can access the new build here: https://jenkins2.symphony.com/view/Electron/job/dev/job/electron-custom-build-win/177/

## Documentation
See here more details about electron-build [electron-build configuration](https://www.electron.build/configuration/configuration)
## Fix
- Before
![electron-884-before](https://user-images.githubusercontent.com/9887288/48566740-b1521680-e8e2-11e8-91e0-024ab03dc28d.png)
- After 
![electron-884-after](https://user-images.githubusercontent.com/9887288/48566746-b57e3400-e8e2-11e8-87bc-b44d329dcc04.png)

## QA Checklist
- [x] Unit-Tests
- [ ] Automation-Tests

Attach unit & spectron tests results in PDF format against the above task lists for this branch