### PR TITLE
SEARCH-1059 (Electron - Swift search - A JavaScript error displays when the user reloads the Electron while the file .lz4 is creating)

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,6 @@
   },
   "optionalDependencies": {
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.2",
-    "swift-search": "2.0.1-r53"
+    "swift-search": "2.0.2"
   }
 }


### PR DESCRIPTION
## Description
Electron - Swift search - A JavaScript error displays when the user reloads the Electron while the file .lz4 is creating
[SEARCH-1059](https://perzoinc.atlassian.net/browse/SEARCH-1059)

![atula_01_error](https://user-images.githubusercontent.com/596478/48604393-c0e36500-e99f-11e8-8798-b5f516a6fb92.png)


## Solution Approach
Add try catch and this is anyways replaced by lz4 extraction.

## Documentation
N/A

## Related PRs
List related PRs against other branches / repositories:

branch | PR
------ | ------
Swift-Search | [PR](https://github.com/symphonyoss/SwiftSearch/pull/6)

## QA Checklist
- [x] Unit-Tests

Attach unit in PDF format against the above task lists for this branch
