### PR TITLE
ELECTRON-825: fix typo in screen-sharing permissions message

### DIFF
--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -295,7 +295,7 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
 
         if (config && config.permissions) {
             const permission = ' screen sharing';
-            const fullMessage = i18n.getMessageFor('Your administrator has disabled') + permission + '. ' + i18n.getMessageFor('Please contact your admin for help');
+            const fullMessage = i18n.getMessageFor('Your administrator has disabled ') + permission + '. ' + i18n.getMessageFor('Please contact your admin for help');
             const dialogContent = { type: 'error', title: i18n.getMessageFor('Permission Denied') + '!', message: fullMessage };
             mainWindow.webContents.send('is-screen-share-enabled', config.permissions.media, dialogContent);
         }


### PR DESCRIPTION
## Description
Fix typo in a permissions message related to screen-sharing permissions [ELECTRON-825](https://perzoinc.atlassian.net/browse/ELECTRON-825)

## Solution Approach
Update the strings

## Documentation
N/A

## Related PRs
N/A

## QA Checklist
- [x] Unit-Tests
[ELECTRON-825 Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2641861/ELECTRON-825.Unit.Tests.pdf)
