### PR TITLE
ELECTRON-899: add dev tools to menu & ELECTRON-905: read dev tools config dynamically

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -395,6 +395,11 @@ function readConfigFileSync() {
     
 }
 
+const readConfigFromFile = (key) => {
+    let data = readConfigFileSync();
+    return data[key];
+}
+
 module.exports = {
 
     configFileName,
@@ -411,6 +416,7 @@ module.exports = {
     clearCachedConfigs,
     
     readConfigFileSync,
+    readConfigFromFile,
 
     // use only if you specifically need to read global config fields
     getGlobalConfigField,

--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const electron = require('electron');
 
-const { updateConfigField, getMultipleConfigField } = require('../config.js');
+const { updateConfigField, getMultipleConfigField, readConfigFromFile } = require('../config.js');
 const { isMac, isWindowsOS } = require('../utils/misc.js');
 const archiveHandler = require('../utils/archiveHandler');
 const log = require('../log.js');
@@ -189,6 +189,24 @@ function getTemplate(app) {
                                             });
                                         }
                                     });
+                            }
+                        },
+                        {
+                            label: 'Toggle Developer Tools',
+                            accelerator: isMac ? 'Alt+Command+I' : 'Ctrl+Shift+I',
+                            click(item, focusedWindow) {
+                                let devToolsEnabled = readConfigFromFile('devToolsEnabled');
+                                if (focusedWindow && devToolsEnabled) {
+                                    focusedWindow.webContents.toggleDevTools();
+                                } else {
+                                    log.send(logLevels.INFO, `dev tools disabled for ${focusedWindow.winName} window`);                                    
+                                    electron.dialog.showMessageBox(focusedWindow, {
+                                        type: 'warning',
+                                        buttons: ['Ok'],
+                                        title: i18n.getMessageFor('Dev Tools disabled'),
+                                        message: i18n.getMessageFor('Dev Tools has been disabled! Please contact your system administrator to enable it!'),
+                                    });
+                                }
                             }
                         },
                         {

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -20,7 +20,7 @@ const logLevels = require('./enums/logLevels.js');
 const notify = require('./notify/electron-notify.js');
 const eventEmitter = require('./eventEmitter');
 const throttle = require('./utils/throttle.js');
-const { getConfigField, updateConfigField, readConfigFileSync, getMultipleConfigField } = require('./config.js');
+const { getConfigField, updateConfigField, readConfigFileSync, getMultipleConfigField, readConfigFromFile } = require('./config.js');
 const { isMac, isWindowsOS, isDevEnv } = require('./utils/misc');
 const { isWhitelisted, parseDomain } = require('./utils/whitelistHandler');
 const { initCrashReporterMain, initCrashReporterRenderer } = require('./crashReporter.js');
@@ -614,8 +614,7 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
 
         function devTools() {
             const focusedWindow = BrowserWindow.getFocusedWindow();
-
-            
+            devToolsEnabled = readConfigFromFile('devToolsEnabled');
             if (focusedWindow && !focusedWindow.isDestroyed()) {
                 if (devToolsEnabled) {
                     focusedWindow.webContents.toggleDevTools();


### PR DESCRIPTION
## Description
[ELECTRON-899](https://perzoinc.atlassian.net/browse/ELECTRON-899): Add dev tools as a menu item to the "Troubleshooting" menu under "Help" so users can easily access the dev tools.
[ELECTRON-905](https://perzoinc.atlassian.net/browse/ELECTRON-899): Dynamically read the dev tools config (to enable / disable) to ensure important data is not missed while troubleshooting.

## Solution Approach
- Add menu item in menu template
- Read config file dynamically for dev tools config

## Documentation
N/A

## Related PRs
N/A

## QA Checklist
- [x] Unit-Tests
[ELECTRON-899 Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2641857/ELECTRON-899.Unit.Tests.pdf)
