### PR TITLE
Change node-ffi base fork to symphonyoss

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "electron-dl": "1.12.0",
     "electron-log": "2.2.17",
     "electron-spellchecker": "git+https://github.com/KiranNiranjan/electron-spellchecker.git#v3.0.6",
-    "ffi": "git+https://github.com/keerthi16/node-ffi.git#v1.2.8",
+    "ffi": "git+https://github.com/symphonyoss/node-ffi.git#v1.2.8",
     "filesize": "3.6.1",
     "keymirror": "0.1.1",
     "lodash.difference": "4.5.0",
@@ -130,6 +130,6 @@
   },
   "optionalDependencies": {
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.3",
-    "swift-search": "2.0.2"
+    "swift-search": "2.0.3"
   }
 }


### PR DESCRIPTION
## Description
Change node-ffi base fork to symphonyoss

Bump swift-search version which now also uses symphonyoss.

## QA Checklist
- [x] Unit-Tests
- [ ] Automation-Tests

Attach unit & spectron tests results in PDF format against the above task lists for this branch
[Symphony Electron Test Result.pdf](https://github.com/symphonyoss/SwiftSearch/files/2671788/Symphony.Electron.Test.Result.pdf)