### PR TITLE
ELECTRON-955 - fixing toast notification does not show on top of the Electron after it is minimized and maximized again

### DIFF
--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -122,6 +122,25 @@ function createMainWindow(initialUrl) {
 }
 
 /**
+ * ELECTRON-955: Always on Top - Toast notification does not show on top (front) of the Electron app after it is minimized and maximized again
+ * Bring to front all notification windows
+ */
+function bringToFrontNotification() {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+        let allBrowserWindows = BrowserWindow.getAllWindows();
+        const notificationWindow = allBrowserWindows.filter((item) => item.winName === 'notification-window');
+        if (mainWindow.isAlwaysOnTop()) {
+            notificationWindow.forEach((item) => {
+                if (item && !item.isDestroyed()) {
+                    item.setAlwaysOnTop(true);
+                }
+            });
+        }
+    }
+}
+
+
+/**
  * Creates the main window with bounds
  * @param initialUrl
  * @param initialBounds
@@ -758,6 +777,7 @@ function saveMainWinBounds() {
     if (mainWindow && !mainWindow.isDestroyed()) {
         newBounds.isMaximized = mainWindow.isMaximized();
         newBounds.isFullScreen = mainWindow.isFullScreen();
+        bringToFrontNotification();
     }
 
     if (newBounds) {


### PR DESCRIPTION
## Description
Toast notification does not show on top (front) of the Electron app after it is minimized and maximized again [ELECTRON-955](https://perzoinc.atlassian.net/browse/ELECTRON-955)

## Fix
![electron-955](https://user-images.githubusercontent.com/9887288/49888542-661a1d80-fe26-11e8-834a-09f408cc12fa.gif)


## QA Checklist
- [x] Unit-Tests
- [ ] Automation-Tests

Attach unit & spectron tests results in PDF format against the above task lists for this branch
[Symphony Electron Test Result.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2672985/Symphony.Electron.Test.Result.pdf)
