### PR TITLE
ELECTRON-956 - removing the minimize and maximize from the configure desktop alert position

### DIFF
--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -441,8 +441,8 @@ function getTemplate(app) {
         // This adds About Symphony under help menu for windows
         template[3].submenu.push({
             label: i18n.getMessageFor('About Symphony'),
-            click(focusedWindow) {
-                let windowName = focusedWindow ? focusedWindow.name : '';
+            click(menuItem, focusedWindow) {
+                let windowName = focusedWindow ? focusedWindow.winName : '';
                 aboutApp.openAboutWindow(windowName);
             }
         });

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -504,6 +504,7 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
                     newWinOptions.minHeight = MIN_HEIGHT;
                     newWinOptions.alwaysOnTop = alwaysOnTop;
                     newWinOptions.frame = true;
+                    newWinOptions.parent = null;
 
                     let newWinKey = getGuid();
 
@@ -794,6 +795,19 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
     }
 
 }
+
+/**
+ * ELECTRON-956: App is not minimized upon "Configure Desktop Alert Position" modal when "Always on Top" = True
+ */
+app.on('browser-window-created', (event, window) => {
+    const parentWindow = window.getParentWindow();
+    if (parentWindow && !parentWindow.isDestroyed()) {
+        if (parentWindow.winName === 'main') {
+            window.setMinimizable(false);
+            window.setMaximizable(false);
+        }
+    }
+});
 
 /**
  * Handles the event before-quit emitted by electron


### PR DESCRIPTION
## Description
App is not minimized upon "Configure Desktop Alert Position" modal when "Always on Top" = True.  [ELECTRON-956](https://perzoinc.atlassian.net/browse/ELECTRON-956)

## Fix
![electron](https://user-images.githubusercontent.com/9887288/49892582-76cf9100-fe30-11e8-93ca-0cb31ccb6f24.png)

## QA Checklist
- [x] Unit-Tests
- [ ] Automation-Tests

Attach unit & spectron tests results in PDF format against the above task lists for this branch
[UnitTest.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2673191/UnitTest.pdf)
