### PR TITLE
ELECTRON-978 (Implement native file picker modal window)

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -70,6 +70,12 @@
         <button id='clear-badge'>clear badge count</button>
         <br>
         <hr>
+        <br>
+        <p> Native file picker modal</p>
+        <button id="file-picker">Choose a file</button>
+        <img id="test-image" width="150px" height="150px"/>
+        <hr>
+        <br>
         <p>Screen Snippet:</p>
         <button id='snippet'>get snippet</button>
         <p>snippet output:</p>
@@ -115,6 +121,19 @@
         openConfigWin.addEventListener('click', function() {
             ssf.showNotificationSettings();
         });
+
+        document.getElementById('file-picker').onclick = () => {
+            ssf.openFilePicker({
+                type: 'openFile',
+                title: 'test',
+                multiSelect: false,
+                filters: [{
+                    name: 'test',
+                    extensions: ['JPG', 'TXT', 'ai'] }]
+            }, (files) => {
+                document.getElementById('test-image').src = URL.createObjectURL(files[0]);
+            });
+        };
 
         var notfEl = document.getElementById('notf');
         var num = 0;

--- a/js/preload/preloadMain.js
+++ b/js/preload/preloadMain.js
@@ -249,15 +249,26 @@ function createAPI() {
                 const browserWindow = remote.getCurrentWindow();
                 const { type, title, defaultPath, multiSelect, filters } = options;
                 const properties = [ type ];
-                if (multiSelect) properties.push('multiSelections');
+                if (multiSelect) {
+                    properties.push('multiSelections');
+                }
                 remote.dialog.showOpenDialog(browserWindow, { title, defaultPath, properties, filters }, (filePaths) => {
-                    if (!filePaths) return;
+                    if (!filePaths) {
+                        return;
+                    }
                     const files = filePaths.map((file) => {
                         const mimeType = mime.lookup(file);
                         const filename = file.substring(file.lastIndexOf('/') + 1);
-                        return new File([ fs.readFileSync(file) ], filename, { type: mimeType });
+                        return readFile(file, filename, mimeType);
                     });
-                    callback(files);
+                    function readFile(file, filename, mimeType) {
+                        return new Promise(resolve => {
+                            return fs.readFile(file, (err, content) => {
+                                return resolve(new File([ content ], filename, { type: mimeType }))
+                            });
+                        });
+                    }
+                    Promise.all(files).then((fileObjects) => callback(fileObjects));
                 });
             }
         },

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "lodash.isequal": "4.5.0",
     "lodash.omit": "4.5.0",
     "lodash.pick": "4.4.0",
+    "mime-types": "2.1.21",
     "node-osascript": "2.1.0",
     "ref": "1.3.5",
     "shell-path": "2.1.0",


### PR DESCRIPTION
## Description
Exposes an API to the web app to open a native file picker modal [ELECTRON-978](https://perzoinc.atlassian.net/browse/ELECTRON-978)

## Solution Approach
Expose an API which invokes `dialog.showOpenDialog` inturn


## Screenshot
![screenshot 2018-12-26 at 5 24 56 pm](https://user-images.githubusercontent.com/13243259/50445249-5543ce80-0933-11e9-9614-68650982d72d.png)


## Related PRs
List related PRs against other branches / repositories:

branch | PR
------ | ------
SFE-Client-App | [#13157](https://github.com/SymphonyOSF/SFE-Client-App/pull/13157)
SFE-Packages | [#2239](https://github.com/SymphonyOSF/SFE-Packages/pull/2239)

## QA Checklist
- [X] Unit-Tests
- [ ] Automation-Tests