### PR TITLE
ELECTRON-839: add logic to set custom logs folder

### DIFF
--- a/js/log.js
+++ b/js/log.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const util = require('util');
 
-const {app} = require('electron');
+const { app } = require('electron');
 const path = require('path');
 const getCmdLineArg = require('./utils/getCmdLineArg.js');
 const logLevels = require('./enums/logLevels.js');
@@ -105,7 +105,15 @@ let loggerInstance = new Logger();
  * Initializes the electron logger for local logging
  */
 function initializeLocalLogger() {
-// eslint-disable-next-line global-require
+
+    // If the user has specified a custom log path use it.
+    let customLogPathArg = getCmdLineArg(process.argv, '--logPath=', false);
+    let customLogsFolder = customLogPathArg && customLogPathArg.substring(customLogPathArg.indexOf('=') + 1);
+
+    if (customLogsFolder && fs.existsSync(customLogsFolder)) {
+        app.setPath('logs', customLogsFolder);
+    }
+    // eslint-disable-next-line global-require
     electronLog = require('electron-log');
     const logPath = app.getPath('logs');
     cleanupOldLogs(logPath);


### PR DESCRIPTION
## Description
To gather data from multiple instances, sometimes, we would need to have different logs folder for different instances. 
We add support for setting custom logs folder via command line with this PR.
[ELECTRON-839](https://perzoinc.atlassian.net/browse/ELECTRON-839)

## Solution Approach
Read command line arguments and set the appropriate value as the log path

## Documentation
https://perzoinc.atlassian.net/wiki/spaces/DES/pages/414810426/Electron+Feature+-+Command+Line+Arguments

## Related PRs
N/A

## QA Checklist
- [x] Unit-Tests
[ELECTRON-839 Unit Tests.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2723311/ELECTRON-839.Unit.Tests.pdf)