### PR TITLE
ELECTRON-826 (Change the focusing logic for Window)

### DIFF
--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -890,26 +890,25 @@ function activate(windowName, shouldFocus = true) {
         return null;
     }
 
-    let keys = Object.keys(windows);
-    for (let i = 0, len = keys.length; i < len; i++) {
-        let window = windows[keys[i]];
-        if (window && !window.isDestroyed() && window.winName === windowName) {
+    for (const key in windows) {
+        if (Object.prototype.hasOwnProperty.call(windows, key)) {
+            const window = windows[ key ];
+            if (window && !window.isDestroyed() && window.winName === windowName) {
 
-            // Flash task bar icon in Windows
-            if (isWindowsOS && !shouldFocus) {
-                return window.flashFrame(true);
+                // Bring the window to the top without focusing
+                // Flash task bar icon in Windows for windows
+                if (!shouldFocus) {
+                    return isMac ? window.showInactive() : window.flashFrame(true);
+                }
+
+                // Note: On window just focusing will preserve window snapped state
+                // Hiding the window and just calling the focus() won't display the window
+                if (isWindowsOS) {
+                    return window.isMinimized() ? window.restore() : window.focus();
+                }
+
+                return window.isMinimized() ? window.restore() : window.show();
             }
-
-            // brings window without giving focus on mac
-            if (isMac && !shouldFocus) {
-                return window.showInactive();
-            }
-
-            if (window.isMinimized()) {
-                return window.restore();
-            }
-
-            return window.show();
         }
     }
     return null;


### PR DESCRIPTION
## Description
Change the window focusing logic for Windows to preserve the window snapped state [ELECTRON-826](https://perzoinc.atlassian.net/browse/ELECTRON-826)

## Solution Approach
Use the Focus method instead of the show method to preserve the window snapped state

## Before
![2019-01-09 12 46 34](https://user-images.githubusercontent.com/13243259/50883016-c5128880-140c-11e9-9bc0-aa90cf935d76.gif)

## After
![2019-01-09 12 43 18](https://user-images.githubusercontent.com/13243259/50883034-cd6ac380-140c-11e9-9431-23c00887860f.gif)


## QA Checklist
- [X] Unit-Tests
- [ ] Automation-Tests