### PR TITLE
ELECTRON-816: add checks for crash events when it is killed

### DIFF
--- a/js/aboutApp/index.js
+++ b/js/aboutApp/index.js
@@ -95,7 +95,14 @@ function openAboutWindow(windowName) {
         }
     });
 
-    aboutWindow.webContents.on('crashed', function () {
+    aboutWindow.webContents.on('crashed', function (event, killed) {
+
+        log.send(logLevels.INFO, `About Window crashed! Killed? ${killed}`);
+
+        if (killed) {
+            return;
+        }
+
         const options = {
             type: 'error',
             title: i18n.getMessageFor('Renderer Process Crashed'),

--- a/js/basicAuth/index.js
+++ b/js/basicAuth/index.js
@@ -111,7 +111,14 @@ function openBasicAuthWindow(windowName, hostname, isValidCredentials, clearSett
         }
     });
 
-    basicAuthWindow.webContents.on('crashed', function () {
+    basicAuthWindow.webContents.on('crashed', function (event, killed) {
+
+        log.send(logLevels.INFO, `Basic Auth Window crashed! Killed? ${killed}`);
+
+        if (killed) {
+            return;
+        }
+
         const options = {
             type: 'error',
             title: i18n.getMessageFor('Renderer Process Crashed'),

--- a/js/desktopCapturer/index.js
+++ b/js/desktopCapturer/index.js
@@ -106,7 +106,14 @@ function openScreenPickerWindow(eventSender, sources, id) {
         screenPickerWindow.webContents.send('desktop-capturer-sources', sources, isWindowsOS);
     });
 
-    screenPickerWindow.webContents.on('crashed', function () {
+    screenPickerWindow.webContents.on('crashed', function (event, killed) {
+
+        log.send(logLevels.INFO, `Screen Picker Window crashed! Killed? ${killed}`);
+
+        if (killed) {
+            return;
+        }
+
         const options = {
             type: 'error',
             title: i18n.getMessageFor('Renderer Process Crashed'),

--- a/js/moreInfo/index.js
+++ b/js/moreInfo/index.js
@@ -95,7 +95,14 @@ function openMoreInfoWindow(windowName) {
         }
     });
 
-    moreInfoWindow.webContents.on('crashed', function () {
+    moreInfoWindow.webContents.on('crashed', function (event, killed) {
+
+        log.send(logLevels.INFO, `More Info Window crashed! Killed? ${killed}`);
+
+        if (killed) {
+            return;
+        }
+
         const options = {
             type: 'error',
             title: i18n.getMessageFor('Renderer Process Crashed'),

--- a/js/screenSharingIndicator/index.js
+++ b/js/screenSharingIndicator/index.js
@@ -69,7 +69,14 @@ function openScreenSharingIndicator(eventSender, displayId, id) {
         });
     });
 
-    indicatorWindow.webContents.on('crashed', () => {
+    indicatorWindow.webContents.on('crashed', (event, killed) => {
+
+        log.send(logLevels.INFO, `Screen Sharing Indicator Window crashed! Killed? ${killed}`);
+
+        if (killed) {
+            return;
+        }
+
         const errorDialogOptions = {
             type: 'error',
             title: i18n.getMessageFor('Renderer Process Crashed'),
@@ -83,7 +90,7 @@ function openScreenSharingIndicator(eventSender, displayId, id) {
         if (indicatorId === id) {
             eventSender.send('stop-sharing-requested', id);
         }
-    }
+    };
 
     const handleDestroyScreensharingIndicator = (event, indicatorId) => {
         if (indicatorId === id) {

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -327,7 +327,14 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
 
     // In case a renderer process crashes, provide an
     // option for the user to either reload or close the window
-    mainWindow.webContents.on('crashed', function () {
+    mainWindow.webContents.on('crashed', function (event, killed) {
+
+        log.send(logLevels.INFO, `Main Window crashed! Killed? ${killed}`);
+
+        if (killed) {
+            return;
+        }
+
         const options = {
             type: 'error',
             title: i18n.getMessageFor('Renderer Process Crashed'),
@@ -506,8 +513,12 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
                             browserWin.setAlwaysOnTop(alwaysOnTop);
                             logBrowserWindowEvents(browserWin, browserWin.winName);
 
-                            let handleChildWindowCrashEvent = (e) => {
-                                log.send(logLevels.INFO, `Child Window crashed!`);
+                            let handleChildWindowCrashEvent = (e, killed) => {
+                                log.send(logLevels.INFO, `Child Window crashed! Killed? ${killed}`);
+
+                                if (killed) {
+                                    return;
+                                }
                                 const options = {
                                     type: 'error',
                                     title: i18n.getMessageFor('Renderer Process Crashed'),
@@ -996,7 +1007,7 @@ function isAlwaysOnTop(boolean, shouldActivateMainWindow = true) {
 }
 
 // node event emitter to update always on top
-eventEmitter.on('isAlwaysOnTop', (params) => {    
+eventEmitter.on('isAlwaysOnTop', (params) => {
     isAlwaysOnTop(params.isAlwaysOnTop, params.shouldActivateMainWindow);
     log.send(logLevels.INFO, `Updating settings for always on top ${params}`);
 });


### PR DESCRIPTION
## Description
Currently on Windows, when the app is killed, a crash event is emitted which sends the wrong signal to the user that the app actually crashed which isn't the case because the app was in fact killed. So, this PR adds an extra check to see if the app was killed and shows the crash dialog based on that.

[ELECTRON-816](https://perzoinc.atlassian.net/browse/ELECTRON-816)

## Solution Approach
Adds an extra check to see if the app was killed and shows the crash dialog based on that

## Documentation
N/A

## Related PRs
N/A

## QA Checklist
- [x] Unit-Tests
[ELECTRON-816 Unit Test Results.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2745156/ELECTRON-816.Unit.Test.Results.pdf)
