### PR TITLE
ELECTRON-989: fix sso checkbox refresh

### DIFF
--- a/installer/win/Symphony-x64.aip
+++ b/installer/win/Symphony-x64.aip
@@ -580,6 +580,7 @@
     <ROW Dialog_="InstallationDlg" Control_="SsoCheckbox" Event="[POD_URL]" Argument="[POD_URL]/login/sso/initsso" Condition="AI_INSTALL AND ( SSO_CHECKBOX )" Ordering="0"/>
     <ROW Dialog_="InstallationDlg" Control_="SsoCheckbox" Event="DoAction" Argument="SsoCheckbox" Condition="AI_INSTALL AND ( NOT SSO_CHECKBOX )" Ordering="1"/>
     <ROW Dialog_="InstallationDlg" Control_="SsoCheckbox" Event="[AiRefreshDlg]" Argument="1" Condition="AI_INSTALL AND ( NOT SSO_CHECKBOX )" Ordering="2"/>
+    <ROW Dialog_="InstallationDlg" Control_="SsoCheckbox" Event="[AiRefreshDlg]" Argument="0" Condition="AI_INSTALL AND ( SSO_CHECKBOX )" Ordering="3"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiCreateFolderComponent">
     <ROW Directory_="Symphony_Dir" Component_="Symphony" ManualDelete="false"/>

--- a/installer/win/Symphony-x86.aip
+++ b/installer/win/Symphony-x86.aip
@@ -569,6 +569,7 @@
     <ROW Dialog_="InstallationDlg" Control_="SsoCheckbox" Event="[POD_URL]" Argument="[POD_URL]/login/sso/initsso" Condition="AI_INSTALL AND ( SSO_CHECKBOX )" Ordering="0"/>
     <ROW Dialog_="InstallationDlg" Control_="SsoCheckbox" Event="DoAction" Argument="SsoCheckbox" Condition="AI_INSTALL AND ( NOT SSO_CHECKBOX )" Ordering="1"/>
     <ROW Dialog_="InstallationDlg" Control_="SsoCheckbox" Event="[AiRefreshDlg]" Argument="1" Condition="AI_INSTALL AND ( NOT SSO_CHECKBOX )" Ordering="2"/>
+    <ROW Dialog_="InstallationDlg" Control_="SsoCheckbox" Event="[AiRefreshDlg]" Argument="0" Condition="AI_INSTALL AND ( SSO_CHECKBOX )" Ordering="3"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiCreateFolderComponent">
     <ROW Directory_="Symphony_Dir" Component_="Symphony" ManualDelete="false"/>


### PR DESCRIPTION
## Description
When sso checkbox was checked, the dialog was not being refreshed which resulted in the pod url text box not being updated. Now, we refresh the dialog when the SSO checkbox is checked or unchecked both.
[ELECTRON-989](https://perzoinc.atlassian.net/browse/ELECTRON-989)

## Solution Approach
Refresh the dialog when the SSO checkbox is checked or unchecked both.

### Before
![electron-989 before](https://user-images.githubusercontent.com/5968790/51029068-4576ec00-15bb-11e9-8d0b-3980702a6a9e.gif)

### After
![electron-989 after](https://user-images.githubusercontent.com/5968790/51028925-e1ecbe80-15ba-11e9-8fae-0398480ee292.gif)

## Documentation
N/A

## Related PRs
N/A

## QA Checklist
- [x] Unit-Tests
[ELECTRON-989 Unit Tests Report.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2749218/ELECTRON-989.Unit.Tests.Report.pdf)
