### PR TITLE
ELECTRON-1003: fix menuitems with roles default

### DIFF
--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -528,8 +528,8 @@ function buildMenuItem(role, label) {
     }
 
     if (isWindowsOS) {
-        return label ? { role: role, label: label, accelerator: windowsAccelerator[role] || '' }
-            : { role: role, accelerator: windowsAccelerator[role] || '' }
+        return label ? { role: role, label: label, accelerator: windowsAccelerator[role] || '', registerAccelerator: true }
+            : { role: role, accelerator: windowsAccelerator[role] || '', registerAccelerator: true }
     }
 
     return label ? { role: role, label: label } : { role: role }


### PR DESCRIPTION
## Description
Hamburger Menu - Window: Close option does not work when triggering with shortcut (Ctrl+W). [ELECTRON-1003](https://perzoinc.atlassian.net/browse/ELECTRON-1003)

## Solution Approach
The keyboard shortcut stopped work in v4 any menu item with default role are not registered by default. 
To force registration the registerAccelerator was set to true.
More information in https://github.com/electron/electron/issues/16303

## Screenshot
![electron-1003](https://user-images.githubusercontent.com/9887288/51036387-16994f80-1594-11e9-978d-efffd4761bc8.gif)

## QA Checklist
- [x] Unit-Tests
- [ ] Automation-Tests

Attach unit & spectron tests results in PDF format against the above task lists for this branch
[Symphony Electron Test Result.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2749714/Symphony.Electron.Test.Result.pdf)
