### PR TITLE
ELECTRON-869 (Enable spellchecker for main window)

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -50,8 +50,6 @@ require('./mainApiMgr.js');
 require('./memoryMonitor.js');
 
 const windowMgr = require('./windowMgr.js');
-const SpellChecker = require('./spellChecker').SpellCheckHelper;
-const spellchecker = new SpellChecker();
 const { ContextMenuBuilder } = require('electron-spellchecker');
 const i18n = require('./translation/i18n');
 
@@ -252,6 +250,7 @@ app.on('web-contents-created', function (event, webContents) {
 });
 
 function onWebContent(webContents) {
+    const spellchecker = windowMgr.getSpellchecker();
     spellchecker.initializeSpellChecker();
     spellchecker.updateContextMenuLocale(i18n.getMessageFor('ContextMenu'));
     const contextMenuBuilder = new ContextMenuBuilder(spellchecker.spellCheckHandler, webContents, false, spellchecker.processMenu.bind(spellchecker));

--- a/js/mainApiMgr.js
+++ b/js/mainApiMgr.js
@@ -180,6 +180,13 @@ electron.ipcMain.on(apiName, (event, arg) => {
                 windowMgr.handleKeyPress(arg.keyCode);
             }
             break;
+        case apiCmds.isMisspelled:
+            if (typeof arg.text === 'string') {
+                /* eslint-disable no-param-reassign */
+                event.returnValue = windowMgr.isMisspelled(arg.text);
+                /* eslint-enable no-param-reassign */
+            }
+            break;
         case apiCmds.openScreenSharingIndicator:
             if (typeof arg.displayId === 'string' && typeof arg.id === 'number') {
                 openScreenSharingIndicator(event.sender, arg.displayId, arg.id);

--- a/js/spellChecker/index.js
+++ b/js/spellChecker/index.js
@@ -95,6 +95,16 @@ class SpellCheckHelper {
         return menu;
     }
 
+    /**
+     * Method that checks if a text is misspelled
+     *
+     * @param text {string}
+     * @returns {*}
+     */
+    isMisspelled(text) {
+        return this.spellCheckHandler.isMisspelled(text);
+    }
+
 }
 
 module.exports = {

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -27,6 +27,9 @@ const { initCrashReporterMain, initCrashReporterRenderer } = require('./crashRep
 const i18n = require('./translation/i18n');
 const getCmdLineArg = require('./utils/getCmdLineArg');
 
+const SpellChecker = require('./spellChecker').SpellCheckHelper;
+const spellchecker = new SpellChecker();
+
 // show dialog when certificate errors occur
 require('./dialogs/showCertError.js');
 require('./dialogs/showBasicAuth.js');
@@ -98,6 +101,27 @@ function getParsedUrl(appUrl) {
     }
     let url = nodeURL.format(parsedUrl);
     return nodeURL.parse(url);
+}
+
+/**
+ * Returns the Spellchecker instance
+ * @returns {SpellCheckHelper}
+ */
+function getSpellchecker() {
+    return spellchecker;
+}
+
+/**
+ * Method that invokes native module that
+ * verifies missed spelled word
+ * @param text {string}
+ * @returns {*}
+ */
+function isMisspelled(text) {
+    if (!spellchecker) {
+        return false;
+    }
+    return spellchecker.isMisspelled(text);
 }
 
 /**
@@ -1270,4 +1294,6 @@ module.exports = {
     cleanUpChildWindows: cleanUpChildWindows,
     setLocale: setLocale,
     getIsOnline: getIsOnline,
+    getSpellchecker: getSpellchecker,
+    isMisspelled: isMisspelled,
 };


### PR DESCRIPTION
## Description
Enables spellchecker for main window [link](https://perzoinc.atlassian.net/browse/ELECTRON-869)

## Solution Approach
Enable spellchecker only for the main window until the underline memory leak is fixed on electron
https://github.com/electron/electron/issues/15459

## Screen shot
![screenshot 2019-01-14 at 4 29 48 pm](https://user-images.githubusercontent.com/13243259/51109072-1316fa00-181a-11e9-80d3-531b744169f6.png)


## Related PRs
List related PRs against other branches / repositories:

branch | PR
------ | ------
Electron | [Issue](https://github.com/electron/electron/issues/15459)

## QA Checklist
- [X] Unit-Tests
[Symphony Electron Test Result.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2754871/Symphony.Electron.Test.Result.pdf)

- [ ] Automation-Tests