### PR TITLE
ELECTRON-903: fixing the notification text overflowing under user avatar

### DIFF
--- a/js/notify/electron-notify.js
+++ b/js/notify/electron-notify.js
@@ -130,6 +130,8 @@ let config = {
         webkitBoxOrient: 'vertical',
         cursor: 'default',
         textOverflow: 'ellipsis',
+        width: '100%',
+        overflowWrap: 'break-word',
     },
     defaultStyleLogoContainer: {
         display: 'flex',


### PR DESCRIPTION
## Description
Notification text overflows under user avatar [ELECTRON-903](https://perzoinc.atlassian.net/browse/ELECTRON-903)
When a message is sufficiently long, the text of the message overflows under the user's avatar and blocks a good chunk of the message.

## Fix
- before 
![before](https://user-images.githubusercontent.com/9887288/51113521-586f0380-17e9-11e9-9493-7bc14fe347e8.png)

- after 
![after](https://user-images.githubusercontent.com/9887288/51113524-5ad15d80-17e9-11e9-914f-7c0c7cd33b04.png)

## QA Checklist
- [x] Unit-Tests
- [ ] Automation-Tests

Attach unit & spectron tests results in PDF format against the above task lists for this branch
[Symphony Electron Test Result.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2756041/Symphony.Electron.Test.Result.pdf)
