### PR TITLE
SEARCH-1243 (Electron crashing after 54 pushed to corp on Thursday, Jan 10, 2019)

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,6 @@
   },
   "optionalDependencies": {
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.3",
-    "swift-search": "2.0.3"
+    "swift-search": "2.0.4"
   }
 }


### PR DESCRIPTION
## Description
Electron crashing after 54 pushed to corp on Thursday, Jan 10, 2019
[SEARCH-1243](https://perzoinc.atlassian.net/browse/SEARCH-1243)

## Solution Approach
The cause of the crash is still unknown. But this PR is just to re-create the index

## Documentation
N/A

## Related PRs
List related PRs against other branches / repositories:

branch | PR
------ | ------
Swift-Search | [link](https://github.com/symphonyoss/SwiftSearch/pull/8)

## QA Checklist
- [x] Unit-Tests
- [ ] Automation-Tests

![screenshot 2019-01-15 at 2 39 02 pm](https://user-images.githubusercontent.com/596478/51170209-dd364c00-18d3-11e9-9ac2-0ca8f7d59076.png)