### PR TITLE
SEARCH-1243 - Electron crashing after 54 pushed to corp on Thursday, Jan 10, 2019.

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,6 @@
   },
   "optionalDependencies": {
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.3",
-    "swift-search": "2.0.3"
+    "swift-search": "2.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -129,6 +129,6 @@
   },
   "optionalDependencies": {
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.3",
-    "swift-search": "2.0.4"
+    "swift-search": "3.0.0"
   }
 }


### PR DESCRIPTION
## Description
Electron crashing after 54 pushed to corp on Thursday, Jan 10, 2019.
[SEARCH-1243](https://perzoinc.atlassian.net/browse/SEARCH-1243)

## Solution Approach
The fix is in the client app and this is just to clear the corrupted index.

## Documentation
N/A

## Related PRs
List related PRs against other branches / repositories:

Repo | Branch | PR #
------ | ------ | ------
SFE-Client-App | SEARCH-1243 | [PR #13335](https://github.com/SymphonyOSF/SFE-Client-App/pull/13335)
SwiftSearch | SEARCH-1243-new | [PR #9](https://github.com/symphonyoss/SwiftSearch/pull/9)


## QA Checklist
- [x] Unit-Tests
- [ ] Automation-Tests