### PR TITLE
ELECTRON-992, ELECTRON-978: upgrade electron version to fix issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "browserify": "16.2.3",
     "chromedriver": "2.45.0",
     "cross-env": "5.2.0",
-    "electron": "4.0.1",
+    "electron": "4.0.2",
     "electron-builder": "20.38.4",
     "electron-builder-squirrel-windows": "20.38.3",
     "electron-chromedriver": "4.0.0-beta.1",


### PR DESCRIPTION
## Description
Upgrading Electron to 4.0.2 resolves the following 2 issues:
-  Pop-outs crashing
- File dialog going to background. We use sheets in place of modals now.
[ELECTRON-992](https://perzoinc.atlassian.net/browse/ELECTRON-992)
[ELECTRON-978](https://perzoinc.atlassian.net/browse/ELECTRON-978)

## Solution Approach
Upgrade to electron version 4.0.2

## Documentation
N/A

## Related PRs
N/A

## QA Checklist
- [x] Unit-Tests
[ELECTRON-992-978 Unit Tests Report.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2786523/ELECTRON-992-978.Unit.Tests.Report.pdf)
