### PR TITLE
ELECTRON-769: removing context menu when right click on minimize, maximize and close button

### DIFF
--- a/js/windowsTitleBar/index.js
+++ b/js/windowsTitleBar/index.js
@@ -78,6 +78,9 @@ class TitleBar {
         attachEventListeners(this.closeButton, 'click', this.closeWindow.bind(this));
         attachEventListeners(this.maximizeButton, 'click', this.maximizeOrUnmaximize.bind(this));
         attachEventListeners(this.minimizeButton, 'click', this.minimize.bind(this));
+        attachEventListeners(this.minimizeButton, 'contextmenu', this.removeContextMenu.bind(this));
+        attachEventListeners(this.maximizeButton, 'contextmenu', this.removeContextMenu.bind(this));
+        attachEventListeners(this.closeButton, 'contextmenu', this.removeContextMenu.bind(this));
 
         attachEventListeners(this.hamburgerMenuButton, 'mousedown', TitleBar.handleMouseDown.bind(this));
         attachEventListeners(this.closeButton, 'mousedown', TitleBar.handleMouseDown.bind(this));
@@ -94,6 +97,18 @@ class TitleBar {
         this.minimizeButton.title = content.Minimize || 'Minimize';
         this.maximizeButton.title = content.Maximize || 'Maximize';
         this.closeButton.title = content.Close || 'Close';
+    }
+
+    /**
+     * Method that remove context menu
+     * ELECTRON-769: Hamburger Menu - Copy/ Reload in menu context displays when right 
+     * clicking on minimize, maximize, close button of the hamburger menu
+     *
+     */
+    // eslint-disable-next-line class-methods-use-this
+    removeContextMenu(event) {
+        event.preventDefault();
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Description
Hamburger Menu - Copy/ Reload in menu context displays when right clicking on minimize, maximize, close button of the hamburger menu. [ELECTRON-769](https://perzoinc.atlassian.net/browse/ELECTRON-769)

## Fix
- before
![atula_02](https://user-images.githubusercontent.com/9887288/51621317-67f1f900-1f1b-11e9-913b-7c15b342458d.gif)

- after
![electron](https://user-images.githubusercontent.com/9887288/51621338-72ac8e00-1f1b-11e9-8d41-4a3d4270a4db.gif)


## QA Checklist
- [x] Unit-Tests
- [ ] Automation-Tests

Attach unit & spectron tests results in PDF format against the above task lists for this branch
[Symphony Electron Test Result.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2788305/Symphony.Electron.Test.Result.pdf)
