### PR TITLE
ELECTRON-962: fix undesired javascript error

### DIFF
--- a/js/notify/electron-notify.js
+++ b/js/notify/electron-notify.js
@@ -687,7 +687,7 @@ function moveNotificationAnimation(i, done) {
  * @param posY
  */
 function setWindowPosition(browserWin, posX, posY) {
-    if (!browserWin.isDestroyed()) {
+    if (browserWin && !browserWin.isDestroyed()) {
         browserWin.setPosition(parseInt(posX, 10), parseInt(posY, 10))
     }
 }


### PR DESCRIPTION
## Description
When a notification’s position is changed and the browser window is destroyed, SDA throws up an undesired error message which is not apt for users to see. 
This was because of a validity check missing to see if the browser window still exists.
[ELECTRON-962](https://perzoinc.atlassian.net/browse/ELECTRON-962)

## Solution Approach
Add an extra check to see if the browser window is not null

## Documentation
N/A

## Related PRs
N/A

## QA Checklist
- [x] Unit-Tests
[ELECTRON-962 Unit Tests Report.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2790434/ELECTRON-962.Unit.Tests.Report.pdf)
