### PR TITLE
ELECTRON-1030: add localisation for about symphony window on Windows

### DIFF
--- a/js/aboutApp/index.js
+++ b/js/aboutApp/index.js
@@ -88,7 +88,12 @@ function openAboutWindow(windowName) {
         // initialize crash reporter
         initCrashReporterMain({ process: 'about app window' });
         initCrashReporterRenderer(aboutWindow, { process: 'render | about app window' });
-        aboutWindow.webContents.send('versionInfo', { version, clientVersion, buildNumber });
+        aboutWindow.webContents.send('versionInfo', { 
+            version,
+            clientVersion,
+            buildNumber,
+            i18n: i18n.getMessageFor('AboutSymphony')
+        });
         if (!isMac) {
             // prevents from displaying menu items when "alt" key is pressed
             aboutWindow.setMenu(null);

--- a/js/aboutApp/renderer.js
+++ b/js/aboutApp/renderer.js
@@ -21,10 +21,10 @@ ipcRenderer.on('versionInfo', (event, versionInfo) => {
     const versionText = document.getElementById('version');
     const { version, clientVersion, buildNumber, i18n } = versionInfo;
 
-    document.title = i18n['About Symphony'];    
+    document.title = i18n['About Symphony'] || 'About Symphony';
 
     if (versionText) {
-        versionText.innerHTML = version ? `${i18n.Version} ${clientVersion}-${version} (${buildNumber})` : 'N/A';
+        versionText.innerHTML = version ? `${i18n.Version || 'Version'} ${clientVersion}-${version} (${buildNumber})` : 'N/A';
     }
 });
 

--- a/js/aboutApp/renderer.js
+++ b/js/aboutApp/renderer.js
@@ -19,10 +19,12 @@ function renderDom() {
 
 ipcRenderer.on('versionInfo', (event, versionInfo) => {
     const versionText = document.getElementById('version');
-    const { version, clientVersion, buildNumber } = versionInfo;
+    const { version, clientVersion, buildNumber, i18n } = versionInfo;
+
+    document.title = i18n['About Symphony'];    
 
     if (versionText) {
-        versionText.innerHTML = version ? `Version ${clientVersion}-${version} (${buildNumber})` : 'N/A';
+        versionText.innerHTML = version ? `${i18n.Version} ${clientVersion}-${version} (${buildNumber})` : 'N/A';
     }
 });
 

--- a/locale/en-US.json
+++ b/locale/en-US.json
@@ -124,6 +124,10 @@
     "Pen": "Pen",
     "Snipping Tool": "Snipping Tool"
   },
+  "AboutSymphony": {
+    "About Symphony": "About Symphony",
+    "Version": "Version"
+  },
   "Select All": "Select All",
   "Services": "Services",
   "Show All": "Show All",

--- a/locale/en.json
+++ b/locale/en.json
@@ -124,6 +124,10 @@
     "Pen": "Pen",
     "Snipping Tool": "Snipping Tool"
   },
+  "AboutSymphony": {
+    "About Symphony": "About Symphony",
+    "Version": "Version"
+  },
   "Select All": "Select All",
   "Services": "Services",
   "Show All": "Show All",

--- a/locale/fr-FR.json
+++ b/locale/fr-FR.json
@@ -124,6 +124,10 @@
     "Pen": "Stylo",
     "Snipping Tool": "Outil Capture"
   },
+  "AboutSymphony": {
+    "About Symphony": "À propos de Symphony",
+    "Version": "Version"
+  },
   "Select All": "Tout sélectionner",
   "Services": "Services",
   "Show All": "Tout afficher",

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -124,6 +124,10 @@
     "Pen": "Stylo",
     "Snipping Tool": "Outil Capture"
   },
+  "AboutSymphony": {
+    "About Symphony": "À propos de Symphony",
+    "Version": "Version"
+  },
   "Select All": "Tout sélectionner",
   "Services": "Services",
   "Show All": "Tout afficher",

--- a/locale/ja-JP.json
+++ b/locale/ja-JP.json
@@ -124,6 +124,10 @@
     "Pen": "ペン",
     "Snipping Tool": "切り取りツール"
   },
+  "AboutSymphony": {
+    "About Symphony": "Symphonyについて",
+    "Version": "バージョン"
+  },
   "Select All": "すべてを選択",
   "Services": "サービス",
   "Show All": "すべてを表示",

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -124,6 +124,10 @@
     "Pen": "ペン",
     "Snipping Tool": "切り取りツール"
   },
+  "AboutSymphony": {
+    "About Symphony": "Symphonyについて",
+    "Version": "バージョン"
+  },
   "Select All": "すべてを選択",
   "Services": "サービス",
   "Show All": "すべてを表示",


### PR DESCRIPTION
## Description
Add localisation (japanese, french) for about symphony window on Windows 
[ELECTRON-1030](https://perzoinc.atlassian.net/browse/ELECTRON-1030)

## Solution Approach
N/A

## Documentation
N/A

## Related PRs
N/A

## QA Checklist
- [x] Unit-Tests
[ELECTRON-1030 Unit Tests Report.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2790555/ELECTRON-1030.Unit.Tests.Report.pdf)
