### PR TITLE
ELECTRON-1070: let electron handle protocol registration

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -49,6 +49,9 @@ require('./mainApiMgr.js');
 // monitor memory of main process
 require('./memoryMonitor.js');
 
+// adds 'symphony' as a protocol in the system. plist file in macOS
+app.setAsDefaultProtocolClient('symphony');
+
 const windowMgr = require('./windowMgr.js');
 const { ContextMenuBuilder } = require('electron-spellchecker');
 const i18n = require('./translation/i18n');
@@ -225,12 +228,7 @@ app.on('activate', function () {
     }
 });
 
-// adds 'symphony' as a protocol in the system. plist file in macOS
-
-// on windows, we create the protocol handler via the installer
-// because electron leaves registry traces upon uninstallation
 if (isMac) {
-    app.setAsDefaultProtocolClient('symphony');
     // Sets application version info that will be displayed in about app panel
     app.setAboutPanelOptions({ applicationVersion: `${clientVersion}-${version}`, version: buildNumber });
 }

--- a/js/main.js
+++ b/js/main.js
@@ -49,7 +49,8 @@ require('./mainApiMgr.js');
 // monitor memory of main process
 require('./memoryMonitor.js');
 
-// adds 'symphony' as a protocol in the system. plist file in macOS
+// adds 'symphony' as a protocol in the system.
+// plist file in macOS and registry entries on windows
 app.setAsDefaultProtocolClient('symphony');
 
 const windowMgr = require('./windowMgr.js');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Symphony",
   "productName": "Symphony",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "clientVersion": "1.54",
   "buildNumber": "0",
   "description": "Symphony desktop app (Foundation ODP)",


### PR DESCRIPTION
## Description
Because of [ELECTRON-805](https://perzoinc.atlassian.net/browse/ELECTRON-805), we weren't creating all the required registry entries on Windows for handling custom protocol in SDA. This PR addresses that issue.
[ELECTRON-1070](https://perzoinc.atlassian.net/browse/ELECTRON-1070)

## Solution Approach
N/A

## Documentation
N/A

## Related PRs
N/A

## QA Checklist
- [x] Unit-Tests
[ELECTRON-1070 Unit Tests Report.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2859729/ELECTRON-1070.Unit.Tests.Report.pdf)
