### PR TITLE
ELECTRON-1019: Enable spellchecker for popup window

### DIFF
--- a/js/preload/preloadMain.js
+++ b/js/preload/preloadMain.js
@@ -86,10 +86,6 @@ const throttledSetIsInMeetingStatus = throttle(1000, function (isInMeeting) {
 local.ipcRenderer.on('on-page-load', () => {
     snackBar = new SnackBar();
 
-    // Enable spellchecker only for main window until
-    // the underline memory leak is fixed on electron
-    // https://github.com/electron/electron/issues/15459
-    if (window.name === 'main') {
         webFrame.setSpellCheckProvider('en-US', true, {
             spellCheck (text) {
                 return !local.ipcRenderer.sendSync(apiName, {
@@ -98,7 +94,6 @@ local.ipcRenderer.on('on-page-load', () => {
                 });
             }
         });
-    }
 
     // only registers main window's preload
     if (window.name === 'main') {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "browserify": "16.2.3",
     "chromedriver": "2.45.0",
     "cross-env": "5.2.0",
-    "electron": "4.0.4",
+    "electron": "4.0.5",
     "electron-builder": "20.38.4",
     "electron-builder-squirrel-windows": "20.38.3",
     "electron-chromedriver": "4.0.0-beta.1",


### PR DESCRIPTION
## Description
Enable spellchecker to popup window [ELECTRON-1019](https://perzoinc.atlassian.net/browse/ELECTRON-1019)

## Solution Approach
N/A

## Documentation
Memory leak with use sandbox true and webFrame.setSpellCheckProvider [link](https://github.com/electron/electron/issues/15459)
Fix memory leak when using webFrame and spell checker (4-0-x) [link](https://github.com/electron/electron/pull/16772)

## Related PRs
N/A

## QA Checklist
- [x] Unit-Tests
- [ ] Automation-Tests

Attach unit & spectron tests results in PDF format against the above task lists for this branch