### PR TITLE
fixing Compiler error: Generic type ReactElement<P, T>

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@types/jest": "23.3.12",
     "@types/lodash.omit": "^4.5.4",
     "@types/node": "10.11.4",
-    "@types/react": "16.4.18",
+    "@types/react": "16.8.3",
     "@types/react-dom": "16.0.9",
     "babel-cli": "6.26.0",
     "babel-eslint": "7.2.3",


### PR DESCRIPTION
## Description
This error is shown when is executed: 

> npm run start

![Screen Shot 2019-03-11 at 10 06 43](https://user-images.githubusercontent.com/9887288/54127322-458f3e80-43e8-11e9-9d05-7f74c3aa9e68.png)

## Solution Approach
bump @types/react to 16.8.3 version

## Documentation
[enzyme Compiler error: Generic type 'ReactElement<P, T>' requires between 1 and 2 type arguments](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33048)

## QA Checklist
- [x] Unit-Tests
- [ ] Automation-Tests

