### PR TITLE
ELECTRON-1129 (Fix first time launch config update logic)

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -275,7 +275,7 @@ function updateUserConfig(oldUserConfig) {
  * Manipulates user config on first time launch
  * @returns {Promise}
  */
-function updateUserConfigOnLaunch() {
+function updateUserConfigOnLaunch(resolve, reject) {
     // we get the user config path using electron
     const userConfigFile = path.join(app.getPath('userData'), configFileName);
 
@@ -283,7 +283,7 @@ function updateUserConfigOnLaunch() {
     // user config file doesn't exist, we simple move on
     if (!fs.existsSync(userConfigFile)) {
         log.send(logLevels.WARN, 'config: Could not find the user config file!');
-        return Promise.reject(new Error('config: Could not find the user config file!'));
+        return reject(new Error('config: Could not find the user config file!'));
     }
 
     // In case the file exists, we remove it so that all the
@@ -294,9 +294,11 @@ function updateUserConfigOnLaunch() {
         const version = app.getVersion().toString() || '1.0.0';
         const updatedData = Object.assign(data || {}, { configVersion: version });
 
-        return updateUserConfig(updatedData);
+        updateUserConfig(updatedData)
+            .then(resolve)
+            .catch(reject);
     }).catch((err) => {
-        return Promise.reject(err);
+        return reject(err);
     });
 
 }

--- a/js/config.js
+++ b/js/config.js
@@ -265,6 +265,7 @@ function updateUserConfig(oldUserConfig) {
                 reject(new Error(`Failed to update user config error: ${err}`));
                 return;
             }
+            userConfig = newUserConfig;
             resolve();
         });
     });

--- a/js/main.js
+++ b/js/main.js
@@ -323,7 +323,7 @@ function checkFirstTimeLaunch() {
                 if (!(configVersion
                     && typeof configVersion === 'string'
                     && (compareSemVersions.check(appVersionString, configVersion) !== 1))) {
-                    return setupFirstTimeLaunch(reject, resolve, shouldUpdateUserConfig);
+                    return setupFirstTimeLaunch(resolve, reject, shouldUpdateUserConfig);
                 }
                 log.send(logLevels.INFO, `not a first-time launch as 
             configVersion: ${configVersion} appVersion: ${appVersionString} shouldUpdateUserConfig: ${shouldUpdateUserConfig}`);
@@ -331,7 +331,7 @@ function checkFirstTimeLaunch() {
             })
             .catch((e) => {
                 log.send(logLevels.ERROR, `Error reading configVersion error: ${e}`);
-                return setupFirstTimeLaunch(reject, resolve, false);
+                return setupFirstTimeLaunch(resolve, reject, false);
             });
     });
 }
@@ -342,15 +342,14 @@ function checkFirstTimeLaunch() {
  *
  * @return {Promise<any>}
  */
-function setupFirstTimeLaunch(reject, resolve, shouldUpdateUserConfig) {
+function setupFirstTimeLaunch(resolve, reject, shouldUpdateUserConfig) {
     log.send(logLevels.INFO, 'setting first time launch config');
     getConfigField('launchOnStartup')
         .then(setStartup)
         .then(() => {
             if (shouldUpdateUserConfig) {
-                return updateUserConfigOnLaunch()
-                    .then(resolve)
-                    .catch(reject)
+                log.send(logLevels.INFO, `Resetting user config data? ${shouldUpdateUserConfig}`);
+                return updateUserConfigOnLaunch(resolve, reject);
             }
             return resolve();
         })


### PR DESCRIPTION
## Description
Fix first time config update logic [ELECTRON-1129](https://perzoinc.atlassian.net/browse/ELECTRON-1129)

## Solution Approach
- Fix issue in `Promise`
- Change logic to update user config only if the install type is `per user`
- Change the logic to set first time launch if config version less than the installer version

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
master | [link](https://github.com/symphonyoss/SymphonyElectron/pull/590)

## QA Checklist
- [X] Unit-Tests
- [ ] Automation-Tests

![Screenshot 2019-03-12 at 9 00 03 PM](https://user-images.githubusercontent.com/13243259/54213100-dc9fe780-4509-11e9-8aa5-8be77ce0388f.png)