### PR TITLE
ELECTRON-1131: changing extension from jpeg to png on windows

### DIFF
--- a/js/screenSnippet/index.js
+++ b/js/screenSnippet/index.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { isMac, isDevEnv } = require('../utils/misc.js');
+const { isMac, isDevEnv, isWindowsOS } = require('../utils/misc.js');
 const log = require('../log.js');
 const logLevels = require('../enums/logLevels.js');
 const eventEmitter = require('.././eventEmitter');
@@ -41,7 +41,7 @@ class ScreenSnippet {
 
             log.send(logLevels.INFO, 'ScreenSnippet: starting screen capture');
 
-            let tmpFilename = 'symphonyImage-' + Date.now() + '.jpg';
+            let tmpFilename = (isWindowsOS) ? 'symphonyImage-' + Date.now() + '.png' : 'symphonyImage-' + Date.now() + '.jpg';
             let tmpDir = os.tmpdir();
 
             let outputFileName = path.join(tmpDir, tmpFilename);
@@ -144,10 +144,11 @@ function readResult(outputFileName, resolve, reject, childProcessErr) {
         try {
             // convert binary data to base64 encoded string
             let output = Buffer.from(data).toString('base64');
-            resolve({
-                type: 'image/jpg;base64',
+            const resultOutput = {
+                type: isWindowsOS ? 'image/png;base64' : 'image/jpg;base64',
                 data: output
-            });
+            };
+            resolve(resultOutput);
         } catch (error) {
             reject(createError(error));
         } finally {


### PR DESCRIPTION
## Description
Unable to sent screenshots captured from the snipping tool in Electron [ELECTRON-1131](https://perzoinc.atlassian.net/browse/ELECTRON-1131)

## Approach
Change the image extension from jpg to png on Windows OS

#### Fix:
- WIndows
![ELECTRON-1131-windows](https://user-images.githubusercontent.com/9887288/54308231-4e307200-45ac-11e9-80de-356f4b0feeca.gif)

## Related PRs
List related PRs against other branches / repositories:

branch | PR
------ | ------
SFE-Client-App | [link](https://github.com/SymphonyOSF/SFE-Client-App/pull/13962)
ELECTRON-3.x | [link](https://github.com/symphonyoss/SymphonyElectron/pull/595)

## QA Checklist
- [x] Unit-Tests
- [ ] Automation-Tests

Attach unit & spectron tests results in PDF format against the above task lists for this branch
[Symphony Electron Test Result.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2963235/Symphony.Electron.Test.Result.pdf)
