### PR TITLE
ELECTRON-1138: support opening email composition in new window

### DIFF
--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -466,7 +466,7 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
 
                 // only allow window.open to succeed is if coming from same host,
                 // otherwise open in default browser.
-                if ((newWinHost === mainWinHost || newWinUrl === emptyUrlString) && dispositionWhitelist.includes(disposition)) {
+                if ((newWinHost === mainWinHost || newWinUrl === emptyUrlString || (newWinHost.indexOf(mainWinHost) !== -1 && frameName !== "")) && dispositionWhitelist.includes(disposition)) {
                     // handle: window.open
 
                     if (!frameName) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Symphony",
   "productName": "Symphony",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "clientVersion": "1.54",
   "buildNumber": "0",
   "description": "Symphony desktop app (Foundation ODP)",


### PR DESCRIPTION
## Description
Currently, due to security reasons, we don't open any url which is not the same as the main window url in a new window, instead, we open it in a new tab of the system default browser.

However, this impacts the email app as we'll need new window to be opened to compose an email. This commit fixes that issue by checking if we need to open a sub-domain of the pod url domain.

[ELECTRON-1138](https://perzoinc.atlassian.net/browse/ELECTRON-1138)

## Solution Approach
Checking if we need to open a sub-domain of the pod url domain.

## Documentation
N/A

## Related PRs
branch | PR
------ | ------
master | [link](https://github.com/symphonyoss/SymphonyElectron/pull/602)

## QA Checklist
- [x] Unit-Tests
[ELECTRON-1138 Unit Tests Report.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2982607/ELECTRON-1138.Unit.Tests.Report.pdf)
