### PR TITLE
reverting screen snippet: change extension from png to jpeg on windows

### DIFF
--- a/js/screenSnippet/index.js
+++ b/js/screenSnippet/index.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { isMac, isDevEnv, isWindowsOS } = require('../utils/misc.js');
+const { isMac, isDevEnv } = require('../utils/misc.js');
 const log = require('../log.js');
 const logLevels = require('../enums/logLevels.js');
 const eventEmitter = require('.././eventEmitter');
@@ -41,7 +41,7 @@ class ScreenSnippet {
 
             log.send(logLevels.INFO, 'ScreenSnippet: starting screen capture');
 
-            let tmpFilename = (isWindowsOS) ? 'symphonyImage-' + Date.now() + '.png' : 'symphonyImage-' + Date.now() + '.jpg';
+            let tmpFilename ='symphonyImage-' + Date.now() + '.jpg';
             let tmpDir = os.tmpdir();
 
             let outputFileName = path.join(tmpDir, tmpFilename);
@@ -145,7 +145,7 @@ function readResult(outputFileName, resolve, reject, childProcessErr) {
             // convert binary data to base64 encoded string
             let output = Buffer.from(data).toString('base64');
             const resultOutput = {
-                type: isWindowsOS ? 'image/png;base64' : 'image/jpg;base64',
+                type: 'image/jpg;base64',
                 data: output
             };
             resolve(resultOutput);

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "winreg": "1.2.4"
   },
   "optionalDependencies": {
-    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.5",
+    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.4",
     "swift-search": "3.0.1"
   }
 }


### PR DESCRIPTION
## Description
Reverting screen snippet: change extension from png to jpeg on windows [ELECTRON-1161](https://perzoinc.atlassian.net/browse/ELECTRON-1161)


## Related PRs
List related PRs against other branches / repositories:

branch | PR
------ | ------
SFE-Client-App | [link](https://github.com/SymphonyOSF/SFE-Client-App/pull/13962)
ELECTRON-master | [link](https://github.com/symphonyoss/SymphonyElectron/pull/593)
ELECTRON-3x | [link](https://github.com/symphonyoss/SymphonyElectron/pull/595)

## QA Checklist
- [x] Unit-Tests
- [ ] Automation-Tests