### PR TITLE
mocking updateUserConfig on autoLaunchController unit test

### DIFF
--- a/spec/autoLaunchController.spec.ts
+++ b/spec/autoLaunchController.spec.ts
@@ -13,6 +13,7 @@ jest.mock('../src/app/config-handler', () => {
                     launchOnStartup: true,
                 };
             }),
+            updateUserConfig: jest.fn(),
         },
     };
 });


### PR DESCRIPTION
## Description
fixing autoLaunchController unit test

## Solution Approach
it was necessary mock the updateUserConfig on autoLaunchController.spec

<img width="279" alt="Screen Shot 2019-04-08 at 08 59 47" src="https://user-images.githubusercontent.com/9887288/55722451-ba9c6680-59dc-11e9-9874-1d60d583cf3b.png">
