### PR TITLE
ELECTRON-967 (Remove auto retry logic and add manual retry)

### DIFF
--- a/js/enums/api.js
+++ b/js/enums/api.js
@@ -26,7 +26,6 @@ const cmds = keyMirror({
     setLocale: null,
     keyPress: null,
     openScreenSharingIndicator: null,
-    quitWindow: null,
     reloadWindow: null,
 });
 

--- a/js/enums/api.js
+++ b/js/enums/api.js
@@ -26,8 +26,8 @@ const cmds = keyMirror({
     setLocale: null,
     keyPress: null,
     openScreenSharingIndicator: null,
-    cancelNetworkStatusCheck: null,
     quitWindow: null,
+    reloadWindow: null,
 });
 
 module.exports = {

--- a/js/mainApiMgr.js
+++ b/js/mainApiMgr.js
@@ -5,7 +5,6 @@
  * from the renderer process.
  */
 const electron = require('electron');
-const app = electron.app;
 
 const windowMgr = require('./windowMgr.js');
 const log = require('./log.js');
@@ -193,9 +192,6 @@ electron.ipcMain.on(apiName, (event, arg) => {
             break;
         case apiCmds.reloadWindow:
             windowMgr.reloadWindow();
-            break;
-        case apiCmds.quitWindow:
-            app.quit();
             break;
         default:
     }

--- a/js/mainApiMgr.js
+++ b/js/mainApiMgr.js
@@ -191,8 +191,8 @@ electron.ipcMain.on(apiName, (event, arg) => {
                 openScreenSharingIndicator(event.sender, arg.displayId, arg.id);
             }
             break;
-        case apiCmds.cancelNetworkStatusCheck:
-            windowMgr.cancelNetworkStatusCheck();
+        case apiCmds.reloadWindow:
+            windowMgr.reloadWindow();
             break;
         case apiCmds.quitWindow:
             app.quit();

--- a/js/networkError/contents.js
+++ b/js/networkError/contents.js
@@ -109,12 +109,11 @@ const errorContent = (data) => {
         <div class="main-message">
             <p class="NetworkError-header">${data["Problem connecting to Symphony"] || "Problem connecting to Symphony"}</p>
             <p id="NetworkError-reason">
-                ${data["Looks like you are not connected to the Internet. We'll try to reconnect automatically."]
-                    || "Looks like you are not connected to the Internet. We'll try to reconnect automatically."}
+                ${data["Looks like you are not connected to the Internet."]
+                    || "Looks like you are not connected to the Internet."}
             </p>
             <div id="error-code" class="NetworkError-error-code">ERR_INTERNET_DISCONNECTED</div>
             <button id="retry-button" class="NetworkError-button">${data.Retry || "Retry"}</button>
-            <button id="quit-button" class="NetworkError-button">${data["Quit Symphony"] || "Quit Symphony"}</button>
         </div>
     </div>
 </div>`);

--- a/js/networkError/contents.js
+++ b/js/networkError/contents.js
@@ -113,7 +113,7 @@ const errorContent = (data) => {
                     || "Looks like you are not connected to the Internet. We'll try to reconnect automatically."}
             </p>
             <div id="error-code" class="NetworkError-error-code">ERR_INTERNET_DISCONNECTED</div>
-            <button id="cancel-retry-button" class="NetworkError-button">${data["Cancel Retry"] || "Cancel Retry"}</button>
+            <button id="retry-button" class="NetworkError-button">${data.Retry || "Retry"}</button>
             <button id="quit-button" class="NetworkError-button">${data["Quit Symphony"] || "Quit Symphony"}</button>
         </div>
     </div>

--- a/js/networkError/index.js
+++ b/js/networkError/index.js
@@ -29,13 +29,6 @@ class NetworkError {
             });
         };
         retryButton.addEventListener('click', retry);
-        
-        const quitButton = errorContent.getElementById('quit-button');
-        quitButton.addEventListener('click', () => {
-            ipcRenderer.send(apiName, {
-                cmd: apiCmds.quitWindow
-            });
-        });
 
         const mainFrame = errorContent.getElementById('main-frame');
         document.body.appendChild(mainFrame);

--- a/js/networkError/index.js
+++ b/js/networkError/index.js
@@ -20,15 +20,15 @@ class NetworkError {
         errorContent.getElementById('error-code').innerText = error || "UNKNOWN_ERROR";
 
         // Add event listeners for buttons
-        const cancelRetryButton = errorContent.getElementById('cancel-retry-button');
-        const cancelRetry = () => {
+        const retryButton = errorContent.getElementById('retry-button');
+        const retry = () => {
+            retryButton.classList.add('disabled');
+            retryButton.removeEventListener('click', retry);
             ipcRenderer.send(apiName, {
-                cmd: apiCmds.cancelNetworkStatusCheck
+                cmd: apiCmds.reloadWindow
             });
-            cancelRetryButton.classList.add('disabled');
-            cancelRetryButton.removeEventListener('click', cancelRetry);
         };
-        cancelRetryButton.addEventListener('click', cancelRetry);
+        retryButton.addEventListener('click', retry);
         
         const quitButton = errorContent.getElementById('quit-button');
         quitButton.addEventListener('click', () => {

--- a/locale/en-US.json
+++ b/locale/en-US.json
@@ -71,7 +71,7 @@
   "NetworkError": {
     "Problem connecting to Symphony": "Problem connecting to Symphony",
     "Looks like you are not connected to the Internet. We'll try to reconnect automatically.": "Looks like you are not connected to the Internet. We'll try to reconnect automatically.",
-    "Cancel Retry": "Cancel Retry",
+    "Retry": "Retry",
     "Quit Symphony": "Quit Symphony"
   },
   "No crashes available to share": "No crashes available to share",

--- a/locale/en-US.json
+++ b/locale/en-US.json
@@ -70,7 +70,7 @@
   "Network connectivity has been lost. Check your internet connection.": "Network connectivity has been lost. Check your internet connection.",
   "NetworkError": {
     "Problem connecting to Symphony": "Problem connecting to Symphony",
-    "Looks like you are not connected to the Internet. We'll try to reconnect automatically.": "Looks like you are not connected to the Internet. We'll try to reconnect automatically.",
+    "Looks like you are not connected to the Internet.": "Looks like you are not connected to the Internet.",
     "Retry": "Retry",
     "Quit Symphony": "Quit Symphony"
   },

--- a/locale/en.json
+++ b/locale/en.json
@@ -71,7 +71,7 @@
   "NetworkError": {
     "Problem connecting to Symphony": "Problem connecting to Symphony",
     "Looks like you are not connected to the Internet. We'll try to reconnect automatically.": "Looks like you are not connected to the Internet. We'll try to reconnect automatically.",
-    "Cancel Retry": "Cancel Retry",
+    "Retry": "Retry",
     "Quit Symphony": "Quit Symphony"
   },
   "No crashes available to share": "No crashes available to share",

--- a/locale/en.json
+++ b/locale/en.json
@@ -70,7 +70,7 @@
   "Network connectivity has been lost. Check your internet connection.": "Network connectivity has been lost. Check your internet connection.",
   "NetworkError": {
     "Problem connecting to Symphony": "Problem connecting to Symphony",
-    "Looks like you are not connected to the Internet. We'll try to reconnect automatically.": "Looks like you are not connected to the Internet. We'll try to reconnect automatically.",
+    "Looks like you are not connected to the Internet.": "Looks like you are not connected to the Internet.",
     "Retry": "Retry",
     "Quit Symphony": "Quit Symphony"
   },

--- a/locale/fr-FR.json
+++ b/locale/fr-FR.json
@@ -70,7 +70,7 @@
   "Network connectivity has been lost. Check your internet connection.": "La connectivité a été perdue. Vérifiez votre connection à l'internet.",
   "NetworkError": {
     "Problem connecting to Symphony": "Problème de connexion à Symphony",
-    "Looks like you are not connected to the Internet. We'll try to reconnect automatically.": "On dirait que vous n'êtes pas connecté à Internet. Nous allons essayer de vous reconnecter automatiquement.",
+    "Looks like you are not connected to the Internet.": "On dirait que vous n'êtes pas connecté à Internet.",
     "Retry": "Réessayez",
     "Quit Symphony": "Quitter Symphony"
   },

--- a/locale/fr-FR.json
+++ b/locale/fr-FR.json
@@ -71,7 +71,7 @@
   "NetworkError": {
     "Problem connecting to Symphony": "Problème de connexion à Symphony",
     "Looks like you are not connected to the Internet. We'll try to reconnect automatically.": "On dirait que vous n'êtes pas connecté à Internet. Nous allons essayer de vous reconnecter automatiquement.",
-    "Cancel Retry": "Annuler réessayer",
+    "Retry": "Réessayez",
     "Quit Symphony": "Quitter Symphony"
   },
   "No crashes available to share": "Pas de crash à partager",

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -70,7 +70,7 @@
   "Network connectivity has been lost. Check your internet connection.": "La connectivité a été perdue. Vérifiez votre connection à l'internet.",
   "NetworkError": {
     "Problem connecting to Symphony": "Problème de connexion à Symphony",
-    "Looks like you are not connected to the Internet. We'll try to reconnect automatically.": "On dirait que vous n'êtes pas connecté à Internet. Nous allons essayer de vous reconnecter automatiquement.",
+    "Looks like you are not connected to the Internet.": "On dirait que vous n'êtes pas connecté à Internet.",
     "Retry": "Réessayez",
     "Quit Symphony": "Quitter Symphony"
   },

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -71,7 +71,7 @@
   "NetworkError": {
     "Problem connecting to Symphony": "Problème de connexion à Symphony",
     "Looks like you are not connected to the Internet. We'll try to reconnect automatically.": "On dirait que vous n'êtes pas connecté à Internet. Nous allons essayer de vous reconnecter automatiquement.",
-    "Cancel Retry": "Annuler réessayer",
+    "Retry": "Réessayez",
     "Quit Symphony": "Quitter Symphony"
   },
   "No crashes available to share": "Pas de crash à partager",

--- a/locale/ja-JP.json
+++ b/locale/ja-JP.json
@@ -71,7 +71,7 @@
   "NetworkError": {
     "Problem connecting to Symphony": "Symphonyへの接続に関する問題",
     "Looks like you are not connected to the Internet. We'll try to reconnect automatically.": "インターネットに接続していないようです。 自動的に再接続します。",
-    "Cancel Retry": "再試行をキャンセル",
+    "Retry": "再試行を",
     "Quit Symphony": "Symphonyを終了します"
   },
   "No crashes available to share": "共有できるクラッシュはありません",

--- a/locale/ja-JP.json
+++ b/locale/ja-JP.json
@@ -70,7 +70,7 @@
   "Network connectivity has been lost. Check your internet connection.": "ネットワーク接続が失われました。インターネット接続を確認してください。",
   "NetworkError": {
     "Problem connecting to Symphony": "Symphonyへの接続に関する問題",
-    "Looks like you are not connected to the Internet. We'll try to reconnect automatically.": "インターネットに接続していないようです。 自動的に再接続します。",
+    "Looks like you are not connected to the Internet.": "インターネットに接続していないようです。",
     "Retry": "再試行を",
     "Quit Symphony": "Symphonyを終了します"
   },

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -71,7 +71,7 @@
   "NetworkError": {
     "Problem connecting to Symphony": "Symphonyへの接続に関する問題",
     "Looks like you are not connected to the Internet. We'll try to reconnect automatically.": "インターネットに接続していないようです。 自動的に再接続します。",
-    "Cancel Retry": "再試行をキャンセル",
+    "Retry": "再試行を",
     "Quit Symphony": "Symphonyを終了します"
   },
   "No crashes available to share": "共有できるクラッシュはありません",

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -70,7 +70,7 @@
   "Network connectivity has been lost. Check your internet connection.": "ネットワーク接続が失われました。インターネット接続を確認してください。",
   "NetworkError": {
     "Problem connecting to Symphony": "Symphonyへの接続に関する問題",
-    "Looks like you are not connected to the Internet. We'll try to reconnect automatically.": "インターネットに接続していないようです。 自動的に再接続します。",
+    "Looks like you are not connected to the Internet.": "インターネットに接続していないようです。",
     "Retry": "再試行を",
     "Quit Symphony": "Symphonyを終了します"
   },

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "async.mapseries": "0.5.2",
     "auto-launch": "5.0.5",
     "electron-dl": "1.12.0",
-    "electron-fetch": "1.3.0",
     "electron-log": "2.2.17",
     "electron-spellchecker": "git+https://github.com/symphonyoss/electron-spellchecker.git#v1.1.4",
     "ffi": "git+https://github.com/symphonyoss/node-ffi.git#v1.2.8",


### PR DESCRIPTION
## Description
This changes the auto refresh logic to manual refresh where users can use the retry button to reload the client
[ELECTRON-967](https://perzoinc.atlassian.net/browse/ELECTRON-967)

## Solution Approach
Add a `Retry` button which on clicked loads the main window with the global config URL

## Screenshot
![Screenshot 2019-05-03 at 6 44 01 PM](https://user-images.githubusercontent.com/13243259/57139661-7d58a800-6dd3-11e9-89d1-fc0023996f33.png)



## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
master | [link](https://github.com/symphonyoss/SymphonyElectron/pull/637)
