### PR TITLE
ELECTRON-1239 (Add safety check in electron-notify to prevent javascript errors)

### DIFF
--- a/js/aboutApp/index.js
+++ b/js/aboutApp/index.js
@@ -85,6 +85,9 @@ function openAboutWindow(windowName) {
     });
 
     aboutWindow.webContents.on('did-finish-load', () => {
+        if (!aboutWindow || aboutWindow.isDestroyed()) {
+            return;
+        }
         // initialize crash reporter
         initCrashReporterMain({ process: 'about app window' });
         initCrashReporterRenderer(aboutWindow, { process: 'render | about app window' });

--- a/js/basicAuth/index.js
+++ b/js/basicAuth/index.js
@@ -98,6 +98,9 @@ function openBasicAuthWindow(windowName, hostname, isValidCredentials, clearSett
     });
 
     basicAuthWindow.webContents.on('did-finish-load', () => {
+        if (!basicAuthWindow || basicAuthWindow.isDestroyed()) {
+            return;
+        }
         const basicAuthContent = i18n.getMessageFor('BasicAuth');
         basicAuthWindow.webContents.send('i18n-basic-auth', basicAuthContent);
         // initialize crash reporter

--- a/js/desktopCapturer/index.js
+++ b/js/desktopCapturer/index.js
@@ -98,6 +98,9 @@ function openScreenPickerWindow(eventSender, sources, id) {
     });
 
     screenPickerWindow.webContents.on('did-finish-load', () => {
+        if (!screenPickerWindow || screenPickerWindow.isDestroyed()) {
+            return;
+        }
         const screenPickerContent = i18n.getMessageFor('ScreenPicker');
         screenPickerWindow.webContents.send('i18n-screen-picker', screenPickerContent);
         // initialize crash reporter

--- a/js/moreInfo/index.js
+++ b/js/moreInfo/index.js
@@ -84,6 +84,9 @@ function openMoreInfoWindow(windowName) {
     });
 
     moreInfoWindow.webContents.on('did-finish-load', () => {
+        if (!moreInfoWindow || moreInfoWindow.isDestroyed()) {
+            return;
+        }
         // initialize crash reporter
         initCrashReporterMain({ process: 'more info window' });
         initCrashReporterRenderer(moreInfoWindow, { process: 'render | more info window' });

--- a/js/notify/electron-notify.js
+++ b/js/notify/electron-notify.js
@@ -419,6 +419,9 @@ function showNotification(notificationObj) {
                 activeNotifications.push(updatedNotfWindow);
 
                 resolve(updatedNotfWindow);
+            }).catch((err) => {
+                log.send(logLevels.ERROR, `Unable to show notification error: ${err}`);
+                resolve();
             })
         } else {
             // Add to notificationQueue
@@ -718,7 +721,7 @@ function calcInsertPos() {
  * @returns {Promise}
  */
 function getWindow() {
-    return new Promise(function(resolve) {
+    return new Promise(function(resolve, reject) {
         let notificationWindow;
         // Are there still inactiveWindows?
         if (inactiveWindows.length > 0) {
@@ -734,6 +737,10 @@ function getWindow() {
             notificationWindow.setVisibleOnAllWorkspaces(true);
             notificationWindow.loadURL(getTemplatePath());
             notificationWindow.webContents.on('did-finish-load', function() {
+                if (!notificationWindow || !windowExists(notificationWindow)) {
+                    reject(new Error('notification window has been destroyed'));
+                    return;
+                }
                 // Done
                 notificationWindow.webContents.send('electron-notify-load-config', config);
                 resolve(notificationWindow)

--- a/js/notify/settings/configure-notification-position.js
+++ b/js/notify/settings/configure-notification-position.js
@@ -125,6 +125,11 @@ function openConfigurationWindow(windowName) {
     });
 
     configurationWindow.webContents.on('did-finish-load', () => {
+
+        if (!configurationWindow || configurationWindow.isDestroyed()) {
+            return;
+        }
+
         const notificationSettingsContent = i18n.getMessageFor('NotificationSettings');
         configurationWindow.webContents.send('i18n-notification-settings', notificationSettingsContent);
         if (screens && screens.length >= 0) {

--- a/js/screenSharingIndicator/index.js
+++ b/js/screenSharingIndicator/index.js
@@ -60,6 +60,9 @@ function openScreenSharingIndicator(eventSender, displayId, id) {
     });
 
     indicatorWindow.webContents.on('did-finish-load', () => {
+        if (!indicatorWindow || indicatorWindow.isDestroyed()) {
+            return;
+        }
         initCrashReporterMain({ process: 'screen sharing indicator window' });
         initCrashReporterRenderer(indicatorWindow, { process: 'render | screen sharing indicator window' });
         indicatorWindow.webContents.send('window-data', {


### PR DESCRIPTION
## Description
Add safety check in electron-notify to prevent javascript errors
[ELECTRON-1239](https://perzoinc.atlassian.net/browse/ELECTRON-1239)

## Solution Approach
Add a safety check to access the window instance
