### PR TITLE
SEARCH-1496 - Clear search_index folder before decompressing

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,6 @@
   },
   "optionalDependencies": {
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.5",
-    "swift-search": "3.0.2"
+    "swift-search": "3.0.3"
   }
 }


### PR DESCRIPTION
## Description
App crashes when opening the Message tab after closing the app while the batch index is starting (3.x)
[SEARCH-1496](https://perzoinc.atlassian.net/browse/SEARCH-1496)

## Solution Approach
When the app is force terminated while the data is being written to disk the file gets corrupted and when we are opening that file which led to the crash. So to prevent this we clear the folder before decompression. 

## Documentation
N/A

## Related PRs
List related PRs against other branches / repositories:

branch | PR
------ | ------
Swift-Search - `master` | [#17](https://github.com/symphonyoss/SwiftSearch/pull/17)

## QA Checklist
- [x] Unit-Tests