### PR TITLE
ELECTRON-988 (Remove registerAccelerator from menuItem options)

### DIFF
--- a/js/menus/menuTemplate.js
+++ b/js/menus/menuTemplate.js
@@ -508,8 +508,8 @@ function buildMenuItem(role, label) {
     }
 
     if (isWindowsOS) {
-        return label ? { role: role, label: label, accelerator: windowsAccelerator[role] || '', registerAccelerator: true }
-            : { role: role, accelerator: windowsAccelerator[role] || '', registerAccelerator: true }
+        return label ? { role: role, label: label, accelerator: windowsAccelerator[role] || '' }
+            : { role: role, accelerator: windowsAccelerator[role] || '' }
     }
 
     return label ? { role: role, label: label } : { role: role }


### PR DESCRIPTION
## Description
Remove registerAccelerator from menuItem options
[ELECTRON-988](https://perzoinc.atlassian.net/browse/ELECTRON-988)

## Solution Approach
Setting registerAccelerator `electron` seem to register some accelerators twice.
In Electron version `3.1.6` registerAccelerator defaults to true and hence all the shortcuts works as expected

## Before
![2019-05-15 10 46 16](https://user-images.githubusercontent.com/13243259/57750602-7baab080-7700-11e9-8715-17c69bdf7026.gif)

## After
![2019-05-15 10 43 31](https://user-images.githubusercontent.com/13243259/57750593-764d6600-7700-11e9-9c4e-2a8007571bd3.gif)



## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
ELECTRON-1003 | [link](https://github.com/symphonyoss/SymphonyElectron/pull/546)
