### PR TITLE
ELECTRON-1241: handling js errors in main process

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -253,6 +253,10 @@ app.on('web-contents-created', function (event, webContents) {
     onWebContent(webContents);
 });
 
+process.on('uncaughtException', function(err) {
+    log.send(logLevels.ERROR, `Uncaught Exception Event: ${err}`);
+});
+
 function onWebContent(webContents) {
 
     if (!ContextMenuBuilder) {


### PR DESCRIPTION
## Description
MacOS: Sometimes JavaScript error shows when taking screenshot [ELECTRON-1241](https://perzoinc.atlassian.net/browse/ELECTRON-1241)

## Solution Approach
I am handling all JS errors thrown in main process using process.on('uncaughtException',..) callback

## Fix 
 - Before
https://drive.google.com/open?id=1Sf1WGYnMzYk_FTHgoIAHUR0oDqOqlPNk
- After
https://drive.google.com/open?id=1gUh7DD_ty5_QdPNZuRVV0n88sb_CHVXw
