### PR TITLE
ELECTRON-1247 (Remove old Symphony launch agent plist file)

### DIFF
--- a/js/autoLaunch/index.js
+++ b/js/autoLaunch/index.js
@@ -19,6 +19,7 @@ const props = isMac ? {
     path: getAutoLaunchPath() || process.execPath,
 };
 
+// TODO: Remove this method in the future
 removeOldLaunchAgent();
 
 /**

--- a/js/autoLaunch/index.js
+++ b/js/autoLaunch/index.js
@@ -1,4 +1,5 @@
 const { app } = require('electron');
+const AutoLaunch = require('auto-launch');
 
 // Local Dependencies
 const log = require('../log.js');
@@ -17,6 +18,17 @@ const props = isMac ? {
     name: 'Symphony',
     path: getAutoLaunchPath() || process.execPath,
 };
+
+/**
+ * @deprecated - removes old Symphony launch agent if exists
+ */
+if (isMac) {
+    const autoLaunch = new AutoLaunch(props);
+    autoLaunch.disable()
+        .then(() => log.send(logLevels.INFO, `Old Symphony launch agent successfully removed`))
+        .catch((e) => log.send(logLevels.ERROR, `Old Symphony launch agent failed to remove error: ${e}`));
+}
+
 
 /**
  * Replace forward slash in the path to backward slash

--- a/js/autoLaunch/index.js
+++ b/js/autoLaunch/index.js
@@ -19,16 +19,19 @@ const props = isMac ? {
     path: getAutoLaunchPath() || process.execPath,
 };
 
+removeOldLaunchAgent();
+
 /**
  * @deprecated - removes old Symphony launch agent if exists
  */
-if (isMac) {
-    const autoLaunch = new AutoLaunch(props);
-    autoLaunch.disable()
-        .then(() => log.send(logLevels.INFO, `Old Symphony launch agent successfully removed`))
-        .catch((e) => log.send(logLevels.ERROR, `Old Symphony launch agent failed to remove error: ${e}`));
+function removeOldLaunchAgent() {
+    if (isMac) {
+        const autoLaunch = new AutoLaunch(props);
+        autoLaunch.disable()
+            .then(() => log.send(logLevels.INFO, `Old Symphony launch agent successfully removed`))
+            .catch((e) => log.send(logLevels.ERROR, `Old Symphony launch agent failed to remove error: ${e}`));
+    }
 }
-
 
 /**
  * Replace forward slash in the path to backward slash

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "archiver": "3.0.0",
     "async.map": "0.5.2",
     "async.mapseries": "0.5.2",
+    "auto-launch": "5.0.5",
     "electron-dl": "1.12.0",
     "electron-log": "2.2.17",
     "electron-spellchecker": "git+https://github.com/symphonyoss/electron-spellchecker.git#v2.0.1",


### PR DESCRIPTION
## Description
Remove old Symphony launch agent plist file 
[ELECTRON-1247](https://perzoinc.atlassian.net/browse/ELECTRON-1247)

## Solution Approach
Using the third party `auto-launch` module (used previously) to remove the plist file.
The new launch on startup API provided by Electron creates an entry @ login items