### PR TITLE
ELECTRON-771 (Fix custom title bar button titles & localization)

### DIFF
--- a/js/preload/preloadMain.js
+++ b/js/preload/preloadMain.js
@@ -490,7 +490,7 @@ function createAPI() {
 
     // Adds custom title bar style for Windows 10 OS
     local.ipcRenderer.on('initiate-windows-title-bar', (event, arg) => {
-        if (arg && typeof arg === 'string') {
+        if (arg && typeof arg === 'object') {
             titleBar.initiateWindowsTitleBar(arg);
         }
     });

--- a/js/windowMgr.js
+++ b/js/windowMgr.js
@@ -314,7 +314,8 @@ function doCreateMainWindow(initialUrl, initialBounds, isCustomTitleBar) {
             mainWindow.webContents.insertCSS(titleBarStyles);
             // This is required to initiate Windows title bar only after insertCSS
             const titleBarStyle = getTitleBarStyle();
-            mainWindow.webContents.send('initiate-windows-title-bar', titleBarStyle);
+            const titleBar = i18n.getMessageFor('TitleBar');
+            mainWindow.webContents.send('initiate-windows-title-bar', { titleBarStyle, titleBar });
         }
 
         if (!isOnline) {

--- a/js/windowsTitleBar/index.js
+++ b/js/windowsTitleBar/index.js
@@ -18,9 +18,10 @@ class TitleBar {
         this.titleBar = titleBarParsed.getElementById('title-bar');
     }
 
-    initiateWindowsTitleBar(titleBarStyle) {
+    initiateWindowsTitleBar({ titleBarStyle, titleBar }) {
 
         const actionItemsParsed = this.domParser.parseFromString(htmlContents.button, 'text/html');
+        this.localeContent = titleBar;
 
         if (titleBarStyle === titleBarStyles.CUSTOM) {
             const buttons = actionItemsParsed.getElementsByClassName('action-items');
@@ -31,7 +32,7 @@ class TitleBar {
             }
         }
 
-        const updateIcon = TitleBar.updateIcons;
+        const updateIcon = this.updateIcons;
 
         // Event to capture and update icons
         this.window.on('maximize', updateIcon.bind(this, true));
@@ -67,6 +68,8 @@ class TitleBar {
         this.initiateEventListeners();
 
         this.updateTitleBar(this.window.isFullScreen());
+        this.updateLocale(this.localeContent);
+        this.updateIcons(this.window.isMaximized());
     }
 
     /**
@@ -93,9 +96,12 @@ class TitleBar {
      * @param content {Object}
      */
     updateLocale(content) {
+        this.localeContent = content;
         this.hamburgerMenuButton.title = content.Menu || 'Menu';
         this.minimizeButton.title = content.Minimize || 'Minimize';
-        this.maximizeButton.title = content.Maximize || 'Maximize';
+        this.maximizeButton.title = this.isMaximized
+            ? (content.Restore || 'Restore')
+            : (content.Maximize || 'Maximize');
         this.closeButton.title = content.Close || 'Close';
     }
 
@@ -151,7 +157,8 @@ class TitleBar {
      * unmaximize icons
      * @param isMaximized
      */
-    static updateIcons(isMaximized) {
+    updateIcons(isMaximized) {
+        this.isMaximized = isMaximized;
         const button = document.getElementById('title-bar-maximize-button');
 
         if (!button) {
@@ -160,8 +167,10 @@ class TitleBar {
 
         if (isMaximized) {
             button.innerHTML = htmlContents.unMaximizeButton;
+            button.title = this.localeContent ? (this.localeContent.Restore || 'Restore') : 'Restore';
         } else {
             button.innerHTML = htmlContents.maximizeButton;
+            button.title = this.localeContent ? (this.localeContent.Maximize || 'Maximize') : 'Maximize';
         }
     }
 

--- a/locale/en-US.json
+++ b/locale/en-US.json
@@ -156,7 +156,8 @@
     "Close": "Close",
     "Maximize": "Maximize",
     "Menu": "Menu",
-    "Minimize": "Minimize"
+    "Minimize": "Minimize",
+    "Restore": "Restore"
   },
   "Title Bar Style": "Title Bar Style",
   "Toggle Full Screen": "Toggle Full Screen",

--- a/locale/en.json
+++ b/locale/en.json
@@ -156,7 +156,8 @@
     "Close": "Close",
     "Maximize": "Maximize",
     "Menu": "Menu",
-    "Minimize": "Minimize"
+    "Minimize": "Minimize",
+    "Restore": "Restore"
   },
   "Title Bar Style": "Title Bar Style",
   "Toggle Full Screen": "Toggle Full Screen",

--- a/locale/fr-FR.json
+++ b/locale/fr-FR.json
@@ -156,7 +156,8 @@
     "Close": "Fermer",
     "Maximize": "Maximiser",
     "Menu": "Menu",
-    "Minimize": "Minimiser"
+    "Minimize": "Minimiser",
+    "Restore": "Restaurer"
   },
   "Title Bar Style": "Style de la barre de titre",
   "Toggle Full Screen": "Basculer plein écran",

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -156,7 +156,8 @@
     "Close": "Fermer",
     "Maximize": "Maximiser",
     "Menu": "Menu",
-    "Minimize": "Minimiser"
+    "Minimize": "Minimiser",
+    "Restore": "Restaurer"
   },
   "Title Bar Style": "Style de la barre de titre",
   "Toggle Full Screen": "Basculer plein écran",

--- a/locale/ja-JP.json
+++ b/locale/ja-JP.json
@@ -156,7 +156,8 @@
     "Close": "閉じる",
     "Maximize": "最大化する",
     "Menu": "メニュー",
-    "Minimize": "最小化する"
+    "Minimize": "最小化する",
+    "Restore": "戻す"
   },
   "Title Bar Style": "タイトルバーのスタイル",
   "Toggle Full Screen": "画面表示を切り替え",

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -156,7 +156,8 @@
     "Close": "閉じる",
     "Maximize": "最大化する",
     "Menu": "メニュー",
-    "Minimize": "最小化する"
+    "Minimize": "最小化する",
+    "Restore": "戻す"
   },
   "Title Bar Style": "タイトルバーのスタイル",
   "Toggle Full Screen": "画面表示を切り替え",


### PR DESCRIPTION
## Description
Fix custom title bar's `maximized` and `restore` titles
Also, fix the localization issue with button titles
[ELECTRON-771](https://perzoinc.atlassian.net/browse/ELECTRON-771)

## Solution Approach
Check the window state and update the button titles

New translation added
- FR - "Restore": "Restaurer"
- JP - "Restore": "戻す"

## Before
![2019-05-17 13 32 30](https://user-images.githubusercontent.com/13243259/57912582-4d67d500-78a8-11e9-8090-749b8c40bad1.gif)

## After
![2019-05-17 13 30 51](https://user-images.githubusercontent.com/13243259/57912589-5193f280-78a8-11e9-9563-fcd1523a253e.gif)

