### PR TITLE
ELECTRON-771 (Fix custom title bar button titles & localization)

### DIFF
--- a/spec/__snapshots__/windowsTitleBar.spec.ts.snap
+++ b/spec/__snapshots__/windowsTitleBar.spec.ts.snap
@@ -85,7 +85,7 @@ exports[`windows title bar should render correctly 1`] = `
       className="title-bar-button"
       onClick={[Function]}
       onMouseDown={[Function]}
-      title="unMaximize"
+      title="Maximize"
     >
       <svg
         viewBox="0 0 14 10.2"

--- a/spec/windowsTitleBar.spec.ts
+++ b/spec/windowsTitleBar.spec.ts
@@ -146,7 +146,7 @@ describe('windows title bar', () => {
 
     describe('maximize functions', () => {
         it('should call `unmaximize` correctly when is not full screen', () => {
-            const titleLabel = 'Maximize';
+            const titleLabel = 'Restore';
             const unmaximizeFn = 'unmaximize';
             const customSelector = `button.title-bar-button[title="${titleLabel}"]`;
             const wrapper = shallow(React.createElement(WindowsTitleBar));
@@ -160,7 +160,7 @@ describe('windows title bar', () => {
 
         it('should call `unmaximize` correctly when is full screen', () => {
             const windowSpyFn = 'setFullScreen';
-            const titleLabel = 'Maximize';
+            const titleLabel = 'Restore';
             const customSelector = `button.title-bar-button[title="${titleLabel}"]`;
             const wrapper = shallow(React.createElement(WindowsTitleBar));
             const instance: any = wrapper.instance();
@@ -175,7 +175,7 @@ describe('windows title bar', () => {
         });
 
         it('should call maximize correctly when it is not in full screen', () => {
-            const titleLabel = 'unMaximize';
+            const titleLabel = 'Maximize';
             const maximizeFn = 'maximize';
             const expectedState = { isMaximized: true };
             const customSelector = `button.title-bar-button[title="${titleLabel}"]`;

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -162,7 +162,8 @@
     "Close": "Close",
     "Maximize": "Maximize",
     "Menu": "Menu",
-    "Minimize": "Minimize"
+    "Minimize": "Minimize",
+    "Restore": "Restore"
   },
   "Title Bar Style": "Title Bar Style",
   "Toggle Full Screen": "Toggle Full Screen",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -162,7 +162,8 @@
     "Close": "Close",
     "Maximize": "Maximize",
     "Menu": "Menu",
-    "Minimize": "Minimize"
+    "Minimize": "Minimize",
+    "Restore": "Restore"
   },
   "Title Bar Style": "Title Bar Style",
   "Toggle Full Screen": "Toggle Full Screen",

--- a/src/locale/fr-FR.json
+++ b/src/locale/fr-FR.json
@@ -162,7 +162,8 @@
     "Close": "Fermer",
     "Maximize": "Maximiser",
     "Menu": "Menu",
-    "Minimize": "Minimiser"
+    "Minimize": "Minimiser",
+    "Restore": "Restaurer"
   },
   "Title Bar Style": "Style de la barre de titre",
   "Toggle Full Screen": "Basculer plein écran",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -162,7 +162,8 @@
     "Close": "Fermer",
     "Maximize": "Maximiser",
     "Menu": "Menu",
-    "Minimize": "Minimiser"
+    "Minimize": "Minimiser",
+    "Restore": "Restaurer"
   },
   "Title Bar Style": "Style de la barre de titre",
   "Toggle Full Screen": "Basculer plein écran",

--- a/src/locale/ja-JP.json
+++ b/src/locale/ja-JP.json
@@ -162,7 +162,8 @@
     "Close": "閉じる",
     "Maximize": "最大化する",
     "Menu": "メニュー",
-    "Minimize": "最小化する"
+    "Minimize": "最小化する",
+    "Restore": "戻す"
   },
   "Title Bar Style": "タイトルバーのスタイル",
   "Toggle Full Screen": "画面表示を切り替え",

--- a/src/locale/ja.json
+++ b/src/locale/ja.json
@@ -162,7 +162,8 @@
     "Close": "閉じる",
     "Maximize": "最大化する",
     "Menu": "メニュー",
-    "Minimize": "最小化する"
+    "Minimize": "最小化する",
+    "Restore": "戻す"
   },
   "Title Bar Style": "タイトルバーのスタイル",
   "Toggle Full Screen": "画面表示を切り替え",

--- a/src/renderer/components/windows-title-bar.tsx
+++ b/src/renderer/components/windows-title-bar.tsx
@@ -9,6 +9,7 @@ interface IState {
     isFullScreen: boolean;
     titleBarHeight: string;
 }
+const TITLE_BAR_NAMESPACE = 'TitleBar';
 
 export default class WindowsTitleBar extends React.Component<{}, IState> {
     private readonly window: Electron.BrowserWindow;
@@ -75,7 +76,7 @@ export default class WindowsTitleBar extends React.Component<{}, IState> {
             >
                 <div className='title-bar-button-container'>
                     <button
-                        title={i18n.t('Menu')()}
+                        title={i18n.t('Menu', TITLE_BAR_NAMESPACE)()}
                         className='hamburger-menu-button'
                         onClick={this.eventHandlers.onShowMenu}
                         onMouseDown={this.handleMouseDown}
@@ -94,7 +95,7 @@ export default class WindowsTitleBar extends React.Component<{}, IState> {
                 <div className='title-bar-button-container'>
                     <button
                         className='title-bar-button'
-                        title={i18n.t('Minimize')()}
+                        title={i18n.t('Minimize', TITLE_BAR_NAMESPACE)()}
                         onClick={this.eventHandlers.onMinimize}
                         onMouseDown={this.handleMouseDown}
                     >
@@ -109,7 +110,7 @@ export default class WindowsTitleBar extends React.Component<{}, IState> {
                 <div className='title-bar-button-container'>
                     <button
                         className='title-bar-button'
-                        title={i18n.t('Close')()}
+                        title={i18n.t('Close', TITLE_BAR_NAMESPACE)()}
                         onClick={this.eventHandlers.onClose}
                         onMouseDown={this.handleMouseDown}
                     >
@@ -136,7 +137,7 @@ export default class WindowsTitleBar extends React.Component<{}, IState> {
             return (
                 <button
                     className='title-bar-button'
-                    title={i18n.t('Maximize')()}
+                    title={i18n.t('Restore', TITLE_BAR_NAMESPACE)()}
                     onClick={this.eventHandlers.onUnmaximize}
                     onMouseDown={this.handleMouseDown}
                 >
@@ -152,7 +153,7 @@ export default class WindowsTitleBar extends React.Component<{}, IState> {
         return (
             <button
                 className='title-bar-button'
-                title={i18n.t('unMaximize')()}
+                title={i18n.t('Maximize', TITLE_BAR_NAMESPACE)()}
                 onClick={this.eventHandlers.onMaximize}
                 onMouseDown={this.handleMouseDown}
             >


### PR DESCRIPTION
## Description
Fix custom title bar's `maximized` and `restore` titles
[ELECTRON-771](https://perzoinc.atlassian.net/browse/ELECTRON-771)

## Solution Approach
Check the window state and update the button titles

New translation added
- FR - "Restore": "Restaurer"
- JP - "Restore": "戻す"

## Before
![2019-05-17 13 32 30](https://user-images.githubusercontent.com/13243259/57912582-4d67d500-78a8-11e9-8090-749b8c40bad1.gif)

## After
![2019-05-17 13 30 51](https://user-images.githubusercontent.com/13243259/57912589-5193f280-78a8-11e9-9563-fcd1523a253e.gif)

