### PR TITLE
SEARCH-1466 - Data not tracking in user custom path

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,6 @@
   },
   "optionalDependencies": {
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.5",
-    "swift-search": "3.0.3"
+    "swift-search": "3.0.4"
   }
 }


### PR DESCRIPTION
## Description
LZ4 not creating in custom user data path (was using cd on the drive)
[SEARCH-1466](https://perzoinc.atlassian.net/browse/SEARCH-1466)

## Solution Approach
Use the drive name to navigate to that drive before performing any task

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
Swift-Search | [#18](https://github.com/symphonyoss/SwiftSearch/pull/18)
Swift-Search | [#19](https://github.com/symphonyoss/SwiftSearch/pull/19)
SymphonyElectron - master | [#653](https://github.com/symphonyoss/SymphonyElectron/pull/653)
