### PR TITLE
ELECTRON-1247 (Remove old Symphony launch agent plist file)

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,8 @@
     "react": "16.6.3",
     "react-dom": "16.6.0",
     "ref-napi": "1.4.1",
-    "shell-path": "2.1.0"
+    "shell-path": "2.1.0",
+    "auto-launch": "5.0.5"
   },
   "optionalDependencies": {
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.5",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
   "dependencies": {
     "archiver": "3.0.0",
     "async.map": "0.5.2",
+    "auto-launch": "5.0.5",
     "classnames": "2.2.6",
     "electron-dl": "1.14.0",
     "electron-fetch": "1.3.0",
@@ -123,8 +124,7 @@
     "react": "16.6.3",
     "react-dom": "16.6.0",
     "ref-napi": "1.4.1",
-    "shell-path": "2.1.0",
-    "auto-launch": "5.0.5"
+    "shell-path": "2.1.0"
   },
   "optionalDependencies": {
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.5",

--- a/src/app/auto-launch-controller.ts
+++ b/src/app/auto-launch-controller.ts
@@ -1,3 +1,4 @@
+import AutoLaunch = require('auto-launch');
 import { app, LoginItemSettings } from 'electron';
 
 import { isMac } from '../common/env';
@@ -57,6 +58,11 @@ class AutoLaunchController {
         const { launchOnStartup }: IConfig = config.getConfigFields([ 'launchOnStartup' ]);
         const { openAtLogin: isAutoLaunchEnabled }: LoginItemSettings = this.isAutoLaunchEnabled();
 
+        if (isMac) {
+            // TODO: Remove this method in the future
+            await this.removeOldLaunchAgent();
+        }
+
         if (typeof launchOnStartup === 'boolean' && launchOnStartup) {
             if (!isAutoLaunchEnabled) {
                 this.enableAutoLaunch();
@@ -65,6 +71,20 @@ class AutoLaunchController {
         }
         if (isAutoLaunchEnabled) {
             this.disableAutoLaunch();
+        }
+    }
+
+    /**
+     * Removes old Symphony launch agent if exists
+     *
+     * @deprecated
+     */
+    private async removeOldLaunchAgent(): Promise<void> {
+        const autoLaunch = new AutoLaunch(props);
+        try {
+            await autoLaunch.disable();
+        } catch (e) {
+            logger.error(`auto-launch-controller: Old Symphony launch agent failed to remove ${e}`);
         }
     }
 }

--- a/src/app/auto-launch-controller.ts
+++ b/src/app/auto-launch-controller.ts
@@ -83,6 +83,7 @@ class AutoLaunchController {
         const autoLaunch = new AutoLaunch(props);
         try {
             await autoLaunch.disable();
+            logger.info(`auto-launch-controller: Old Symphony launch agent has been successfully removed`);
         } catch (e) {
             logger.error(`auto-launch-controller: Old Symphony launch agent failed to remove ${e}`);
         }

--- a/src/app/config-handler.ts
+++ b/src/app/config-handler.ts
@@ -97,9 +97,6 @@ class Config {
         this.readGlobalConfig();
 
         this.checkFirstTimeLaunch();
-
-        logger.info(`config-handler: user config path -> ${this.userConfigPath}`);
-        logger.info(`config-handler: global config path -> ${this.globalConfigPath}`);
     }
 
     /**

--- a/src/app/config-handler.ts
+++ b/src/app/config-handler.ts
@@ -97,6 +97,9 @@ class Config {
         this.readGlobalConfig();
 
         this.checkFirstTimeLaunch();
+
+        logger.info(`config-handler: user config path -> ${this.userConfigPath}`);
+        logger.info(`config-handler: global config path -> ${this.globalConfigPath}`);
     }
 
     /**


### PR DESCRIPTION
## Description
Remove old Symphony launch agent plist file 
[ELECTRON-1247](https://perzoinc.atlassian.net/browse/ELECTRON-1247)

## Solution Approach
Using the third party `auto-launch` module (used previously) to remove the plist file.
The new launch on startup API provided by Electron creates an entry @ login items

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
3.x | [link](https://github.com/symphonyoss/SymphonyElectron/pull/649)
