### PR TITLE
feat: SEARCH-1514 - Include Index-Validator for verifying the index

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,6 @@
   },
   "optionalDependencies": {
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.5",
-    "swift-search": "1.55.2-beta.2"
+    "swift-search": "1.55.2-beta.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
       "config/titleBarStyles.css",
       "dictionaries/**",
       "library/libsymphonysearch.dylib",
+      "library/indexvalidator.exec",
       "library/cryptoLib.dylib",
       "library/lz4.exec"
     ],
@@ -128,6 +129,6 @@
   },
   "optionalDependencies": {
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.5",
-    "swift-search": "1.55.2-beta.1"
+    "swift-search": "1.55.2-beta.2"
   }
 }


### PR DESCRIPTION
## Description
Include Index-Validator for verifying the index.
[SEARCH-1514](https://perzoinc.atlassian.net/browse/SEARCH-1514)

## Solution Approach
When we initialize the corrupted index it crashes the electron app. So in order to prevent unexpected crashes, we validate the index before initializing.  

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
SymphonyElectron `5.x` | [#670](https://github.com/symphonyoss/SymphonyElectron/pull/670)
SwiftSearch | [#22](https://github.com/symphonyoss/SwiftSearch/pull/22)