### PR TITLE
feat: SEARCH-1313 - Bump swift-search version from 3.0.0 to 1.55.2

### DIFF
--- a/src/renderer/ssf-api.ts
+++ b/src/renderer/ssf-api.ts
@@ -176,7 +176,8 @@ export class SSFApi {
             containerVer: appVer,
             buildNumber,
             apiVer: '2.0.0',
-            searchApiVer: '3.0.0',
+            // Only need to bump if there are any breaking changes.
+            searchApiVer: '1.55.2',
         });
     }
 


### PR DESCRIPTION
## Description
Support Swift-Search from `1.55.2`
[JIRA-ticket](https://perzoinc.atlassian.net/browse/JIRA-ticket)

## Solution Approach
1. Swift-Search will be supported from 1.55.2
2. All the older build we will be deprecated

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
SymphonyElectron - `master` | [#674](https://github.com/symphonyoss/SymphonyElectron/pull/674)
