### PR TITLE
fix: Typescript (Bump electron version to 3.1.11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "browserify": "16.2.3",
     "cross-env": "5.2.0",
     "del": "3.0.0",
-    "electron": "3.1.9",
+    "electron": "3.1.11",
     "electron-builder": "20.38.4",
     "electron-builder-squirrel-windows": "20.38.3",
     "electron-rebuild": "1.8.2",


### PR DESCRIPTION
Bump Electron version to `3.1.11`

https://github.com/electron/electron/releases/tag/v3.1.11