### PR TITLE
feat: ELECTRON-1297 (Add role alert to the notification container)

### DIFF
--- a/src/renderer/components/notification-comp.tsx
+++ b/src/renderer/components/notification-comp.tsx
@@ -59,7 +59,7 @@ export default class NotificationComp extends React.Component<{}, IState> {
         const bgColor = { backgroundColor: colorHex || '#ffffff' };
 
         return (
-            <div className='container' style={bgColor} onClick={this.eventHandlers.onClick(id)}>
+            <div className='container' role='alert' style={bgColor} onClick={this.eventHandlers.onClick(id)}>
                 <div className='logo-container'>
                     <img className={`logo ${theme}`} alt='symphony logo'/>
                 </div>


### PR DESCRIPTION
## Description
Add role alert to the notification container to make screenreader read it properly 
[ELECTRON-1297](https://perzoinc.atlassian.net/browse/ELECTRON-1297)

## Solution Approach
Add `role: 'alert'` to the notification container
