### PR TITLE
fix: ELECTRON-1169 (Increase screen sharing indicator to support Japanese chars)

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -95,7 +95,7 @@ export class WindowHandler {
      */
     private static getScreenSharingIndicatorOpts(): ICustomBrowserWindowConstructorOpts {
         return {
-            width: 592,
+            width: 620,
             height: 48,
             show: false,
             modal: true,


### PR DESCRIPTION
## Description
Fix Japanese chars from overlapping with button 
[ELECTRON-1169](https://perzoinc.atlassian.net/browse/ELECTRON-1169)

## Solution Approach
Increase the size of the window from `592` to `620`

### Screenshots

#### Before
![Screenshot 2019-06-17 at 1 35 53 PM](https://user-images.githubusercontent.com/13243259/59588501-5a751f80-9105-11e9-966f-56b149904881.png)

#### After
<img src="https://user-images.githubusercontent.com/13243259/59588509-61039700-9105-11e9-8336-30475ae7d463.png" alt="Screenshot 2019-06-17 at 1 37 14 PM" width="617">
