### PR TITLE
feat: Bump search API version to 1.55.3 to support from R55.3

### DIFF
--- a/src/renderer/ssf-api.ts
+++ b/src/renderer/ssf-api.ts
@@ -177,7 +177,7 @@ export class SSFApi {
             buildNumber,
             apiVer: '2.0.0',
             // Only need to bump if there are any breaking changes.
-            searchApiVer: '3.0.0',
+            searchApiVer: '1.55.3',
         });
     }
 


### PR DESCRIPTION
## Description
Bump search API version to 1.55.3 to support from R55.3
[JIRA-ticket](https://perzoinc.atlassian.net/browse/JIRA-ticket)

## Solution Approach
N/A

## Related PRs
N/A