### PR TITLE
feat: SEARCH-1527 - Display swift-search version details in the More Info

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,6 @@
   },
   "optionalDependencies": {
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.5",
-    "swift-search": "1.55.2-beta.5"
+    "swift-search": "1.55.2-beta.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "3.8.0",
   "clientVersion": "1.55",
   "buildNumber": "0",
+  "searchAPIVersion": "1.55.3",
   "description": "Symphony desktop app (Foundation ODP)",
   "author": "Symphony",
   "main": "lib/src/app/init.js",

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -14,12 +14,12 @@
     "User name:": "User name:"
   },
   "MoreInfo": {
+    "Index Version": "Index Version",
     "More Information": "More Information",
     "Others": "Others",
     "related": "related",
-    "Version Information": "Version Information",
     "Supported Version": "Supported Version",
-    "Index Version": "Index Version"
+    "Version Information": "Version Information"
   },
   "Bring All to Front": "Bring All to Front",
   "Bring to Front on Notifications": "Bring to Front on Notifications",

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -17,7 +17,9 @@
     "More Information": "More Information",
     "Others": "Others",
     "related": "related",
-    "Version Information": "Version Information"
+    "Version Information": "Version Information",
+    "Supported Version": "Supported Version",
+    "Index Version": "Index Version"
   },
   "Bring All to Front": "Bring All to Front",
   "Bring to Front on Notifications": "Bring to Front on Notifications",

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -14,11 +14,11 @@
     "User name:": "User name:"
   },
   "MoreInfo": {
-    "Index Version": "Index Version",
+    "Swift Search Version": "Swift Search Version",
     "More Information": "More Information",
     "Others": "Others",
     "related": "related",
-    "Supported Version": "Supported Version",
+    "API Version": "API Version",
     "Version Information": "Version Information"
   },
   "Bring All to Front": "Bring All to Front",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -14,12 +14,12 @@
     "User name:": "User name:"
   },
   "MoreInfo": {
+    "Index Version": "Index Version",
     "More Information": "More Information",
     "Others": "Others",
     "related": "related",
-    "Version Information": "Version Information",
     "Supported Version": "Supported Version",
-    "Index Version": "Index Version"
+    "Version Information": "Version Information"
   },
   "Bring All to Front": "Bring All to Front",
   "Bring to Front on Notifications": "Bring to Front on Notifications",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -17,7 +17,9 @@
     "More Information": "More Information",
     "Others": "Others",
     "related": "related",
-    "Version Information": "Version Information"
+    "Version Information": "Version Information",
+    "Supported Version": "Supported Version",
+    "Index Version": "Index Version"
   },
   "Bring All to Front": "Bring All to Front",
   "Bring to Front on Notifications": "Bring to Front on Notifications",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -14,11 +14,11 @@
     "User name:": "User name:"
   },
   "MoreInfo": {
-    "Index Version": "Index Version",
+    "Swift Search Version": "Swift Search Version",
     "More Information": "More Information",
     "Others": "Others",
     "related": "related",
-    "Supported Version": "Supported Version",
+    "API Version": "API Version",
     "Version Information": "Version Information"
   },
   "Bring All to Front": "Bring All to Front",

--- a/src/locale/fr-FR.json
+++ b/src/locale/fr-FR.json
@@ -73,11 +73,11 @@
   "Minimize on Close": "Minimiser Symphony au lieu quitter",
   "More Information": "Informations détaillées",
   "MoreInfo": {
-    "Index Version": "Version d'index",
+    "Swift Search Version": "Version de recherche rapide",
     "More Information": "Informations détaillées",
     "Others": "Autres",
     "related": "en relation",
-    "Supported Version": "Version prise en charge",
+    "API Version": "Version de l'API",
     "Version Information": "Information sur cette version de Symphony"
   },
   "Native": "Originaire",

--- a/src/locale/fr-FR.json
+++ b/src/locale/fr-FR.json
@@ -73,12 +73,12 @@
   "Minimize on Close": "Minimiser Symphony au lieu quitter",
   "More Information": "Informations détaillées",
   "MoreInfo": {
+    "Index Version": "Version d'index",
     "More Information": "Informations détaillées",
     "Others": "Autres",
     "related": "en relation",
-    "Version Information": "Information sur cette version de Symphony",
     "Supported Version": "Version prise en charge",
-    "Index Version": "Version d'index"
+    "Version Information": "Information sur cette version de Symphony"
   },
   "Native": "Originaire",
   "Network connectivity has been lost. Check your internet connection.": "La connectivité a été perdue. Vérifiez votre connection à l'internet.",

--- a/src/locale/fr-FR.json
+++ b/src/locale/fr-FR.json
@@ -76,7 +76,9 @@
     "More Information": "Informations détaillées",
     "Others": "Autres",
     "related": "en relation",
-    "Version Information": "Information sur cette version de Symphony"
+    "Version Information": "Information sur cette version de Symphony",
+    "Supported Version": "Version prise en charge",
+    "Index Version": "Version d'index"
   },
   "Native": "Originaire",
   "Network connectivity has been lost. Check your internet connection.": "La connectivité a été perdue. Vérifiez votre connection à l'internet.",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -73,11 +73,11 @@
   "Minimize on Close": "Minimiser Symphony au lieu quitter",
   "More Information": "Informations détaillées",
   "MoreInfo": {
-    "Index Version": "Version d'index",
+    "Swift Search Version": "Version de recherche rapide",
     "More Information": "Informations détaillées",
     "Others": "Autres",
     "related": "en relation",
-    "Supported Version": "Version prise en charge",
+    "API Version": "Version de l'API",
     "Version Information": "Information sur cette version de Symphony"
   },
   "Native": "Originaire",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -73,12 +73,12 @@
   "Minimize on Close": "Minimiser Symphony au lieu quitter",
   "More Information": "Informations détaillées",
   "MoreInfo": {
+    "Index Version": "Version d'index",
     "More Information": "Informations détaillées",
     "Others": "Autres",
     "related": "en relation",
-    "Version Information": "Information sur cette version de Symphony",
     "Supported Version": "Version prise en charge",
-    "Index Version": "Version d'index"
+    "Version Information": "Information sur cette version de Symphony"
   },
   "Native": "Originaire",
   "Network connectivity has been lost. Check your internet connection.": "La connectivité a été perdue. Vérifiez votre connection à l'internet.",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -76,7 +76,9 @@
     "More Information": "Informations détaillées",
     "Others": "Autres",
     "related": "en relation",
-    "Version Information": "Information sur cette version de Symphony"
+    "Version Information": "Information sur cette version de Symphony",
+    "Supported Version": "Version prise en charge",
+    "Index Version": "Version d'index"
   },
   "Native": "Originaire",
   "Network connectivity has been lost. Check your internet connection.": "La connectivité a été perdue. Vérifiez votre connection à l'internet.",

--- a/src/locale/ja-JP.json
+++ b/src/locale/ja-JP.json
@@ -17,7 +17,9 @@
     "More Information": "詳しくは",
     "Others": "その他",
     "related": "関連した",
-    "Version Information": "バージョン情報"
+    "Version Information": "バージョン情報",
+    "Supported Version": "対応バージョン",
+    "Index Version": "索引バージョン"
   },
   "Bring All to Front": "すべて前面に表示",
   "Bring to Front on Notifications": "通知時に前面に表示",

--- a/src/locale/ja-JP.json
+++ b/src/locale/ja-JP.json
@@ -14,12 +14,12 @@
     "User name:": "ユーザー名："
   },
   "MoreInfo": {
+    "Index Version": "索引バージョン",
     "More Information": "詳しくは",
     "Others": "その他",
     "related": "関連した",
-    "Version Information": "バージョン情報",
     "Supported Version": "対応バージョン",
-    "Index Version": "索引バージョン"
+    "Version Information": "バージョン情報"
   },
   "Bring All to Front": "すべて前面に表示",
   "Bring to Front on Notifications": "通知時に前面に表示",

--- a/src/locale/ja-JP.json
+++ b/src/locale/ja-JP.json
@@ -14,11 +14,11 @@
     "User name:": "ユーザー名："
   },
   "MoreInfo": {
-    "Index Version": "索引バージョン",
+    "Swift Search Version": "迅速な検索バージョン",
     "More Information": "詳しくは",
     "Others": "その他",
     "related": "関連した",
-    "Supported Version": "対応バージョン",
+    "API Version": "APIのバージョン",
     "Version Information": "バージョン情報"
   },
   "Bring All to Front": "すべて前面に表示",

--- a/src/locale/ja.json
+++ b/src/locale/ja.json
@@ -17,7 +17,9 @@
     "More Information": "詳しくは",
     "Others": "その他",
     "related": "関連した",
-    "Version Information": "バージョン情報"
+    "Version Information": "バージョン情報",
+    "Supported Version": "対応バージョン",
+    "Index Version": "索引バージョン"
   },
   "Bring All to Front": "すべて前面に表示",
   "Bring to Front on Notifications": "通知時に前面に表示",

--- a/src/locale/ja.json
+++ b/src/locale/ja.json
@@ -14,12 +14,12 @@
     "User name:": "ユーザー名："
   },
   "MoreInfo": {
+    "Index Version": "索引バージョン",
     "More Information": "詳しくは",
     "Others": "その他",
     "related": "関連した",
-    "Version Information": "バージョン情報",
     "Supported Version": "対応バージョン",
-    "Index Version": "索引バージョン"
+    "Version Information": "バージョン情報"
   },
   "Bring All to Front": "すべて前面に表示",
   "Bring to Front on Notifications": "通知時に前面に表示",

--- a/src/locale/ja.json
+++ b/src/locale/ja.json
@@ -14,11 +14,11 @@
     "User name:": "ユーザー名："
   },
   "MoreInfo": {
-    "Index Version": "索引バージョン",
+    "Swift Search Version": "迅速な検索バージョン",
     "More Information": "詳しくは",
     "Others": "その他",
     "related": "関連した",
-    "Supported Version": "対応バージョン",
+    "API Version": "APIのバージョン",
     "Version Information": "バージョン情報"
   },
   "Bring All to Front": "すべて前面に表示",

--- a/src/renderer/components/more-info.tsx
+++ b/src/renderer/components/more-info.tsx
@@ -2,11 +2,61 @@ import * as React from 'react';
 
 import { i18n } from '../../common/i18n-preload';
 
+interface ISSDataInterface {
+    supportedVersion?: string;
+    indexVersion?: string;
+}
+
 const MORE_INFO_NAMESPACE = 'MoreInfo';
+
+/**
+ * Returns process variable if the value is set
+ */
+const getSwiftSearchData = () => {
+    let swiftSearchInfo = null;
+
+    if (process && process.env) {
+        try {
+            swiftSearchInfo = JSON.parse(process.env.SWIFT_SEARCH || '');
+        } catch (e) {
+            return null;
+        }
+    }
+
+    return swiftSearchInfo;
+};
+
 /**
  * Window that display app version and copyright info
  */
 export default class MoreInfo extends React.PureComponent {
+
+    /**
+     * Render Swift-Search version details
+     */
+    public static renderSwiftSearchInfo(): JSX.Element | null {
+        const { indexVersion, supportedVersion }: ISSDataInterface = getSwiftSearchData() || {};
+        if (!indexVersion || !supportedVersion) {
+            return null;
+        }
+        return (
+            <div className='content'>
+                <h4>Swift Search</h4>
+                <table>
+                    <tbody>
+                    <tr>
+                        <th>{i18n.t('Supported Version', MORE_INFO_NAMESPACE)()}</th>
+                        <th>{i18n.t('Index Version', MORE_INFO_NAMESPACE)()}</th>
+                    </tr>
+                    <tr>
+                        <td>{supportedVersion || 'N/A'}</td>
+                        <td>{indexVersion || 'N/A'}</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        );
+    }
 
     /**
      * main render function
@@ -57,6 +107,7 @@ export default class MoreInfo extends React.PureComponent {
                         </tbody>
                     </table>
                 </div>
+                {MoreInfo.renderSwiftSearchInfo()}
             </div>
         );
     }

--- a/src/renderer/components/more-info.tsx
+++ b/src/renderer/components/more-info.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 
+import { optionalDependencies, searchAPIVersion } from '../../../package.json';
 import { i18n } from '../../common/i18n-preload';
 
 interface ISSDataInterface {
     supportedVersion?: string;
-    indexVersion?: string;
+    swiftSearchVersion?: string;
 }
 
 const MORE_INFO_NAMESPACE = 'MoreInfo';
@@ -13,16 +14,10 @@ const MORE_INFO_NAMESPACE = 'MoreInfo';
  * Returns process variable if the value is set
  */
 const getSwiftSearchData = () => {
-    let swiftSearchInfo = null;
-
-    if (process && process.env) {
-        try {
-            swiftSearchInfo = JSON.parse(process.env.SWIFT_SEARCH || '');
-        } catch (e) {
-            return null;
-        }
-    }
-
+    const swiftSearchInfo: ISSDataInterface = {
+            swiftSearchVersion: optionalDependencies['swift-search'],
+            supportedVersion: searchAPIVersion,
+    };
     return swiftSearchInfo;
 };
 
@@ -35,8 +30,8 @@ export default class MoreInfo extends React.PureComponent {
      * Render Swift-Search version details
      */
     public static renderSwiftSearchInfo(): JSX.Element | null {
-        const { indexVersion, supportedVersion }: ISSDataInterface = getSwiftSearchData() || {};
-        if (!indexVersion || !supportedVersion) {
+        const { swiftSearchVersion, supportedVersion }: ISSDataInterface = getSwiftSearchData() || {};
+        if (!swiftSearchVersion || !supportedVersion) {
             return null;
         }
         return (
@@ -45,12 +40,12 @@ export default class MoreInfo extends React.PureComponent {
                 <table>
                     <tbody>
                     <tr>
-                        <th>{i18n.t('Supported Version', MORE_INFO_NAMESPACE)()}</th>
-                        <th>{i18n.t('Index Version', MORE_INFO_NAMESPACE)()}</th>
+                        <th>{i18n.t('Swift Search Version', MORE_INFO_NAMESPACE)()}</th>
+                        <th>{i18n.t('API Version', MORE_INFO_NAMESPACE)()}</th>
                     </tr>
                     <tr>
+                        <td>{swiftSearchVersion || 'N/A'}</td>
                         <td>{supportedVersion || 'N/A'}</td>
-                        <td>{indexVersion || 'N/A'}</td>
                     </tr>
                     </tbody>
                 </table>

--- a/src/renderer/ssf-api.ts
+++ b/src/renderer/ssf-api.ts
@@ -1,6 +1,6 @@
 import { ipcRenderer, remote } from 'electron';
 
-import { buildNumber } from '../../package.json';
+import { buildNumber, searchAPIVersion } from '../../package.json';
 import { ICustomBrowserWindow } from '../app/window-handler';
 import {
     apiCmds,
@@ -177,7 +177,7 @@ export class SSFApi {
             buildNumber,
             apiVer: '2.0.0',
             // Only need to bump if there are any breaking changes.
-            searchApiVer: '1.55.3',
+            searchApiVer: searchAPIVersion,
         });
     }
 


### PR DESCRIPTION
## Description
Display swift-search version details in the More Info
[SEARCH-1527](https://perzoinc.atlassian.net/browse/SEARCH-1527)

**Preview:** 
![Screenshot 2019-06-19 at 1 47 29 PM](https://user-images.githubusercontent.com/596478/59748485-d5227400-9298-11e9-85c5-c3effa0c62fb.png)

## Solution Approach
Sets the version info data in the `process.env` and displayed in the more-info window only if `Swift Search` is enabled.

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
Swift-Search | [#26](https://github.com/symphonyoss/SwiftSearch/pull/26)
