### PR TITLE
fix: ELECTRON-1264 (Fix ATS for localhost and update TLS version to 1.2)

### DIFF
--- a/config/Symphony.config
+++ b/config/Symphony.config
@@ -13,11 +13,6 @@
         "position": "upper-right",
         "display": ""
     },
-    "crashReporter": {
-        "submitURL": "https://localhost:1127/post",
-        "companyName": "Symphony",
-        "uploadToServer": false
-    },
     "customFlags": {
         "authServerWhitelist": "",
         "authNegotiateDelegateWhitelist": "",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,17 @@
     "appId": "com.symphony.electron-desktop",
     "mac": {
       "target": "dmg",
-      "category": "public.app-category.business"
+      "category": "public.app-category.business",
+      "extendInfo": {
+        "NSAppTransportSecurity": {
+          "NSExceptionDomains": {
+            "localhost": {
+              "NSTemporaryExceptionAllowsInsecureHTTPLoads": false,
+              "NSTemporaryExceptionMinimumTLSVersion": "1.2"
+            }
+          }
+        }
+      }
     },
     "dmg": {
       "contents": [

--- a/package.json
+++ b/package.json
@@ -49,17 +49,7 @@
     "appId": "com.symphony.electron-desktop",
     "mac": {
       "target": "dmg",
-      "category": "public.app-category.business",
-      "extendInfo": {
-        "NSAppTransportSecurity": {
-          "NSExceptionDomains": {
-            "localhost": {
-              "NSTemporaryExceptionAllowsInsecureHTTPLoads": false,
-              "NSTemporaryExceptionMinimumTLSVersion": "1.2"
-            }
-          }
-        }
-      }
+      "category": "public.app-category.business"
     },
     "dmg": {
       "contents": [

--- a/src/app/chrome-flags.ts
+++ b/src/app/chrome-flags.ts
@@ -3,6 +3,10 @@ import { logger } from '../common/logger';
 import { getCommandLineArgs } from '../common/utils';
 import { config, IConfig } from './config-handler';
 
+// Set default flags
+logger.info(`chrome-flags: Setting mandatory chrome flags`, { flag: { 'ssl-version-fallback-min': 'tls1.2' } });
+app.commandLine.appendSwitch('ssl-version-fallback-min', 'tls1.2');
+
 /**
  * Sets chrome flags
  */

--- a/src/app/config-handler.ts
+++ b/src/app/config-handler.ts
@@ -38,7 +38,6 @@ export interface IConfig {
     notificationSettings: INotificationSetting;
     permissions: IPermission;
     customFlags: ICustomFlag;
-    crashReporter: ICrashReporter;
     mainWinPos?: ICustomRectangle;
 }
 
@@ -56,12 +55,6 @@ export interface ICustomFlag {
     authServerWhitelist: string;
     authNegotiateDelegateWhitelist: string;
     disableGpu: boolean;
-}
-
-export interface ICrashReporter {
-    submitURL: string;
-    companyName: string;
-    uploadToServer: boolean;
 }
 
 export interface INotificationSetting {

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -178,7 +178,7 @@ export class WindowHandler {
     constructor(opts?: Electron.BrowserViewConstructorOptions) {
         // Use these variables only on initial setup
         this.config = config.getConfigFields([ 'isCustomTitleBar', 'mainWinPos', 'minimizeOnClose', 'notificationSettings' ]);
-        this.globalConfig = config.getGlobalConfigFields([ 'url', 'crashReporter' ]);
+        this.globalConfig = config.getGlobalConfigFields([ 'url' ]);
 
         this.windows = {};
         this.isCustomTitleBar = isWindowsOS && this.config.isCustomTitleBar;
@@ -190,7 +190,8 @@ export class WindowHandler {
 
         try {
             const extra = { podUrl: this.globalConfig.url, process: 'main' };
-            crashReporter.start({ ...this.globalConfig.crashReporter, extra });
+            const defaultOpts = { uploadToServer: false, companyName: 'Symphony', submitURL: '' };
+            crashReporter.start({ ...defaultOpts, extra });
         } catch (e) {
             throw new Error('failed to init crash report');
         }


### PR DESCRIPTION
## Description
Fix ATS for localhost and update TLS version to `1.2`
[ELECTRON-1264](https://perzoinc.atlassian.net/browse/ELECTRON-1264)

## Solution Approach
- Disable sending crash dumps to server

To prevent vulnerable in the adjacent network
ATS for the localhost has been updated with 
- NSTemporaryExceptionAllowsInsecureHTTPLoads - NO
- NSTemporaryExceptionMinimumTLSVersion - 1.2

### Updated Plist file
```
<key>NSAppTransportSecurity</key>
<dict>
   <key>NSExceptionDomains</key>
   <dict>
      <key>localhost</key>
      <dict>
         <key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
         <false />
         <key>NSTemporaryExceptionMinimumTLSVersion</key>
         <string>1.2</string>
      </dict>
   </dict>
   <key>NSAllowsLocalNetworking</key> // note: can't be updated via electron-builder
   <true />
   <key>NSAllowsArbitraryLoads</key> // note: can't be updated via electron-builder
   <true />
</dict>
```

### Learning
https://github.com/electron-userland/electron-builder/issues/3377

Notes: Fix ATS for localhost and update TLS version to 1.2