### PR TITLE
fix: ELECTRON-1310 L10N: Minimize on Close not localized in French

### DIFF
--- a/src/locale/fr-FR.json
+++ b/src/locale/fr-FR.json
@@ -70,7 +70,7 @@
   "Learn More": "En savoir plus sur Symphony",
   "Loading Error": "Erreur lors du chargement",
   "Minimize": "Minimiser",
-  "Minimize on Close": "Minimiser Symphony au lieu quitter",
+  "Minimize on Close": "Minimiser lors de la fermeture",
   "More Information": "Informations détaillées",
   "MoreInfo": {
     "More Information": "Informations détaillées",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -50,7 +50,7 @@
     "Downloaded": "Téléchargé",
     "File not Found": "Fichier non trouvé",
     "Open": "Ouvrir",
-    "Reveal in Finder": "Reveal in Finder",
+    "Reveal in Finder": "Montrer le fichier",
     "Show in Folder": "Afficher dans le dossier",
     "The file you are trying to open cannot be found in the specified path.": "Le fichier que vous essayez d'ouvrir est introuvable dans le chemin spécifié."
   },
@@ -70,7 +70,7 @@
   "Learn More": "En savoir plus sur Symphony",
   "Loading Error": "Erreur lors du chargement",
   "Minimize": "Minimiser",
-  "Minimize on Close": "Minimiser Symphony au lieu quitter",
+  "Minimize on Close": "Minimiser lors de la fermeture",
   "More Information": "Informations détaillées",
   "MoreInfo": {
     "More Information": "Informations détaillées",


### PR DESCRIPTION
## Description
Fix the main menu option "Minimize on Close" which did not have french translation
[ELECTRON-1310](https://perzoinc.atlassian.net/browse/ELECTRON-1310)

## Solution Approach
Add appropriate strings to the french translation files

## Related PRs
N/A