### PR TITLE
feat: ELECTRON-1292 (Unpack node binding files)

### DIFF
--- a/installer/win/Symphony-x64.aip
+++ b/installer/win/Symphony-x64.aip
@@ -71,10 +71,14 @@
     <ROW Directory="APPDIR" Directory_Parent="TARGETDIR" DefaultDir="APPDIR:." IsPseudoRoot="1"/>
     <ROW Directory="DesktopFolder" Directory_Parent="TARGETDIR" DefaultDir="DESKTO~1|DesktopFolder" IsPseudoRoot="1"/>
     <ROW Directory="ProgramMenuFolder" Directory_Parent="TARGETDIR" DefaultDir="PROGRA~1|ProgramMenuFolder" IsPseudoRoot="1"/>
+    <ROW Directory="Release_1_Dir" Directory_Parent="build_1_Dir" DefaultDir="Release"/>
+    <ROW Directory="Release_2_Dir" Directory_Parent="build_2_Dir" DefaultDir="Release"/>
     <ROW Directory="Release_Dir" Directory_Parent="build_Dir" DefaultDir="Release"/>
     <ROW Directory="Symphony_Dir" Directory_Parent="ProgramMenuFolder" DefaultDir="Symphony"/>
     <ROW Directory="TARGETDIR" DefaultDir="SourceDir"/>
     <ROW Directory="app.asar.unpacked_Dir" Directory_Parent="resources_Dir" DefaultDir="APPASA~1.UNP|app.asar.unpacked"/>
+    <ROW Directory="build_1_Dir" Directory_Parent="spellchecker_Dir" DefaultDir="build"/>
+    <ROW Directory="build_2_Dir" Directory_Parent="keyboardlayout_Dir" DefaultDir="build"/>
     <ROW Directory="build_Dir" Directory_Parent="cld_Dir" DefaultDir="build"/>
     <ROW Directory="cld_Dir" Directory_Parent="nornagon_Dir" DefaultDir="cld"/>
     <ROW Directory="config_Dir" Directory_Parent="APPDIR" DefaultDir="config"/>
@@ -83,6 +87,7 @@
     <ROW Directory="frFR_Dir" Directory_Parent="APPDIR" DefaultDir="fr-FR"/>
     <ROW Directory="jaJP_Dir" Directory_Parent="APPDIR" DefaultDir="ja-JP"/>
     <ROW Directory="jobber_Dir" Directory_Parent="vendor_Dir" DefaultDir="jobber"/>
+    <ROW Directory="keyboardlayout_Dir" Directory_Parent="node_modules_Dir" DefaultDir="KEYBOA~1|keyboard-layout"/>
     <ROW Directory="lib_Dir" Directory_Parent="spawnrx_Dir" DefaultDir="lib"/>
     <ROW Directory="library_Dir" Directory_Parent="APPDIR" DefaultDir="library"/>
     <ROW Directory="locales_Dir" Directory_Parent="APPDIR" DefaultDir="locales"/>
@@ -90,6 +95,7 @@
     <ROW Directory="nornagon_Dir" Directory_Parent="node_modules_Dir" DefaultDir="@NORNA~1|@nornagon"/>
     <ROW Directory="resources_Dir" Directory_Parent="APPDIR" DefaultDir="RESOUR~1|resources"/>
     <ROW Directory="spawnrx_Dir" Directory_Parent="node_modules_Dir" DefaultDir="spawn-rx"/>
+    <ROW Directory="spellchecker_Dir" Directory_Parent="nornagon_Dir" DefaultDir="SPELLC~1|spellchecker"/>
     <ROW Directory="src_1_Dir" Directory_Parent="spawnrx_Dir" DefaultDir="src"/>
     <ROW Directory="src_Dir" Directory_Parent="lib_Dir" DefaultDir="src"/>
     <ROW Directory="vendor_Dir" Directory_Parent="spawnrx_Dir" DefaultDir="vendor"/>
@@ -153,7 +159,7 @@
     <ROW Component="appupdate.yml" ComponentId="{F7586760-660A-4C38-8937-138DBEC18D34}" Directory_="resources_Dir" Attributes="0" KeyPath="app.asar" Type="0"/>
     <ROW Component="blink_image_resources_200_percent.pak" ComponentId="{56AB17A5-B690-4CBE-A39D-512381AAAFE1}" Directory_="APPDIR" Attributes="0" KeyPath="LICENSES.chromium.html" Type="0"/>
     <ROW Component="build.cmd" ComponentId="{2892AEA1-7773-46FE-8F4C-56E7EAC3BDC3}" Directory_="spawnrx_Dir" Attributes="0" KeyPath="build.cmd" Type="0"/>
-    <ROW Component="cld.node" ComponentId="{46D3CC1B-49D8-4C9F-A85F-80D76B303742}" Directory_="Release_Dir" Attributes="256" KeyPath="cld.node" Type="0"/>
+    <ROW Component="cld.node" ComponentId="{2598E57C-15B4-4B21-9DDA-EBD760F45C79}" Directory_="Release_Dir" Attributes="256" KeyPath="cld.node" Type="0"/>
     <ROW Component="d3dcompiler_47.dll" ComponentId="{C7B87C02-3116-43A8-A70B-3592B70E6AC8}" Directory_="APPDIR" Attributes="256" KeyPath="d3dcompiler_47.dll"/>
     <ROW Component="enAU.bdic" ComponentId="{13F10BB0-1A04-4A5E-8B6D-33CA73C97AEB}" Directory_="dictionaries_Dir" Attributes="0" KeyPath="enAU.bdic" Type="0"/>
     <ROW Component="ffmpeg.dll" ComponentId="{A1C4A332-3490-44D8-A5C9-9523889B488B}" Directory_="APPDIR" Attributes="256" KeyPath="ffmpeg.dll"/>
@@ -161,19 +167,21 @@
     <ROW Component="index.js_1" ComponentId="{E2560E07-B7EA-4186-94B6-0EAE52C043C0}" Directory_="src_Dir" Attributes="0" KeyPath="index.js_1" Type="0"/>
     <ROW Component="index.ts" ComponentId="{19341989-DFA6-4A3D-BCA7-9D49243BFB69}" Directory_="src_1_Dir" Attributes="0" KeyPath="index.ts" Type="0"/>
     <ROW Component="indexvalidatorx64.exe" ComponentId="{0266F3CF-5462-4381-9971-2353034D7E1D}" Directory_="library_Dir" Attributes="256" KeyPath="indexvalidatorx64.exe"/>
+    <ROW Component="keyboardlayoutmanager.node" ComponentId="{A5757182-A878-4BFC-A5FB-BD5CD57382F6}" Directory_="Release_2_Dir" Attributes="256" KeyPath="keyboardlayoutmanager.node" Type="0"/>
     <ROW Component="libEGL.dll" ComponentId="{8EEC76AB-3601-4D11-B13E-32EC2A38C539}" Directory_="APPDIR" Attributes="256" KeyPath="libEGL.dll"/>
     <ROW Component="libGLESv2.dll" ComponentId="{0E8B8B21-B4C0-45C9-95D3-637FD93A4EC0}" Directory_="APPDIR" Attributes="256" KeyPath="libGLESv2.dll"/>
     <ROW Component="libsymphonysearchx64.dll" ComponentId="{A8C99D17-FA62-4996-8FAE-52D1DCF9BF26}" Directory_="library_Dir" Attributes="256" KeyPath="libsymphonysearchx64.dll"/>
     <ROW Component="lz4winx64.exe" ComponentId="{8B78B313-EAE9-4533-AFEB-56F9E0CA73A1}" Directory_="library_Dir" Attributes="256" KeyPath="lz4winx64.exe"/>
     <ROW Component="msvcp140.dll" ComponentId="{1707D859-AA62-43AB-9C02-348C17880FB3}" Directory_="APPDIR" Attributes="256" KeyPath="msvcp140.dll"/>
     <ROW Component="node.dll" ComponentId="{0E65A920-9A9F-48AC-A68A-68063FC7A0C2}" Directory_="APPDIR" Attributes="256" KeyPath="node.dll"/>
+    <ROW Component="spellchecker.node" ComponentId="{C3444491-74ED-4F80-8F8A-76363B0DF5E5}" Directory_="Release_1_Dir" Attributes="256" KeyPath="spellchecker.node" Type="0"/>
     <ROW Component="tarwin.exe" ComponentId="{4C98F3B1-1A73-4761-86C0-DE0FC18A8800}" Directory_="library_Dir" Attributes="0" KeyPath="tarwin.exe"/>
     <ROW Component="ucrtbase.dll" ComponentId="{48708875-5036-4297-8F00-42CE4E49FC45}" Directory_="APPDIR" Attributes="256" KeyPath="ucrtbase.dll"/>
     <ROW Component="vcruntime140.dll" ComponentId="{C370CC97-A06E-4E68-9BCF-1263EBD7D14A}" Directory_="APPDIR" Attributes="256" KeyPath="vcruntime140.dll"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiFeatsComponent">
     <ROW Feature="D564007E3BBE4F85950A09B470A7CA65" Title="Visual C++ Redistributable for Visual Studio 2013 x86" Description="Visual C++ Redistributable for Visual Studio 2013 x86" Display="3" Level="1" Attributes="0"/>
-    <ROW Feature="MainFeature" Title="MainFeature" Description="Description" Display="1" Level="1" Directory_="APPDIR" Attributes="0" Components="AI_CustomARPName AI_DisableModify Jobber.exe PodUrl ProductInformation ScreenSnippet.exe ScreenSnippet.resources.dll ScreenSnippet.resources.dll_1 ScreenSnippet.resources.dll_2 Symphony Symphony.config Symphony.exe _ __1 am.pak apimswincoreconsolel110.dll apimswincoredatetimel110.dll apimswincoredebugl110.dll apimswincoreerrorhandlingl110.dll apimswincorefilel110.dll apimswincorefilel120.dll apimswincorefilel210.dll apimswincorehandlel110.dll apimswincoreheapl110.dll apimswincoreinterlockedl110.dll apimswincorelibraryloaderl110.dll apimswincorelocalizationl120.dll apimswincorememoryl110.dll apimswincorenamedpipel110.dll apimswincoreprocessenvironmentl110.dll apimswincoreprocessthreadsl110.dll apimswincoreprocessthreadsl111.dll apimswincoreprofilel110.dll apimswincorertlsupportl110.dll apimswincorestringl110.dll apimswincoresynchl110.dll apimswincoresynchl120.dll apimswincoresysinfol110.dll apimswincoretimezonel110.dll apimswincoreutill110.dll apimswincrtconiol110.dll apimswincrtconvertl110.dll apimswincrtenvironmentl110.dll apimswincrtfilesysteml110.dll apimswincrtheapl110.dll apimswincrtlocalel110.dll apimswincrtmathl110.dll apimswincrtmultibytel110.dll apimswincrtprivatel110.dll apimswincrtprocessl110.dll apimswincrtruntimel110.dll apimswincrtstdiol110.dll apimswincrtstringl110.dll apimswincrttimel110.dll apimswincrtutilityl110.dll appupdate.yml blink_image_resources_200_percent.pak build.cmd cld.node d3dcompiler_47.dll enAU.bdic ffmpeg.dll index.js index.js_1 index.ts indexvalidatorx64.exe libEGL.dll libGLESv2.dll libsymphonysearchx64.dll lz4winx64.exe msvcp140.dll node.dll tarwin.exe ucrtbase.dll vcruntime140.dll"/>
+    <ROW Feature="MainFeature" Title="MainFeature" Description="Description" Display="1" Level="1" Directory_="APPDIR" Attributes="0" Components="AI_CustomARPName AI_DisableModify Jobber.exe PodUrl ProductInformation ScreenSnippet.exe ScreenSnippet.resources.dll ScreenSnippet.resources.dll_1 ScreenSnippet.resources.dll_2 Symphony Symphony.config Symphony.exe _ __1 am.pak apimswincoreconsolel110.dll apimswincoredatetimel110.dll apimswincoredebugl110.dll apimswincoreerrorhandlingl110.dll apimswincorefilel110.dll apimswincorefilel120.dll apimswincorefilel210.dll apimswincorehandlel110.dll apimswincoreheapl110.dll apimswincoreinterlockedl110.dll apimswincorelibraryloaderl110.dll apimswincorelocalizationl120.dll apimswincorememoryl110.dll apimswincorenamedpipel110.dll apimswincoreprocessenvironmentl110.dll apimswincoreprocessthreadsl110.dll apimswincoreprocessthreadsl111.dll apimswincoreprofilel110.dll apimswincorertlsupportl110.dll apimswincorestringl110.dll apimswincoresynchl110.dll apimswincoresynchl120.dll apimswincoresysinfol110.dll apimswincoretimezonel110.dll apimswincoreutill110.dll apimswincrtconiol110.dll apimswincrtconvertl110.dll apimswincrtenvironmentl110.dll apimswincrtfilesysteml110.dll apimswincrtheapl110.dll apimswincrtlocalel110.dll apimswincrtmathl110.dll apimswincrtmultibytel110.dll apimswincrtprivatel110.dll apimswincrtprocessl110.dll apimswincrtruntimel110.dll apimswincrtstdiol110.dll apimswincrtstringl110.dll apimswincrttimel110.dll apimswincrtutilityl110.dll appupdate.yml blink_image_resources_200_percent.pak build.cmd cld.node d3dcompiler_47.dll enAU.bdic ffmpeg.dll index.js index.js_1 index.ts indexvalidatorx64.exe keyboardlayoutmanager.node libEGL.dll libGLESv2.dll libsymphonysearchx64.dll lz4winx64.exe msvcp140.dll node.dll spellchecker.node tarwin.exe ucrtbase.dll vcruntime140.dll"/>
     <ATTRIBUTE name="CurrentFeature" value="MainFeature"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiFilesComponent">
@@ -238,7 +246,7 @@
     <ROW File="build.cmd" Component_="build.cmd" FileName="build.cmd" Attributes="0" SourcePath="..\..\dist\win-unpacked\resources\app.asar.unpacked\node_modules\spawn-rx\build.cmd" SelfReg="false" NextFile="build.sh"/>
     <ROW File="build.sh" Component_="build.cmd" FileName="build.sh" Attributes="0" SourcePath="..\..\dist\win-unpacked\resources\app.asar.unpacked\node_modules\spawn-rx\build.sh" SelfReg="false" NextFile="CODE_OF_CONDUCT.md"/>
     <ROW File="ca.pak" Component_="am.pak" FileName="ca.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\ca.pak" SelfReg="false" NextFile="cs.pak"/>
-    <ROW File="cld.node" Component_="cld.node" FileName="CLD~1.NOD|cld.node" Attributes="0" SourcePath="..\..\dist\win-unpacked\resources\app.asar.unpacked\node_modules\@nornagon\cld\build\Release\cld.node" SelfReg="false" NextFile="build.cmd"/>
+    <ROW File="cld.node" Component_="cld.node" FileName="CLD~1.NOD|cld.node" Attributes="0" SourcePath="..\..\dist\win-unpacked\resources\app.asar.unpacked\node_modules\@nornagon\cld\build\Release\cld.node" SelfReg="false" NextFile="spellchecker.node"/>
     <ROW File="content_resources_200_percent.pak" Component_="blink_image_resources_200_percent.pak" FileName="CONTEN~1.PAK|content_resources_200_percent.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\content_resources_200_percent.pak" SelfReg="false" NextFile="content_shell.pak"/>
     <ROW File="content_shell.pak" Component_="blink_image_resources_200_percent.pak" FileName="CONTEN~2.PAK|content_shell.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\content_shell.pak" SelfReg="false" NextFile="msvcp140.dll"/>
     <ROW File="cs.pak" Component_="am.pak" FileName="cs.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\cs.pak" SelfReg="false" NextFile="da.pak"/>
@@ -262,7 +270,7 @@
     <ROW File="fi.pak" Component_="am.pak" FileName="fi.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\fi.pak" SelfReg="false" NextFile="fil.pak"/>
     <ROW File="fil.pak" Component_="am.pak" FileName="fil.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\fil.pak" SelfReg="false" NextFile="fr.pak"/>
     <ROW File="fr.pak" Component_="am.pak" FileName="fr.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\fr.pak" SelfReg="false" NextFile="gu.pak"/>
-    <ROW File="frFR.bdic" Component_="enAU.bdic" FileName="FR-FR~1.BDI|fr-FR.bdic" Attributes="0" SourcePath="..\..\dist\win-unpacked\dictionaries\fr-FR.bdic" SelfReg="false" NextFile="cld.node"/>
+    <ROW File="frFR.bdic" Component_="enAU.bdic" FileName="FR-FR~1.BDI|fr-FR.bdic" Attributes="0" SourcePath="..\..\dist\win-unpacked\dictionaries\fr-FR.bdic" SelfReg="false" NextFile="build.cmd"/>
     <ROW File="gu.pak" Component_="am.pak" FileName="gu.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\gu.pak" SelfReg="false" NextFile="he.pak"/>
     <ROW File="he.pak" Component_="am.pak" FileName="he.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\he.pak" SelfReg="false" NextFile="hi.pak"/>
     <ROW File="hi.pak" Component_="am.pak" FileName="hi.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\hi.pak" SelfReg="false" NextFile="hr.pak"/>
@@ -277,6 +285,7 @@
     <ROW File="indexvalidatorx64.exe" Component_="indexvalidatorx64.exe" FileName="INDEXV~1.EXE|indexvalidator-x64.exe" Attributes="0" SourcePath="..\..\library\indexvalidator-x64.exe" SelfReg="false" NextFile="libsymphonysearchx64.dll" DigSign="true"/>
     <ROW File="it.pak" Component_="am.pak" FileName="it.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\it.pak" SelfReg="false" NextFile="ja.pak"/>
     <ROW File="ja.pak" Component_="am.pak" FileName="ja.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\ja.pak" SelfReg="false" NextFile="kn.pak"/>
+    <ROW File="keyboardlayoutmanager.node" Component_="keyboardlayoutmanager.node" FileName="KEYBOA~1.NOD|keyboard-layout-manager.node" Attributes="0" SourcePath="..\..\dist\win-unpacked\resources\app.asar.unpacked\node_modules\keyboard-layout\build\Release\keyboard-layout-manager.node" SelfReg="false"/>
     <ROW File="kn.pak" Component_="am.pak" FileName="kn.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\kn.pak" SelfReg="false" NextFile="ko.pak"/>
     <ROW File="ko.pak" Component_="am.pak" FileName="ko.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\ko.pak" SelfReg="false" NextFile="lt.pak"/>
     <ROW File="libEGL.dll" Component_="libEGL.dll" FileName="libEGL.dll" Attributes="0" SourcePath="..\..\dist\win-unpacked\libEGL.dll" SelfReg="false" NextFile="libGLESv2.dll"/>
@@ -301,6 +310,7 @@
     <ROW File="ru.pak" Component_="am.pak" FileName="ru.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\ru.pak" SelfReg="false" NextFile="sk.pak"/>
     <ROW File="sk.pak" Component_="am.pak" FileName="sk.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\sk.pak" SelfReg="false" NextFile="sl.pak"/>
     <ROW File="sl.pak" Component_="am.pak" FileName="sl.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\sl.pak" SelfReg="false" NextFile="sr.pak"/>
+    <ROW File="spellchecker.node" Component_="spellchecker.node" FileName="SPELLC~1.NOD|spellchecker.node" Attributes="0" SourcePath="..\..\dist\win-unpacked\resources\app.asar.unpacked\node_modules\@nornagon\spellchecker\build\Release\spellchecker.node" SelfReg="false" NextFile="keyboardlayoutmanager.node"/>
     <ROW File="sr.pak" Component_="am.pak" FileName="sr.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\sr.pak" SelfReg="false" NextFile="sv.pak"/>
     <ROW File="sv.pak" Component_="am.pak" FileName="sv.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\sv.pak" SelfReg="false" NextFile="sw.pak"/>
     <ROW File="sw.pak" Component_="am.pak" FileName="sw.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\sw.pak" SelfReg="false" NextFile="ta.pak"/>
@@ -318,7 +328,7 @@
     <ROW File="v8_context_snapshot.bin" Component_="blink_image_resources_200_percent.pak" FileName="V8_CON~1.BIN|v8_context_snapshot.bin" Attributes="0" SourcePath="..\..\dist\win-unpacked\v8_context_snapshot.bin" SelfReg="false" NextFile="ScreenSnippet.resources.dll_2"/>
     <ROW File="vcruntime140.dll" Component_="vcruntime140.dll" FileName="VCRUNT~1.DLL|vcruntime140.dll" Attributes="0" SourcePath="..\..\dist\win-unpacked\vcruntime140.dll" SelfReg="false" NextFile="views_resources_200_percent.pak"/>
     <ROW File="vi.pak" Component_="am.pak" FileName="vi.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\vi.pak" SelfReg="false" NextFile="zhCN.pak"/>
-    <ROW File="views_resources_200_percent.pak" Component_="blink_image_resources_200_percent.pak" FileName="VIEWS_~1.PAK|views_resources_200_percent.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\views_resources_200_percent.pak" SelfReg="false"/>
+    <ROW File="views_resources_200_percent.pak" Component_="blink_image_resources_200_percent.pak" FileName="VIEWS_~1.PAK|views_resources_200_percent.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\views_resources_200_percent.pak" SelfReg="false" NextFile="cld.node"/>
     <ROW File="zhCN.pak" Component_="am.pak" FileName="zh-CN.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\zh-CN.pak" SelfReg="false" NextFile="zhTW.pak"/>
     <ROW File="zhTW.pak" Component_="am.pak" FileName="zh-TW.pak" Attributes="0" SourcePath="..\..\dist\win-unpacked\locales\zh-TW.pak" SelfReg="false" NextFile="app.asar"/>
   </COMPONENT>

--- a/installer/win/Symphony-x86.aip
+++ b/installer/win/Symphony-x86.aip
@@ -70,10 +70,14 @@
     <ROW Directory="APPDIR" Directory_Parent="TARGETDIR" DefaultDir="APPDIR:." IsPseudoRoot="1"/>
     <ROW Directory="DesktopFolder" Directory_Parent="TARGETDIR" DefaultDir="DESKTO~1|DesktopFolder" IsPseudoRoot="1"/>
     <ROW Directory="ProgramMenuFolder" Directory_Parent="TARGETDIR" DefaultDir="PROGRA~1|ProgramMenuFolder" IsPseudoRoot="1"/>
+    <ROW Directory="Release_1_Dir" Directory_Parent="build_1_Dir" DefaultDir="Release"/>
+    <ROW Directory="Release_2_Dir" Directory_Parent="build_2_Dir" DefaultDir="Release"/>
     <ROW Directory="Release_Dir" Directory_Parent="build_Dir" DefaultDir="Release"/>
     <ROW Directory="Symphony_Dir" Directory_Parent="ProgramMenuFolder" DefaultDir="Symphony"/>
     <ROW Directory="TARGETDIR" DefaultDir="SourceDir"/>
     <ROW Directory="app.asar.unpacked_Dir" Directory_Parent="resources_Dir" DefaultDir="APPASA~1.UNP|app.asar.unpacked"/>
+    <ROW Directory="build_1_Dir" Directory_Parent="spellchecker_Dir" DefaultDir="build"/>
+    <ROW Directory="build_2_Dir" Directory_Parent="keyboardlayout_Dir" DefaultDir="build"/>
     <ROW Directory="build_Dir" Directory_Parent="cld_Dir" DefaultDir="build"/>
     <ROW Directory="cld_Dir" Directory_Parent="nornagon_Dir" DefaultDir="cld"/>
     <ROW Directory="config_Dir" Directory_Parent="APPDIR" DefaultDir="config"/>
@@ -82,6 +86,7 @@
     <ROW Directory="frFR_Dir" Directory_Parent="APPDIR" DefaultDir="fr-FR"/>
     <ROW Directory="jaJP_Dir" Directory_Parent="APPDIR" DefaultDir="ja-JP"/>
     <ROW Directory="jobber_Dir" Directory_Parent="vendor_Dir" DefaultDir="jobber"/>
+    <ROW Directory="keyboardlayout_Dir" Directory_Parent="node_modules_Dir" DefaultDir="KEYBOA~1|keyboard-layout"/>
     <ROW Directory="lib_Dir" Directory_Parent="spawnrx_Dir" DefaultDir="lib"/>
     <ROW Directory="library_Dir" Directory_Parent="APPDIR" DefaultDir="library"/>
     <ROW Directory="locales_Dir" Directory_Parent="APPDIR" DefaultDir="locales"/>
@@ -89,6 +94,7 @@
     <ROW Directory="nornagon_Dir" Directory_Parent="node_modules_Dir" DefaultDir="@NORNA~1|@nornagon"/>
     <ROW Directory="resources_Dir" Directory_Parent="APPDIR" DefaultDir="RESOUR~1|resources"/>
     <ROW Directory="spawnrx_Dir" Directory_Parent="node_modules_Dir" DefaultDir="spawn-rx"/>
+    <ROW Directory="spellchecker_Dir" Directory_Parent="nornagon_Dir" DefaultDir="SPELLC~1|spellchecker"/>
     <ROW Directory="src_1_Dir" Directory_Parent="spawnrx_Dir" DefaultDir="src"/>
     <ROW Directory="src_Dir" Directory_Parent="lib_Dir" DefaultDir="src"/>
     <ROW Directory="vendor_Dir" Directory_Parent="spawnrx_Dir" DefaultDir="vendor"/>
@@ -153,7 +159,7 @@
     <ROW Component="appupdate.yml" ComponentId="{0C70DAF7-B9A5-42E8-8EAD-986872DA450E}" Directory_="resources_Dir" Attributes="0" KeyPath="app.asar" Type="0"/>
     <ROW Component="blink_image_resources_200_percent.pak" ComponentId="{19811F96-6FFC-4970-A103-9D0F5A1A402D}" Directory_="APPDIR" Attributes="0" KeyPath="LICENSES.chromium.html" Type="0"/>
     <ROW Component="build.cmd" ComponentId="{0B1FF3EE-4E08-405F-817D-CB331FA79B71}" Directory_="spawnrx_Dir" Attributes="0" KeyPath="build.cmd" Type="0"/>
-    <ROW Component="cld.node" ComponentId="{BF08B491-B206-459D-AFBC-6C9E0E423FAE}" Directory_="Release_Dir" Attributes="0" KeyPath="cld.node" Type="0"/>
+    <ROW Component="cld.node" ComponentId="{020FE13E-4FB0-47FF-A5B9-37BB11E493E6}" Directory_="Release_Dir" Attributes="0" KeyPath="cld.node" Type="0"/>
     <ROW Component="d3dcompiler_47.dll" ComponentId="{86265353-5735-4FB2-85EB-26947BE73061}" Directory_="APPDIR" Attributes="0" KeyPath="d3dcompiler_47.dll"/>
     <ROW Component="enAU.bdic" ComponentId="{D150D8CE-8674-41D5-BDDA-3524275B8B22}" Directory_="dictionaries_Dir" Attributes="0" KeyPath="enAU.bdic" Type="0"/>
     <ROW Component="ffmpeg.dll" ComponentId="{6ECB1C9B-C14D-4224-A048-D2C4666426DC}" Directory_="APPDIR" Attributes="0" KeyPath="ffmpeg.dll"/>
@@ -161,19 +167,21 @@
     <ROW Component="index.js_1" ComponentId="{980DEA8F-BCD4-462C-BB10-19CB9C9BF379}" Directory_="src_Dir" Attributes="0" KeyPath="index.js_1" Type="0"/>
     <ROW Component="index.ts" ComponentId="{E723998B-165A-4AD5-B006-3FA866BB5172}" Directory_="src_1_Dir" Attributes="0" KeyPath="index.ts" Type="0"/>
     <ROW Component="indexvalidatorx86.exe" ComponentId="{173E5F1C-C2AF-48A4-8D6C-7A68B79D45E0}" Directory_="library_Dir" Attributes="0" KeyPath="indexvalidatorx86.exe"/>
+    <ROW Component="keyboardlayoutmanager.node" ComponentId="{532EB1E2-D4E0-4CB8-8347-B3E02770F85A}" Directory_="Release_2_Dir" Attributes="0" KeyPath="keyboardlayoutmanager.node" Type="0"/>
     <ROW Component="libEGL.dll" ComponentId="{4FA3C90D-C473-4484-B884-1A32AD9DE4D7}" Directory_="APPDIR" Attributes="0" KeyPath="libEGL.dll"/>
     <ROW Component="libGLESv2.dll" ComponentId="{06513829-1D3E-4286-BB01-112BF26E6684}" Directory_="APPDIR" Attributes="0" KeyPath="libGLESv2.dll"/>
     <ROW Component="libsymphonysearchx86.dll" ComponentId="{0FE8E551-95CE-4936-8553-217ED411CAD5}" Directory_="library_Dir" Attributes="0" KeyPath="libsymphonysearchx86.dll"/>
     <ROW Component="lz4winx86.exe" ComponentId="{C71364D8-6FE2-4BA1-8D89-12B075FFAEFD}" Directory_="library_Dir" Attributes="0" KeyPath="lz4winx86.exe"/>
     <ROW Component="msvcp140.dll" ComponentId="{525C79C9-0E1B-4B26-83D6-86985DA3D108}" Directory_="APPDIR" Attributes="0" KeyPath="msvcp140.dll"/>
     <ROW Component="node.dll" ComponentId="{23EB0B96-6B0C-4773-805B-AAEAE3A27C1F}" Directory_="APPDIR" Attributes="0" KeyPath="node.dll"/>
+    <ROW Component="spellchecker.node" ComponentId="{92E61C9F-EA4D-4EE6-8AC8-5E4BAB91E98B}" Directory_="Release_1_Dir" Attributes="0" KeyPath="spellchecker.node" Type="0"/>
     <ROW Component="tarwin.exe" ComponentId="{B7E57E12-8788-49D4-A31C-23E821D36B2F}" Directory_="library_Dir" Attributes="0" KeyPath="tarwin.exe"/>
     <ROW Component="ucrtbase.dll" ComponentId="{8D88C162-12DD-4033-85EE-9C11C2F259A0}" Directory_="APPDIR" Attributes="0" KeyPath="ucrtbase.dll"/>
     <ROW Component="vcruntime140.dll" ComponentId="{2D4A913B-D202-47DA-958F-DD5A3EF9C2F2}" Directory_="APPDIR" Attributes="0" KeyPath="vcruntime140.dll"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiFeatsComponent">
     <ROW Feature="D564007E3BBE4F85950A09B470A7CA65" Title="Visual C++ Redistributable for Visual Studio 2013 x86" Description="Visual C++ Redistributable for Visual Studio 2013 x86" Display="3" Level="1" Attributes="0"/>
-    <ROW Feature="MainFeature" Title="MainFeature" Description="Description" Display="1" Level="1" Directory_="APPDIR" Attributes="0" Components="AI_CustomARPName AI_DisableModify APIMSWincorexstatel210.dll Jobber.exe PodUrl ProductInformation ScreenSnippet.exe ScreenSnippet.resources.dll ScreenSnippet.resources.dll_1 ScreenSnippet.resources.dll_2 Symphony Symphony.config Symphony.exe _ __1 am.pak apimswincoreconsolel110.dll apimswincoredatetimel110.dll apimswincoredebugl110.dll apimswincoreerrorhandlingl110.dll apimswincorefilel110.dll apimswincorefilel120.dll apimswincorefilel210.dll apimswincorehandlel110.dll apimswincoreheapl110.dll apimswincoreinterlockedl110.dll apimswincorelibraryloaderl110.dll apimswincorelocalizationl120.dll apimswincorememoryl110.dll apimswincorenamedpipel110.dll apimswincoreprocessenvironmentl110.dll apimswincoreprocessthreadsl110.dll apimswincoreprocessthreadsl111.dll apimswincoreprofilel110.dll apimswincorertlsupportl110.dll apimswincorestringl110.dll apimswincoresynchl110.dll apimswincoresynchl120.dll apimswincoresysinfol110.dll apimswincoretimezonel110.dll apimswincoreutill110.dll apimswincrtconiol110.dll apimswincrtconvertl110.dll apimswincrtenvironmentl110.dll apimswincrtfilesysteml110.dll apimswincrtheapl110.dll apimswincrtlocalel110.dll apimswincrtmathl110.dll apimswincrtmultibytel110.dll apimswincrtprivatel110.dll apimswincrtprocessl110.dll apimswincrtruntimel110.dll apimswincrtstdiol110.dll apimswincrtstringl110.dll apimswincrttimel110.dll apimswincrtutilityl110.dll appupdate.yml blink_image_resources_200_percent.pak build.cmd cld.node d3dcompiler_47.dll enAU.bdic ffmpeg.dll index.js index.js_1 index.ts indexvalidatorx86.exe libEGL.dll libGLESv2.dll libsymphonysearchx86.dll lz4winx86.exe msvcp140.dll node.dll tarwin.exe ucrtbase.dll vcruntime140.dll"/>
+    <ROW Feature="MainFeature" Title="MainFeature" Description="Description" Display="1" Level="1" Directory_="APPDIR" Attributes="0" Components="AI_CustomARPName AI_DisableModify APIMSWincorexstatel210.dll Jobber.exe PodUrl ProductInformation ScreenSnippet.exe ScreenSnippet.resources.dll ScreenSnippet.resources.dll_1 ScreenSnippet.resources.dll_2 Symphony Symphony.config Symphony.exe _ __1 am.pak apimswincoreconsolel110.dll apimswincoredatetimel110.dll apimswincoredebugl110.dll apimswincoreerrorhandlingl110.dll apimswincorefilel110.dll apimswincorefilel120.dll apimswincorefilel210.dll apimswincorehandlel110.dll apimswincoreheapl110.dll apimswincoreinterlockedl110.dll apimswincorelibraryloaderl110.dll apimswincorelocalizationl120.dll apimswincorememoryl110.dll apimswincorenamedpipel110.dll apimswincoreprocessenvironmentl110.dll apimswincoreprocessthreadsl110.dll apimswincoreprocessthreadsl111.dll apimswincoreprofilel110.dll apimswincorertlsupportl110.dll apimswincorestringl110.dll apimswincoresynchl110.dll apimswincoresynchl120.dll apimswincoresysinfol110.dll apimswincoretimezonel110.dll apimswincoreutill110.dll apimswincrtconiol110.dll apimswincrtconvertl110.dll apimswincrtenvironmentl110.dll apimswincrtfilesysteml110.dll apimswincrtheapl110.dll apimswincrtlocalel110.dll apimswincrtmathl110.dll apimswincrtmultibytel110.dll apimswincrtprivatel110.dll apimswincrtprocessl110.dll apimswincrtruntimel110.dll apimswincrtstdiol110.dll apimswincrtstringl110.dll apimswincrttimel110.dll apimswincrtutilityl110.dll appupdate.yml blink_image_resources_200_percent.pak build.cmd cld.node d3dcompiler_47.dll enAU.bdic ffmpeg.dll index.js index.js_1 index.ts indexvalidatorx86.exe keyboardlayoutmanager.node libEGL.dll libGLESv2.dll libsymphonysearchx86.dll lz4winx86.exe msvcp140.dll node.dll spellchecker.node tarwin.exe ucrtbase.dll vcruntime140.dll"/>
     <ATTRIBUTE name="CurrentFeature" value="MainFeature"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiFilesComponent">
@@ -239,7 +247,7 @@
     <ROW File="build.cmd" Component_="build.cmd" FileName="build.cmd" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\resources\app.asar.unpacked\node_modules\spawn-rx\build.cmd" SelfReg="false" NextFile="build.sh"/>
     <ROW File="build.sh" Component_="build.cmd" FileName="build.sh" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\resources\app.asar.unpacked\node_modules\spawn-rx\build.sh" SelfReg="false" NextFile="CODE_OF_CONDUCT.md"/>
     <ROW File="ca.pak" Component_="am.pak" FileName="ca.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\ca.pak" SelfReg="false" NextFile="cs.pak"/>
-    <ROW File="cld.node" Component_="cld.node" FileName="CLD~1.NOD|cld.node" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\resources\app.asar.unpacked\node_modules\@nornagon\cld\build\Release\cld.node" SelfReg="false" NextFile="build.cmd"/>
+    <ROW File="cld.node" Component_="cld.node" FileName="CLD~1.NOD|cld.node" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\resources\app.asar.unpacked\node_modules\@nornagon\cld\build\Release\cld.node" SelfReg="false" NextFile="spellchecker.node"/>
     <ROW File="content_resources_200_percent.pak" Component_="blink_image_resources_200_percent.pak" FileName="CONTEN~1.PAK|content_resources_200_percent.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\content_resources_200_percent.pak" SelfReg="false" NextFile="content_shell.pak"/>
     <ROW File="content_shell.pak" Component_="blink_image_resources_200_percent.pak" FileName="CONTEN~2.PAK|content_shell.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\content_shell.pak" SelfReg="false" NextFile="msvcp140.dll"/>
     <ROW File="cs.pak" Component_="am.pak" FileName="cs.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\cs.pak" SelfReg="false" NextFile="da.pak"/>
@@ -263,7 +271,7 @@
     <ROW File="fi.pak" Component_="am.pak" FileName="fi.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\fi.pak" SelfReg="false" NextFile="fil.pak"/>
     <ROW File="fil.pak" Component_="am.pak" FileName="fil.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\fil.pak" SelfReg="false" NextFile="fr.pak"/>
     <ROW File="fr.pak" Component_="am.pak" FileName="fr.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\fr.pak" SelfReg="false" NextFile="gu.pak"/>
-    <ROW File="frFR.bdic" Component_="enAU.bdic" FileName="FR-FR~1.BDI|fr-FR.bdic" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\dictionaries\fr-FR.bdic" SelfReg="false" NextFile="cld.node"/>
+    <ROW File="frFR.bdic" Component_="enAU.bdic" FileName="FR-FR~1.BDI|fr-FR.bdic" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\dictionaries\fr-FR.bdic" SelfReg="false" NextFile="build.cmd"/>
     <ROW File="gu.pak" Component_="am.pak" FileName="gu.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\gu.pak" SelfReg="false" NextFile="he.pak"/>
     <ROW File="he.pak" Component_="am.pak" FileName="he.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\he.pak" SelfReg="false" NextFile="hi.pak"/>
     <ROW File="hi.pak" Component_="am.pak" FileName="hi.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\hi.pak" SelfReg="false" NextFile="hr.pak"/>
@@ -278,6 +286,7 @@
     <ROW File="indexvalidatorx86.exe" Component_="indexvalidatorx86.exe" FileName="INDEXV~2.EXE|indexvalidator-x86.exe" Attributes="0" SourcePath="..\..\library\indexvalidator-x86.exe" SelfReg="false" NextFile="libsymphonysearchx86.dll" DigSign="true"/>
     <ROW File="it.pak" Component_="am.pak" FileName="it.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\it.pak" SelfReg="false" NextFile="ja.pak"/>
     <ROW File="ja.pak" Component_="am.pak" FileName="ja.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\ja.pak" SelfReg="false" NextFile="kn.pak"/>
+    <ROW File="keyboardlayoutmanager.node" Component_="keyboardlayoutmanager.node" FileName="KEYBOA~1.NOD|keyboard-layout-manager.node" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\resources\app.asar.unpacked\node_modules\keyboard-layout\build\Release\keyboard-layout-manager.node" SelfReg="false"/>
     <ROW File="kn.pak" Component_="am.pak" FileName="kn.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\kn.pak" SelfReg="false" NextFile="ko.pak"/>
     <ROW File="ko.pak" Component_="am.pak" FileName="ko.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\ko.pak" SelfReg="false" NextFile="lt.pak"/>
     <ROW File="libEGL.dll" Component_="libEGL.dll" FileName="libEGL.dll" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\libEGL.dll" SelfReg="false" NextFile="libGLESv2.dll"/>
@@ -302,6 +311,7 @@
     <ROW File="ru.pak" Component_="am.pak" FileName="ru.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\ru.pak" SelfReg="false" NextFile="sk.pak"/>
     <ROW File="sk.pak" Component_="am.pak" FileName="sk.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\sk.pak" SelfReg="false" NextFile="sl.pak"/>
     <ROW File="sl.pak" Component_="am.pak" FileName="sl.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\sl.pak" SelfReg="false" NextFile="sr.pak"/>
+    <ROW File="spellchecker.node" Component_="spellchecker.node" FileName="SPELLC~1.NOD|spellchecker.node" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\resources\app.asar.unpacked\node_modules\@nornagon\spellchecker\build\Release\spellchecker.node" SelfReg="false" NextFile="keyboardlayoutmanager.node"/>
     <ROW File="sr.pak" Component_="am.pak" FileName="sr.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\sr.pak" SelfReg="false" NextFile="sv.pak"/>
     <ROW File="sv.pak" Component_="am.pak" FileName="sv.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\sv.pak" SelfReg="false" NextFile="sw.pak"/>
     <ROW File="sw.pak" Component_="am.pak" FileName="sw.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\sw.pak" SelfReg="false" NextFile="ta.pak"/>
@@ -319,7 +329,7 @@
     <ROW File="v8_context_snapshot.bin" Component_="blink_image_resources_200_percent.pak" FileName="V8_CON~1.BIN|v8_context_snapshot.bin" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\v8_context_snapshot.bin" SelfReg="false" NextFile="ScreenSnippet.resources.dll_2"/>
     <ROW File="vcruntime140.dll" Component_="vcruntime140.dll" FileName="VCRUNT~1.DLL|vcruntime140.dll" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\vcruntime140.dll" SelfReg="false" NextFile="views_resources_200_percent.pak"/>
     <ROW File="vi.pak" Component_="am.pak" FileName="vi.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\vi.pak" SelfReg="false" NextFile="zhCN.pak"/>
-    <ROW File="views_resources_200_percent.pak" Component_="blink_image_resources_200_percent.pak" FileName="VIEWS_~1.PAK|views_resources_200_percent.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\views_resources_200_percent.pak" SelfReg="false"/>
+    <ROW File="views_resources_200_percent.pak" Component_="blink_image_resources_200_percent.pak" FileName="VIEWS_~1.PAK|views_resources_200_percent.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\views_resources_200_percent.pak" SelfReg="false" NextFile="cld.node"/>
     <ROW File="zhCN.pak" Component_="am.pak" FileName="zh-CN.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\zh-CN.pak" SelfReg="false" NextFile="zhTW.pak"/>
     <ROW File="zhTW.pak" Component_="am.pak" FileName="zh-TW.pak" Attributes="0" SourcePath="..\..\dist\win-ia32-unpacked\locales\zh-TW.pak" SelfReg="false" NextFile="app.asar"/>
   </COMPONENT>

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
   },
   "build": {
     "asarUnpack": [
-      "node_modules/@nornagon/cld/build/Release/cld.node"
+      "node_modules/@nornagon/cld/build/Release/cld.node",
+      "node_modules/@nornagon/spellchecker/build/Release/spellchecker.node",
+      "node_modules/keyboard-layout/build/Release/keyboard-layout-manager.node"
     ],
     "files": [
       "!coverage/*",


### PR DESCRIPTION
## Description
Include `.node` bindings files to support proper signing of the files
[ELECTRON-1292](https://perzoinc.atlassian.net/browse/ELECTRON-1292)

## Solution Approach
Include `spellchecker.node` & `keyboard-layout-manager.node` in asarUnpack

## Learning
https://github.com/brave/browser-laptop/issues/12534

Notes: Include node bindings files in packager