### PR TITLE
feat: SEARCH-1562 - Check Index File Size Before Initializing Swift Search

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,6 @@
   },
   "optionalDependencies": {
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.5",
-    "swift-search": "1.55.2-beta.7"
+    "swift-search": "1.55.2-beta.8"
   }
 }


### PR DESCRIPTION
## Description
Check Index File Size Before Initializing Swift Search
[SEARCH-1562](https://perzoinc.atlassian.net/browse/SEARCH-1562)

## Approach
[comment]: # (How does this change address the problem?)
- **Checking disk space is done every time before Swift-Search is initialized.**
            - If low on disk space Swift-Search will be disabled
            - Else Swift-Search will continue with next process
- **Next, If the LZ4 file exists I check the size of the file**
            - If the file size exceeds, Swift-Search is disabled
            - We look at the size of LZ4 file. Let's say it is X. Then we need to check if there is (300MB - X) disk space. If so we should continue
            - Else Swift-Search will be disabled
- **Next, Validate the index**
            - Set the size of the index to the response from the validator
            - If the validation failed, initialize with fresh index
            - Else push it to ram and complete the initialization


## Learning
N/A

#### Blog Posts
N/A

## Related PRs
[comment]: # (List the related PRs against other branches.)

Repo | Branch | PR #
------ | ------ | ------
SFE-Client-App | branch-name | [PR #15317](https://github.com/SymphonyOSF/SFE-Client-App/pull/15317)
Swift-Search | branch-name | [PR #28](https://github.com/symphonyoss/SwiftSearch/pull/28)


## Open Questions if any and Todos
[comment]: # (When resolved, check the box and explain the answer.)
- [ ] Automation-Tests
- [x] Documentation
- [x] Language Translations
- [x] Unit-Tests

## Custom branch on PR builder
N/A