### PR TITLE
fix: ELECTRON-1243: fix chrome flags tests

### DIFF
--- a/config/Symphony.config
+++ b/config/Symphony.config
@@ -17,7 +17,8 @@
     "customFlags": {
         "authServerWhitelist": "",
         "authNegotiateDelegateWhitelist": "",
-        "disableGpu": false
+        "disableGpu": false,
+        "disableThrottling": false
     },
     "permissions": {
         "media": true,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "symphony",
   "productName": "Symphony",
   "version": "3.8.0",
-  "clientVersion": "1.55",
+  "clientVersion": "1.55.3",
   "buildNumber": "0",
   "searchAPIVersion": "1.55.3",
   "description": "Symphony desktop app (Foundation ODP)",

--- a/spec/chromeFlags.spec.ts
+++ b/spec/chromeFlags.spec.ts
@@ -89,8 +89,9 @@ describe('chrome flags', () => {
             expect(spy).nthCalledWith(4, 'disable-d3d11', true);
             expect(spy).nthCalledWith(5, 'disable-gpu', true);
             expect(spy).nthCalledWith(6, 'disable-gpu-compositing', true);
-            expect(spy).nthCalledWith(7, 'remote-debugging-port', '5858');
-            expect(spy).nthCalledWith(8, 'host-rules', 'MAP * 127.0.0.1');
+            expect(spy).nthCalledWith(7, 'disable-renderer-backgrounding', 'false');
+            expect(spy).nthCalledWith(8, 'remote-debugging-port', '5858');
+            expect(spy).nthCalledWith(9, 'host-rules', 'MAP * 127.0.0.1');
         });
 
         it('should return `undefined` when `chromeFlagsFromCmd` is null', () => {

--- a/src/app/chrome-flags.ts
+++ b/src/app/chrome-flags.ts
@@ -21,6 +21,7 @@ export const setChromeFlags = () => {
         'disable-d3d11': customFlags.disableGpu || null,
         'disable-gpu': customFlags.disableGpu || null,
         'disable-gpu-compositing': customFlags.disableGpu || null,
+        'disable-renderer-backgrounding': customFlags.disableThrottling || 'false',
     };
 
     for (const key in configFlags) {

--- a/src/app/config-handler.ts
+++ b/src/app/config-handler.ts
@@ -56,6 +56,7 @@ export interface ICustomFlag {
     authServerWhitelist: string;
     authNegotiateDelegateWhitelist: string;
     disableGpu: boolean;
+    disableThrottling: boolean;
 }
 
 export interface INotificationSetting {

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -10,10 +10,14 @@ import { setChromeFlags } from './chrome-flags';
 import { config } from './config-handler';
 import './dialog-handler';
 import './main-api-handler';
+import { handlePerformanceSettings } from './perf-handler';
 import { protocolHandler } from './protocol-handler';
 import { ICustomBrowserWindow, windowHandler } from './window-handler';
 
 const allowMultiInstance: string | boolean = getCommandLineArgs(process.argv, '--multiInstance', true) || isDevEnv;
+
+handlePerformanceSettings();
+setChromeFlags();
 
 // on windows, we create the protocol handler via the installer
 // because electron leaves registry traces upon uninstallation
@@ -41,7 +45,6 @@ const startApplication = async () => {
         await autoLaunchInstance.handleAutoLaunch();
     }
 
-    setChromeFlags();
 };
 
 // Handle multiple/single instances

--- a/src/app/perf-handler.ts
+++ b/src/app/perf-handler.ts
@@ -1,0 +1,15 @@
+import { powerSaveBlocker } from 'electron';
+import { logger } from '../common/logger';
+import { config, IConfig } from './config-handler';
+
+export const handlePerformanceSettings = () => {
+    const { customFlags } = config.getGlobalConfigFields([ 'customFlags' ]) as IConfig;
+
+    if (customFlags.disableThrottling) {
+        logger.info(`perf-handler: Disabling power throttling!`);
+        powerSaveBlocker.start('prevent-display-sleep');
+        return;
+    }
+
+    logger.info(`perf-handler: Power throttling enabled as config is not set to override power throttling!`);
+};

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -69,6 +69,7 @@ export class WindowHandler {
     public spellchecker: SpellChecker | undefined;
 
     private readonly contextIsolation: boolean;
+    private readonly backgroundThrottling: boolean;
     private readonly windowOpts: ICustomBrowserWindowConstructorOpts;
     private readonly globalConfig: IConfig;
     private readonly config: IConfig;
@@ -89,9 +90,12 @@ export class WindowHandler {
         // Use these variables only on initial setup
         this.config = config.getConfigFields([ 'isCustomTitleBar', 'mainWinPos', 'minimizeOnClose', 'notificationSettings' ]);
         this.globalConfig = config.getGlobalConfigFields([ 'url', 'contextIsolation' ]);
+        const { customFlags } = config.getGlobalConfigFields([ 'customFlags' ]) as IConfig;
+        this.globalConfig.customFlags = customFlags;
 
         this.windows = {};
         this.contextIsolation = this.globalConfig.contextIsolation || false;
+        this.backgroundThrottling = !this.globalConfig.customFlags.disableThrottling;
         this.isCustomTitleBar = isWindowsOS && this.config.isCustomTitleBar;
         this.windowOpts = {
             ...this.getWindowOpts({
@@ -789,6 +793,7 @@ export class WindowHandler {
                 sandbox: true,
                 nodeIntegration: false,
                 contextIsolation: this.contextIsolation,
+                backgroundThrottling: this.backgroundThrottling,
             }, ...webPreferences,
         };
         const defaultWindowOpts = {

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -89,9 +89,7 @@ export class WindowHandler {
     constructor(opts?: Electron.BrowserViewConstructorOptions) {
         // Use these variables only on initial setup
         this.config = config.getConfigFields([ 'isCustomTitleBar', 'mainWinPos', 'minimizeOnClose', 'notificationSettings' ]);
-        this.globalConfig = config.getGlobalConfigFields([ 'url', 'contextIsolation' ]);
-        const { customFlags } = config.getGlobalConfigFields([ 'customFlags' ]) as IConfig;
-        this.globalConfig.customFlags = customFlags;
+        this.globalConfig = config.getGlobalConfigFields([ 'url', 'contextIsolation', 'customFlags' ]);
 
         this.windows = {};
         this.contextIsolation = this.globalConfig.contextIsolation || false;

--- a/src/app/window-utils.ts
+++ b/src/app/window-utils.ts
@@ -164,7 +164,7 @@ export const showBadgeCount = (count: number): void => {
         return;
     }
 
-    logger.info(`window-utils: updating barge count to ${count}!`);
+    logger.info(`window-utils: updating badge count to ${count}!`);
 
     if (isMac) {
         // too big of a number here and setBadgeCount crashes


### PR DESCRIPTION
## Description
Add support for disabling throttling and background rendering.

[ELECTRON-1243](https://perzoinc.atlassian.net/browse/ELECTRON-1243)

## Solution
Add a flag `disableThrottling` in `Symphony.config` that would allow users to disable throttling.
