### PR TITLE
fix: ELECTRON-1278 (Bump up screen snippet version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "shell-path": "2.1.0"
   },
   "optionalDependencies": {
-    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.5",
+    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.6",
     "swift-search": "1.55.2-beta.8"
   }
 }


### PR DESCRIPTION
## Description
Set `useLegacyV2RuntimeActivationPolicy` to support Virtual Devices
[ELECTRON-1278](https://perzoinc.atlassian.net/browse/ELECTRON-1278)

## Solution Approach
Set `useLegacyV2RuntimeActivationPolicy` to support Virtual Devices

## Read more
https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/startup/startup-element
https://devblogs.microsoft.com/dotnet/in-process-side-by-side-part1/

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
ScreenSnippet | [link](https://github.com/symphonyoss/ScreenSnippet/pull/9)
