### PR TITLE
fix: ELECTRON-1227 (Add translations for permissions dialog)

### DIFF
--- a/src/app/window-actions.ts
+++ b/src/app/window-actions.ts
@@ -220,10 +220,9 @@ export const handleSessionPermissions = (permission: boolean, message: string, c
     logger.info(`window-action: permission is ->`, { type: message, permission });
 
     if (!permission) {
-        const fullMessage = `${i18n.t('Your administrator has disabled')()} ${message}. ${i18n.t('Please contact your admin for help')()}`;
         const browserWindow = BrowserWindow.getFocusedWindow();
         if (browserWindow && !browserWindow.isDestroyed()) {
-            dialog.showMessageBox(browserWindow, { type: 'error', title: `${i18n.t('Permission Denied')()}!`, message: fullMessage });
+            dialog.showMessageBox(browserWindow, { type: 'error', title: `${i18n.t('Permission Denied')()}!`, message });
         }
     }
 
@@ -251,19 +250,19 @@ export const handlePermissionRequests = (webContents: Electron.webContents): voi
     session.setPermissionRequestHandler((_webContents, permission, callback) => {
         switch (permission) {
             case Permissions.MEDIA:
-                return handleSessionPermissions(permissions.media, 'sharing your camera, microphone, and speakers', callback);
+                return handleSessionPermissions(permissions.media, i18n.t('Your administrator has disabled sharing your camera, microphone, and speakers. Please contact your admin for help', PERMISSIONS_NAMESPACE)(), callback);
             case Permissions.LOCATION:
-                return handleSessionPermissions(permissions.geolocation, 'sharing your location', callback);
+                return handleSessionPermissions(permissions.geolocation, i18n.t('Your administrator has disabled sharing your location. Please contact your admin for help', PERMISSIONS_NAMESPACE)(), callback);
             case Permissions.NOTIFICATIONS:
-                return handleSessionPermissions(permissions.notifications, 'notifications', callback);
+                return handleSessionPermissions(permissions.notifications, i18n.t('Your administrator has disabled notifications. Please contact your admin for help', PERMISSIONS_NAMESPACE)(), callback);
             case Permissions.MIDI_SYSEX:
-                return handleSessionPermissions(permissions.midiSysex, 'MIDI Sysex', callback);
+                return handleSessionPermissions(permissions.midiSysex, i18n.t('Your administrator has disabled MIDI Sysex. Please contact your admin for help', PERMISSIONS_NAMESPACE)(), callback);
             case Permissions.POINTER_LOCK:
-                return handleSessionPermissions(permissions.pointerLock, 'Pointer Lock', callback);
+                return handleSessionPermissions(permissions.pointerLock, i18n.t('Your administrator has disabled Pointer Lock. Please contact your admin for help', PERMISSIONS_NAMESPACE)(), callback);
             case Permissions.FULL_SCREEN:
-                return handleSessionPermissions(permissions.fullscreen, i18n.t('Full Screen', PERMISSIONS_NAMESPACE)(), callback);
+                return handleSessionPermissions(permissions.fullscreen, i18n.t('Your administrator has disabled Full Screen. Please contact your admin for help', PERMISSIONS_NAMESPACE)(), callback);
             case Permissions.OPEN_EXTERNAL:
-                return handleSessionPermissions(permissions.openExternal, 'Opening External App', callback);
+                return handleSessionPermissions(permissions.openExternal, i18n.t('Your administrator has disabled Opening External App. Please contact your admin for help', PERMISSIONS_NAMESPACE)(), callback);
             default:
                 return callback(false);
         }

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -110,7 +110,12 @@
   "Paste and Match Style": "Paste and Match Style",
   "Permission Denied": "Permission Denied",
   "Permissions": {
-    "Full Screen": "Full Screen"
+    "Your administrator has disabled Full Screen. Please contact your admin for help": "Your administrator has disabled Full Screen. Please contact your admin for help",
+    "Your administrator has disabled notifications. Please contact your admin for help": "Your administrator has disabled notifications. Please contact your admin for help",
+    "Your administrator has disabled Opening External App. Please contact your admin for help": "Your administrator has disabled Opening External App. Please contact your admin for help",
+    "Your administrator has disabled sharing your screen. Please contact your admin for help": "Your administrator has disabled sharing your screen. Please contact your admin for help",
+    "Your administrator has disabled sharing your camera, microphone, and speakers. Please contact your admin for help": "Your administrator has disabled sharing your camera, microphone, and speakers. Please contact your admin for help",
+    "Your administrator has disabled sharing your location. Please contact your admin for help": "Your administrator has disabled sharing your location. Please contact your admin for help"
   },
   "Please contact your admin for help": "Please contact your admin for help",
   "please contact your administrator for more details": "please contact your administrator for more details",

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -111,13 +111,13 @@
   "Permission Denied": "Permission Denied",
   "Permissions": {
     "Your administrator has disabled Full Screen. Please contact your admin for help": "Your administrator has disabled Full Screen. Please contact your admin for help",
-    "Your administrator has disabled notifications. Please contact your admin for help": "Your administrator has disabled notifications. Please contact your admin for help",
     "Your administrator has disabled MIDI Sysex. Please contact your admin for help": "Your administrator has disabled MIDI Sysex. Please contact your admin for help",
+    "Your administrator has disabled notifications. Please contact your admin for help": "Your administrator has disabled notifications. Please contact your admin for help",
     "Your administrator has disabled Opening External App. Please contact your admin for help": "Your administrator has disabled Opening External App. Please contact your admin for help",
     "Your administrator has disabled Pointer Lock. Please contact your admin for help": "Your administrator has disabled Pointer Lock. Please contact your admin for help",
-    "Your administrator has disabled sharing your screen. Please contact your admin for help": "Your administrator has disabled sharing your screen. Please contact your admin for help",
     "Your administrator has disabled sharing your camera, microphone, and speakers. Please contact your admin for help": "Your administrator has disabled sharing your camera, microphone, and speakers. Please contact your admin for help",
-    "Your administrator has disabled sharing your location. Please contact your admin for help": "Your administrator has disabled sharing your location. Please contact your admin for help"
+    "Your administrator has disabled sharing your location. Please contact your admin for help": "Your administrator has disabled sharing your location. Please contact your admin for help",
+    "Your administrator has disabled sharing your screen. Please contact your admin for help": "Your administrator has disabled sharing your screen. Please contact your admin for help"
   },
   "Please contact your admin for help": "Please contact your admin for help",
   "please contact your administrator for more details": "please contact your administrator for more details",

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -112,7 +112,9 @@
   "Permissions": {
     "Your administrator has disabled Full Screen. Please contact your admin for help": "Your administrator has disabled Full Screen. Please contact your admin for help",
     "Your administrator has disabled notifications. Please contact your admin for help": "Your administrator has disabled notifications. Please contact your admin for help",
+    "Your administrator has disabled MIDI Sysex. Please contact your admin for help": "Your administrator has disabled MIDI Sysex. Please contact your admin for help",
     "Your administrator has disabled Opening External App. Please contact your admin for help": "Your administrator has disabled Opening External App. Please contact your admin for help",
+    "Your administrator has disabled Pointer Lock. Please contact your admin for help": "Your administrator has disabled Pointer Lock. Please contact your admin for help",
     "Your administrator has disabled sharing your screen. Please contact your admin for help": "Your administrator has disabled sharing your screen. Please contact your admin for help",
     "Your administrator has disabled sharing your camera, microphone, and speakers. Please contact your admin for help": "Your administrator has disabled sharing your camera, microphone, and speakers. Please contact your admin for help",
     "Your administrator has disabled sharing your location. Please contact your admin for help": "Your administrator has disabled sharing your location. Please contact your admin for help"

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -110,7 +110,14 @@
   "Paste and Match Style": "Paste and Match Style",
   "Permission Denied": "Permission Denied",
   "Permissions": {
-    "Full Screen": "Full Screen"
+    "Your administrator has disabled Full Screen. Please contact your admin for help": "Your administrator has disabled Full Screen. Please contact your admin for help",
+    "Your administrator has disabled notifications. Please contact your admin for help": "Your administrator has disabled notifications. Please contact your admin for help",
+    "Your administrator has disabled MIDI Sysex. Please contact your admin for help": "Your administrator has disabled MIDI Sysex. Please contact your admin for help",
+    "Your administrator has disabled Opening External App. Please contact your admin for help": "Your administrator has disabled Opening External App. Please contact your admin for help",
+    "Your administrator has disabled Pointer Lock. Please contact your admin for help": "Your administrator has disabled Pointer Lock. Please contact your admin for help",
+    "Your administrator has disabled sharing your screen. Please contact your admin for help": "Your administrator has disabled sharing your screen. Please contact your admin for help",
+    "Your administrator has disabled sharing your camera, microphone, and speakers. Please contact your admin for help": "Your administrator has disabled sharing your camera, microphone, and speakers. Please contact your admin for help",
+    "Your administrator has disabled sharing your location. Please contact your admin for help": "Your administrator has disabled sharing your location. Please contact your admin for help"
   },
   "Please contact your admin for help": "Please contact your admin for help",
   "please contact your administrator for more details": "please contact your administrator for more details",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -111,13 +111,13 @@
   "Permission Denied": "Permission Denied",
   "Permissions": {
     "Your administrator has disabled Full Screen. Please contact your admin for help": "Your administrator has disabled Full Screen. Please contact your admin for help",
-    "Your administrator has disabled notifications. Please contact your admin for help": "Your administrator has disabled notifications. Please contact your admin for help",
     "Your administrator has disabled MIDI Sysex. Please contact your admin for help": "Your administrator has disabled MIDI Sysex. Please contact your admin for help",
+    "Your administrator has disabled notifications. Please contact your admin for help": "Your administrator has disabled notifications. Please contact your admin for help",
     "Your administrator has disabled Opening External App. Please contact your admin for help": "Your administrator has disabled Opening External App. Please contact your admin for help",
     "Your administrator has disabled Pointer Lock. Please contact your admin for help": "Your administrator has disabled Pointer Lock. Please contact your admin for help",
-    "Your administrator has disabled sharing your screen. Please contact your admin for help": "Your administrator has disabled sharing your screen. Please contact your admin for help",
     "Your administrator has disabled sharing your camera, microphone, and speakers. Please contact your admin for help": "Your administrator has disabled sharing your camera, microphone, and speakers. Please contact your admin for help",
-    "Your administrator has disabled sharing your location. Please contact your admin for help": "Your administrator has disabled sharing your location. Please contact your admin for help"
+    "Your administrator has disabled sharing your location. Please contact your admin for help": "Your administrator has disabled sharing your location. Please contact your admin for help",
+    "Your administrator has disabled sharing your screen. Please contact your admin for help": "Your administrator has disabled sharing your screen. Please contact your admin for help"
   },
   "Please contact your admin for help": "Please contact your admin for help",
   "please contact your administrator for more details": "please contact your administrator for more details",

--- a/src/locale/fr-FR.json
+++ b/src/locale/fr-FR.json
@@ -111,13 +111,13 @@
   "Permission Denied": "Permission refusée",
   "Permissions": {
     "Your administrator has disabled Full Screen. Please contact your admin for help": "Votre administrateur a désactivé Plein écran. Veuillez contacter votre administrateur pour obtenir de l'aide.",
-    "Your administrator has disabled notifications. Please contact your admin for help": "Votre administrateur a désactivé Notifications. Veuillez contacter votre administrateur pour obtenir de l'aide.",
     "Your administrator has disabled MIDI Sysex. Please contact your admin for help": "Votre administrateur a désactivé MIDI Sysex. Veuillez contacter votre administrateur pour obtenir de l'aide.",
+    "Your administrator has disabled notifications. Please contact your admin for help": "Votre administrateur a désactivé Notifications. Veuillez contacter votre administrateur pour obtenir de l'aide.",
     "Your administrator has disabled Opening External App. Please contact your admin for help": "Votre administrateur a désactivé Ouverture d'application externe. Veuillez contacter votre administrateur pour obtenir de l'aide.",
     "Your administrator has disabled Pointer Lock. Please contact your admin for help": "Votre administrateur a désactivé Pointer Lock. Veuillez contacter votre administrateur pour obtenir de l'aide.",
-    "Your administrator has disabled sharing your screen. Please contact your admin for help": "Votre administrateur a désactivé partager votre écran. Veuillez contacter votre administrateur pour obtenir de l'aide.",
     "Your administrator has disabled sharing your camera, microphone, and speakers. Please contact your admin for help": "Votre administrateur a désactivé partager votre caméra, votre microphone et vos haut-parleurs. Veuillez contacter votre administrateur pour obtenir de l'aide.",
-    "Your administrator has disabled sharing your location. Please contact your admin for help": "Votre administrateur a désactivé partager votre position. Veuillez contacter votre administrateur pour obtenir de l'aide."
+    "Your administrator has disabled sharing your location. Please contact your admin for help": "Votre administrateur a désactivé partager votre position. Veuillez contacter votre administrateur pour obtenir de l'aide.",
+    "Your administrator has disabled sharing your screen. Please contact your admin for help": "Votre administrateur a désactivé partager votre écran. Veuillez contacter votre administrateur pour obtenir de l'aide."
   },
   "Please contact your admin for help": "Veuillez contacter votre administrateur pour obtenir de l'aide.",
   "please contact your administrator for more details": "veuillez contacter votre administrateur pour plus de détails",

--- a/src/locale/fr-FR.json
+++ b/src/locale/fr-FR.json
@@ -110,7 +110,14 @@
   "Paste and Match Style": "Coller et appliquer le style",
   "Permission Denied": "Permission refusée",
   "Permissions": {
-    "Full Screen": "Plein écran"
+    "Your administrator has disabled Full Screen. Please contact your admin for help": "Votre administrateur a désactivé Plein écran. Veuillez contacter votre administrateur pour obtenir de l'aide.",
+    "Your administrator has disabled notifications. Please contact your admin for help": "Votre administrateur a désactivé Notifications. Veuillez contacter votre administrateur pour obtenir de l'aide.",
+    "Your administrator has disabled MIDI Sysex. Please contact your admin for help": "Votre administrateur a désactivé MIDI Sysex. Veuillez contacter votre administrateur pour obtenir de l'aide.",
+    "Your administrator has disabled Opening External App. Please contact your admin for help": "Votre administrateur a désactivé Ouverture d'application externe. Veuillez contacter votre administrateur pour obtenir de l'aide.",
+    "Your administrator has disabled Pointer Lock. Please contact your admin for help": "Votre administrateur a désactivé Pointer Lock. Veuillez contacter votre administrateur pour obtenir de l'aide.",
+    "Your administrator has disabled sharing your screen. Please contact your admin for help": "Votre administrateur a désactivé partager votre écran. Veuillez contacter votre administrateur pour obtenir de l'aide.",
+    "Your administrator has disabled sharing your camera, microphone, and speakers. Please contact your admin for help": "Votre administrateur a désactivé partager votre caméra, votre microphone et vos haut-parleurs. Veuillez contacter votre administrateur pour obtenir de l'aide.",
+    "Your administrator has disabled sharing your location. Please contact your admin for help": "Votre administrateur a désactivé partager votre position. Veuillez contacter votre administrateur pour obtenir de l'aide."
   },
   "Please contact your admin for help": "Veuillez contacter votre administrateur pour obtenir de l'aide.",
   "please contact your administrator for more details": "veuillez contacter votre administrateur pour plus de détails",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -111,13 +111,13 @@
   "Permission Denied": "Permission refusée",
   "Permissions": {
     "Your administrator has disabled Full Screen. Please contact your admin for help": "Votre administrateur a désactivé Plein écran. Veuillez contacter votre administrateur pour obtenir de l'aide.",
-    "Your administrator has disabled notifications. Please contact your admin for help": "Votre administrateur a désactivé Notifications. Veuillez contacter votre administrateur pour obtenir de l'aide.",
     "Your administrator has disabled MIDI Sysex. Please contact your admin for help": "Votre administrateur a désactivé MIDI Sysex. Veuillez contacter votre administrateur pour obtenir de l'aide.",
+    "Your administrator has disabled notifications. Please contact your admin for help": "Votre administrateur a désactivé Notifications. Veuillez contacter votre administrateur pour obtenir de l'aide.",
     "Your administrator has disabled Opening External App. Please contact your admin for help": "Votre administrateur a désactivé Ouverture d'application externe. Veuillez contacter votre administrateur pour obtenir de l'aide.",
     "Your administrator has disabled Pointer Lock. Please contact your admin for help": "Votre administrateur a désactivé Pointer Lock. Veuillez contacter votre administrateur pour obtenir de l'aide.",
-    "Your administrator has disabled sharing your screen. Please contact your admin for help": "Votre administrateur a désactivé partager votre écran. Veuillez contacter votre administrateur pour obtenir de l'aide.",
     "Your administrator has disabled sharing your camera, microphone, and speakers. Please contact your admin for help": "Votre administrateur a désactivé partager votre caméra, votre microphone et vos haut-parleurs. Veuillez contacter votre administrateur pour obtenir de l'aide.",
-    "Your administrator has disabled sharing your location. Please contact your admin for help": "Votre administrateur a désactivé partager votre position. Veuillez contacter votre administrateur pour obtenir de l'aide."
+    "Your administrator has disabled sharing your location. Please contact your admin for help": "Votre administrateur a désactivé partager votre position. Veuillez contacter votre administrateur pour obtenir de l'aide.",
+    "Your administrator has disabled sharing your screen. Please contact your admin for help": "Votre administrateur a désactivé partager votre écran. Veuillez contacter votre administrateur pour obtenir de l'aide."
   },
   "Please contact your admin for help": "Veuillez contacter votre administrateur pour obtenir de l'aide.",
   "please contact your administrator for more details": "veuillez contacter votre administrateur pour plus de détails",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -110,7 +110,14 @@
   "Paste and Match Style": "Coller et appliquer le style",
   "Permission Denied": "Permission refusée",
   "Permissions": {
-    "Full Screen": "Plein écran"
+    "Your administrator has disabled Full Screen. Please contact your admin for help": "Votre administrateur a désactivé Plein écran. Veuillez contacter votre administrateur pour obtenir de l'aide.",
+    "Your administrator has disabled notifications. Please contact your admin for help": "Votre administrateur a désactivé Notifications. Veuillez contacter votre administrateur pour obtenir de l'aide.",
+    "Your administrator has disabled MIDI Sysex. Please contact your admin for help": "Votre administrateur a désactivé MIDI Sysex. Veuillez contacter votre administrateur pour obtenir de l'aide.",
+    "Your administrator has disabled Opening External App. Please contact your admin for help": "Votre administrateur a désactivé Ouverture d'application externe. Veuillez contacter votre administrateur pour obtenir de l'aide.",
+    "Your administrator has disabled Pointer Lock. Please contact your admin for help": "Votre administrateur a désactivé Pointer Lock. Veuillez contacter votre administrateur pour obtenir de l'aide.",
+    "Your administrator has disabled sharing your screen. Please contact your admin for help": "Votre administrateur a désactivé partager votre écran. Veuillez contacter votre administrateur pour obtenir de l'aide.",
+    "Your administrator has disabled sharing your camera, microphone, and speakers. Please contact your admin for help": "Votre administrateur a désactivé partager votre caméra, votre microphone et vos haut-parleurs. Veuillez contacter votre administrateur pour obtenir de l'aide.",
+    "Your administrator has disabled sharing your location. Please contact your admin for help": "Votre administrateur a désactivé partager votre position. Veuillez contacter votre administrateur pour obtenir de l'aide."
   },
   "Please contact your admin for help": "Veuillez contacter votre administrateur pour obtenir de l'aide.",
   "please contact your administrator for more details": "veuillez contacter votre administrateur pour plus de détails",

--- a/src/locale/ja-JP.json
+++ b/src/locale/ja-JP.json
@@ -110,7 +110,14 @@
   "Paste and Match Style": "貼り付けでスタイルを合わせる",
   "Permission Denied": "アクセス許可が拒否されています",
   "Permissions": {
-    "Full Screen": "全画面表示"
+    "Your administrator has disabled Full Screen. Please contact your admin for help": "貴社のシンフォニー管理者が全画面表示設定を無効にしました。詳細については、管理者にお問い合わせください。",
+    "Your administrator has disabled notifications. Please contact your admin for help": "貴社のシンフォニー管理者が通知を無効にしました。詳細については、管理者にお問い合わせください。",
+    "Your administrator has disabled MIDI Sysex. Please contact your admin for help": "貴社のシンフォニー管理者がMIDI Sysexを無効にしました。詳細については、管理者にお問い合わせください。",
+    "Your administrator has disabled Opening External App. Please contact your admin for help": "貴社のシンフォニー管理者が外部アプリを開く共有設定を無効にしました。詳細については、管理者にお問い合わせください。",
+    "Your administrator has disabled Pointer Lock. Please contact your admin for help": "貴社のシンフォニー管理者がPointer Lockを無効にしました。詳細については、管理者にお問い合わせください。",
+    "Your administrator has disabled sharing your screen. Please contact your admin for help": "貴社のシンフォニー管理者が画面共有設定を無効にしました。詳細については、管理者にお問い合わせください。画面",
+    "Your administrator has disabled sharing your camera, microphone, and speakers. Please contact your admin for help": "貴社のシンフォニー管理者がカメラ、マイク、スピーカーの共有設定を無効にしました。詳細については、管理者にお問い合わせください。",
+    "Your administrator has disabled sharing your location. Please contact your admin for help": "貴社のシンフォニー管理者が位置情報の共有設定を無効にしました。詳細については、管理者にお問い合わせください。"
   },
   "Please contact your admin for help": "不明な点がある場合は､管理者にお問い合わせください",
   "please contact your administrator for more details": "詳細は、管理者にお問い合わせください",

--- a/src/locale/ja-JP.json
+++ b/src/locale/ja-JP.json
@@ -111,13 +111,13 @@
   "Permission Denied": "アクセス許可が拒否されています",
   "Permissions": {
     "Your administrator has disabled Full Screen. Please contact your admin for help": "貴社のシンフォニー管理者が全画面表示設定を無効にしました。詳細については、管理者にお問い合わせください。",
-    "Your administrator has disabled notifications. Please contact your admin for help": "貴社のシンフォニー管理者が通知を無効にしました。詳細については、管理者にお問い合わせください。",
     "Your administrator has disabled MIDI Sysex. Please contact your admin for help": "貴社のシンフォニー管理者がMIDI Sysexを無効にしました。詳細については、管理者にお問い合わせください。",
+    "Your administrator has disabled notifications. Please contact your admin for help": "貴社のシンフォニー管理者が通知を無効にしました。詳細については、管理者にお問い合わせください。",
     "Your administrator has disabled Opening External App. Please contact your admin for help": "貴社のシンフォニー管理者が外部アプリを開く共有設定を無効にしました。詳細については、管理者にお問い合わせください。",
     "Your administrator has disabled Pointer Lock. Please contact your admin for help": "貴社のシンフォニー管理者がPointer Lockを無効にしました。詳細については、管理者にお問い合わせください。",
-    "Your administrator has disabled sharing your screen. Please contact your admin for help": "貴社のシンフォニー管理者が画面共有設定を無効にしました。詳細については、管理者にお問い合わせください。画面",
     "Your administrator has disabled sharing your camera, microphone, and speakers. Please contact your admin for help": "貴社のシンフォニー管理者がカメラ、マイク、スピーカーの共有設定を無効にしました。詳細については、管理者にお問い合わせください。",
-    "Your administrator has disabled sharing your location. Please contact your admin for help": "貴社のシンフォニー管理者が位置情報の共有設定を無効にしました。詳細については、管理者にお問い合わせください。"
+    "Your administrator has disabled sharing your location. Please contact your admin for help": "貴社のシンフォニー管理者が位置情報の共有設定を無効にしました。詳細については、管理者にお問い合わせください。",
+    "Your administrator has disabled sharing your screen. Please contact your admin for help": "貴社のシンフォニー管理者が画面共有設定を無効にしました。詳細については、管理者にお問い合わせください。画面"
   },
   "Please contact your admin for help": "不明な点がある場合は､管理者にお問い合わせください",
   "please contact your administrator for more details": "詳細は、管理者にお問い合わせください",

--- a/src/locale/ja.json
+++ b/src/locale/ja.json
@@ -110,7 +110,14 @@
   "Paste and Match Style": "貼り付けでスタイルを合わせる",
   "Permission Denied": "アクセス許可が拒否されています",
   "Permissions": {
-    "Full Screen": "全画面表示"
+    "Your administrator has disabled Full Screen. Please contact your admin for help": "貴社のシンフォニー管理者が全画面表示設定を無効にしました。詳細については、管理者にお問い合わせください。",
+    "Your administrator has disabled notifications. Please contact your admin for help": "貴社のシンフォニー管理者が通知を無効にしました。詳細については、管理者にお問い合わせください。",
+    "Your administrator has disabled MIDI Sysex. Please contact your admin for help": "貴社のシンフォニー管理者がMIDI Sysexを無効にしました。詳細については、管理者にお問い合わせください。",
+    "Your administrator has disabled Opening External App. Please contact your admin for help": "貴社のシンフォニー管理者が外部アプリを開く共有設定を無効にしました。詳細については、管理者にお問い合わせください。",
+    "Your administrator has disabled Pointer Lock. Please contact your admin for help": "貴社のシンフォニー管理者がPointer Lockを無効にしました。詳細については、管理者にお問い合わせください。",
+    "Your administrator has disabled sharing your screen. Please contact your admin for help": "貴社のシンフォニー管理者が画面共有設定を無効にしました。詳細については、管理者にお問い合わせください。画面",
+    "Your administrator has disabled sharing your camera, microphone, and speakers. Please contact your admin for help": "貴社のシンフォニー管理者がカメラ、マイク、スピーカーの共有設定を無効にしました。詳細については、管理者にお問い合わせください。",
+    "Your administrator has disabled sharing your location. Please contact your admin for help": "貴社のシンフォニー管理者が位置情報の共有設定を無効にしました。詳細については、管理者にお問い合わせください。"
   },
   "Please contact your admin for help": "不明な点がある場合は､管理者にお問い合わせください",
   "please contact your administrator for more details": "詳細は、管理者にお問い合わせください",

--- a/src/locale/ja.json
+++ b/src/locale/ja.json
@@ -111,13 +111,13 @@
   "Permission Denied": "アクセス許可が拒否されています",
   "Permissions": {
     "Your administrator has disabled Full Screen. Please contact your admin for help": "貴社のシンフォニー管理者が全画面表示設定を無効にしました。詳細については、管理者にお問い合わせください。",
-    "Your administrator has disabled notifications. Please contact your admin for help": "貴社のシンフォニー管理者が通知を無効にしました。詳細については、管理者にお問い合わせください。",
     "Your administrator has disabled MIDI Sysex. Please contact your admin for help": "貴社のシンフォニー管理者がMIDI Sysexを無効にしました。詳細については、管理者にお問い合わせください。",
+    "Your administrator has disabled notifications. Please contact your admin for help": "貴社のシンフォニー管理者が通知を無効にしました。詳細については、管理者にお問い合わせください。",
     "Your administrator has disabled Opening External App. Please contact your admin for help": "貴社のシンフォニー管理者が外部アプリを開く共有設定を無効にしました。詳細については、管理者にお問い合わせください。",
     "Your administrator has disabled Pointer Lock. Please contact your admin for help": "貴社のシンフォニー管理者がPointer Lockを無効にしました。詳細については、管理者にお問い合わせください。",
-    "Your administrator has disabled sharing your screen. Please contact your admin for help": "貴社のシンフォニー管理者が画面共有設定を無効にしました。詳細については、管理者にお問い合わせください。画面",
     "Your administrator has disabled sharing your camera, microphone, and speakers. Please contact your admin for help": "貴社のシンフォニー管理者がカメラ、マイク、スピーカーの共有設定を無効にしました。詳細については、管理者にお問い合わせください。",
-    "Your administrator has disabled sharing your location. Please contact your admin for help": "貴社のシンフォニー管理者が位置情報の共有設定を無効にしました。詳細については、管理者にお問い合わせください。"
+    "Your administrator has disabled sharing your location. Please contact your admin for help": "貴社のシンフォニー管理者が位置情報の共有設定を無効にしました。詳細については、管理者にお問い合わせください。",
+    "Your administrator has disabled sharing your screen. Please contact your admin for help": "貴社のシンフォニー管理者が画面共有設定を無効にしました。詳細については、管理者にお問い合わせください。画面"
   },
   "Please contact your admin for help": "不明な点がある場合は､管理者にお問い合わせください",
   "please contact your administrator for more details": "詳細は、管理者にお問い合わせください",

--- a/src/renderer/desktop-capturer.ts
+++ b/src/renderer/desktop-capturer.ts
@@ -92,7 +92,7 @@ export const getSource = (options: ICustomSourcesOptions, callback: CallbackType
         const focusedWindow = remote.BrowserWindow.getFocusedWindow();
         if (focusedWindow && !focusedWindow.isDestroyed()) {
             remote.dialog.showMessageBox(focusedWindow, {
-                message: i18n.t('Your administrator has disabled screen share. Please contact your admin for help')(),
+                message: `${i18n.t('Your administrator has disabled sharing your screen. Please contact your admin for help', 'Permissions')()}`,
                 title: `${i18n.t('Permission Denied')()}!`,
                 type: 'error',
             });


### PR DESCRIPTION
## Description
Add translations for permissions dialog
[ELECTRON-1227](https://perzoinc.atlassian.net/browse/ELECTRON-1227)

## Screenshots
- French
![Screenshot 2019-07-04 at 2 12 28 PM](https://user-images.githubusercontent.com/13243259/60652759-66cbdd00-9e66-11e9-93d8-d6ee746b824b.png)
- Japanese
![Screenshot 2019-07-04 at 2 11 16 PM](https://user-images.githubusercontent.com/13243259/60652760-67647380-9e66-11e9-8775-2a8a6155d23f.png)
