### PR TITLE
fix: ELECTRON-1345: fix protocol handler action issues

### DIFF
--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -14,6 +14,8 @@ import { handlePerformanceSettings } from './perf-handler';
 import { protocolHandler } from './protocol-handler';
 import { ICustomBrowserWindow, windowHandler } from './window-handler';
 
+logger.info(`App started with the args ${JSON.stringify(process.argv)}`);
+
 const allowMultiInstance: string | boolean = getCommandLineArgs(process.argv, '--multiInstance', true) || isDevEnv;
 let isAppAlreadyOpen: boolean = false;
 

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -15,6 +15,7 @@ import { protocolHandler } from './protocol-handler';
 import { ICustomBrowserWindow, windowHandler } from './window-handler';
 
 const allowMultiInstance: string | boolean = getCommandLineArgs(process.argv, '--multiInstance', true) || isDevEnv;
+let isAppAlreadyOpen: boolean = false;
 
 handlePerformanceSettings();
 setChromeFlags();
@@ -74,7 +75,8 @@ if (!allowMultiInstance) {
                     mainWindow.restore();
                 }
                 mainWindow.focus();
-                protocolHandler.processArgv(argv);
+                isAppAlreadyOpen = true;
+                protocolHandler.processArgv(argv, isAppAlreadyOpen);
             }
         });
         startApplication();

--- a/src/app/protocol-handler.ts
+++ b/src/app/protocol-handler.ts
@@ -69,7 +69,7 @@ class ProtocolHandler {
         const protocolUriFromArgv = getCommandLineArgs(argv || process.argv, protocol.SymphonyProtocol, false);
         if (protocolUriFromArgv) {
             logger.info(`protocol handler: we have a protocol request for the url ${protocolUriFromArgv}!`);
-        this.sendProtocol(protocolUriFromArgv, isAppAlreadyOpen);
+            this.sendProtocol(protocolUriFromArgv, isAppAlreadyOpen);
         }
     }
 }

--- a/src/app/protocol-handler.ts
+++ b/src/app/protocol-handler.ts
@@ -64,12 +64,12 @@ class ProtocolHandler {
      *
      * @param argv {String[]} - data received from process.argv
      */
-    public processArgv(argv?: string[]): void {
+    public processArgv(argv?: string[], isAppAlreadyOpen: boolean = false): void {
         logger.info(`protocol handler: processing protocol args!`);
         const protocolUriFromArgv = getCommandLineArgs(argv || process.argv, protocol.SymphonyProtocol, false);
         if (protocolUriFromArgv) {
             logger.info(`protocol handler: we have a protocol request for the url ${protocolUriFromArgv}!`);
-            this.sendProtocol(protocolUriFromArgv, false);
+        this.sendProtocol(protocolUriFromArgv, isAppAlreadyOpen);
         }
     }
 }


### PR DESCRIPTION
## Description
Protocol handler was not processing requests on Windows because of a bug in the code that made an incorrect check upon a protocol request. 
[ELECTRON-1345](https://perzoinc.atlassian.net/browse/ELECTRON-1345)

## Solution Approach
Add an app running check and process the protocol action accordingly

## Related PRs
N/A