### PR TITLE
fix: ELECTRON-1338: fix download manager issues

### DIFF
--- a/spec/downloadManager.spec.ts
+++ b/spec/downloadManager.spec.ts
@@ -36,6 +36,7 @@ describe('download manager', () => {
         expect(spy).toBeCalledWith({
             items: [{
                 _id: 1,
+                count: 0,
                 fileName: 'test.png',
                 savedPath: 'path://test',
                 total: 1,

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -1,5 +1,6 @@
 import { app } from 'electron';
 
+import * as electronDownloader from 'electron-dl';
 import { buildNumber, clientVersion, version } from '../../package.json';
 import { isDevEnv, isMac } from '../common/env';
 import { logger } from '../common/logger';
@@ -16,11 +17,10 @@ import { ICustomBrowserWindow, windowHandler } from './window-handler';
 
 const allowMultiInstance: string | boolean = getCommandLineArgs(process.argv, '--multiInstance', true) || isDevEnv;
 
+electronDownloader();
 handlePerformanceSettings();
 setChromeFlags();
 
-// on windows, we create the protocol handler via the installer
-// because electron leaves registry traces upon uninstallation
 if (isMac) {
     // Sets application version info that will be displayed in about app panel
     app.setAboutPanelOptions({ applicationVersion: `${clientVersion}-${version}`, version: buildNumber });

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -1,7 +1,7 @@
 import { app } from 'electron';
+import * as electronDownloader from 'electron-dl';
 import * as shellPath from 'shell-path';
 
-import * as electronDownloader from 'electron-dl';
 import { isDevEnv, isMac } from '../common/env';
 import { logger } from '../common/logger';
 import { getCommandLineArgs } from '../common/utils';

--- a/src/renderer/components/download-manager.tsx
+++ b/src/renderer/components/download-manager.tsx
@@ -12,6 +12,7 @@ interface IDownloadManager {
     savedPath: string;
     total: number;
     flashing: boolean;
+    count: number;
 }
 
 interface IManagerState {
@@ -92,7 +93,7 @@ export default class DownloadManager extends React.Component<{}, IManagerState> 
                 });
             }
         }, 4000);
-        const fileDisplayName = this.getFileDisplayName(fileName);
+        const fileDisplayName = this.getFileDisplayName(fileName, item);
         return (
             <li key={_id} id={_id} className='download-element'>
                 <div className='download-item' id='dl-item' onClick={this.eventHandlers.onOpenFile(_id)}>
@@ -132,6 +133,13 @@ export default class DownloadManager extends React.Component<{}, IManagerState> 
      */
     private injectItem(args: IDownloadManager): void {
         const { items } = this.state;
+        let itemCount = 0;
+        for (const item of items) {
+            if (args.fileName === item.fileName) {
+                itemCount++;
+            }
+        }
+        args.count = itemCount;
         const allItems = [ ...items, ...[ { ...args, ...{ flashing: true } } ] ];
         this.setState({ items: allItems, showMainComponent: true });
     }
@@ -190,31 +198,17 @@ export default class DownloadManager extends React.Component<{}, IManagerState> 
      * Checks and constructs file name
      *
      * @param fileName
+     * @param item
      */
-    private getFileDisplayName(fileName: string): string {
-        const { items } = this.state;
-        let fileNameCount = 0;
-        let fileDisplayName = fileName;
-
-        /* Check if a file with the same name exists
-         * (akin to the user downloading a file with the same name again)
-         * in the download bar
-         */
-        for (const value of items) {
-            if (fileName === value.fileName) {
-                fileNameCount++;
-            }
-        }
-
+    private getFileDisplayName(fileName: string, item: IDownloadManager): string {
         /* If it exists, add a count to the name like how Chrome does */
-        if (fileNameCount) {
-            const extLastIndex = fileDisplayName.lastIndexOf('.');
-            const fileCount = ' (' + fileNameCount + ')';
+        if (item.count > 0) {
+            const extLastIndex = fileName.lastIndexOf('.');
+            const fileCount = ' (' + item.count + ')';
 
-            fileDisplayName = fileDisplayName.slice(0, extLastIndex) + fileCount + fileDisplayName.slice(extLastIndex);
+            fileName = fileName.slice(0, extLastIndex) + fileCount + fileName.slice(extLastIndex);
         }
-
-        return fileDisplayName;
+        return fileName;
     }
 
     /**


### PR DESCRIPTION
## Description
We had the following problems with the download manager
- We used to get a pop-up dialog every time we download a file. This was a regression for not using `electron-dl`
- If the same file was downloaded twice, the download manager was not updating the filename count appropriately
[ELECTRON-1338](https://perzoinc.atlassian.net/browse/ELECTRON-1338)

## Solution Approach
- Use `electron-dl` that automatically downloads the file to the user's download folder on the local system
- Update count in react state

## Related PRs
N/A
