### PR TITLE
fix: ELECTRON-1371 (Fix Custom title bar title margin issue)

### DIFF
--- a/config/titleBarStyles.css
+++ b/config/titleBarStyles.css
@@ -91,7 +91,7 @@ Typically you'll want to set content: url("") and adjust the width property
     overflow: hidden;
 }
 
-.title-bar-title {
+#title-bar-title {
     font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
     color: white;
     margin: 0;

--- a/spec/__snapshots__/windowsTitleBar.spec.ts.snap
+++ b/spec/__snapshots__/windowsTitleBar.spec.ts.snap
@@ -232,7 +232,7 @@ exports[`windows title bar should render correctly 1`] = `
       />
     </svg>
     <p
-      className="title-bar-title"
+      id="title-bar-title"
     >
       Symphony
     </p>

--- a/src/renderer/components/windows-title-bar.tsx
+++ b/src/renderer/components/windows-title-bar.tsx
@@ -90,7 +90,7 @@ export default class WindowsTitleBar extends React.Component<{}, IState> {
                 </div>
                 <div className='title-container'>
                     {this.getSymphonyLogo()}
-                    <p className='title-bar-title'>{document.title || 'Symphony'}</p>
+                    <p id='title-bar-title'>{document.title || 'Symphony'}</p>
                 </div>
                 <div className='title-bar-button-container'>
                     <button

--- a/src/renderer/styles/title-bar.less
+++ b/src/renderer/styles/title-bar.less
@@ -50,7 +50,7 @@
   overflow: hidden;
 }
 
-.title-bar-title {
+#title-bar-title {
   font-family: @font-family;
   color: @color_2;
   margin: 0;


### PR DESCRIPTION
## Description
Fix Custom title bar title margin issue
[ELECTRON-1371](https://perzoinc.atlassian.net/browse/ELECTRON-1371)

## Solution Approach
Change `title-bar-title` from className to id

## Before
![image-20190711-030059](https://user-images.githubusercontent.com/13243259/61036815-78256400-a3e7-11e9-90c7-a1e897030d88.png)

## After
![image-20190711-030118](https://user-images.githubusercontent.com/13243259/61036829-7cea1800-a3e7-11e9-81b8-67397bcc11dc.png)
