### PR TITLE
fix: ELECTRON-1373: fix spacing in download manager

### DIFF
--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -47,7 +47,7 @@
   "Dev Tools has been disabled! Please contact your system administrator to enable it!": "Dev Tools has been disabled! Please contact your system administrator to enable it!",
   "Disable Hamburger menu": "Disable Hamburger menu",
   "DownloadManager": {
-    "Downloaded": "Downloaded",
+    "downloaded": "downloaded",
     "File not Found": "File not Found",
     "Open": "Open",
     "Reveal in Finder": "Reveal in Finder",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -47,7 +47,7 @@
   "Dev Tools has been disabled! Please contact your system administrator to enable it!": "Dev Tools has been disabled! Please contact your system administrator to enable it!",
   "Disable Hamburger menu": "Disable Hamburger menu",
   "DownloadManager": {
-    "Downloaded": "Downloaded",
+    "downloaded": "downloaded",
     "File not Found": "File not Found",
     "Open": "Open",
     "Reveal in Finder": "Reveal in Finder",

--- a/src/locale/fr-FR.json
+++ b/src/locale/fr-FR.json
@@ -47,7 +47,7 @@
   "Dev Tools has been disabled! Please contact your system administrator to enable it!": "Dev Tools a été désactivé ! Veuillez contacter votre administrateur système pour l’activer !",
   "Disable Hamburger menu": "Désactiver le menu Hamburger",
   "DownloadManager": {
-    "Downloaded": "Téléchargé",
+    "downloaded": "téléchargé",
     "File not Found": "Fichier non trouvé",
     "Open": "Ouvrir",
     "Reveal in Finder": "Montrer le fichier",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -47,7 +47,7 @@
   "Dev Tools has been disabled! Please contact your system administrator to enable it!": "Dev Tools a été désactivé ! Veuillez contacter votre administrateur système pour l’activer !",
   "Disable Hamburger menu": "Désactiver le menu Hamburger",
   "DownloadManager": {
-    "Downloaded": "Téléchargé",
+    "downloaded": "téléchargé",
     "File not Found": "Fichier non trouvé",
     "Open": "Ouvrir",
     "Reveal in Finder": "Montrer le fichier",

--- a/src/locale/ja-JP.json
+++ b/src/locale/ja-JP.json
@@ -47,7 +47,7 @@
   "Dev Tools has been disabled! Please contact your system administrator to enable it!": "開発ツールが無効になっています。システム管理者に連絡して、有効にしてください。",
   "Disable Hamburger menu": "ハンバーガーメニューを無効にする",
   "DownloadManager": {
-    "Downloaded": "ダウンロード済み",
+    "downloaded": "ダウンロード済み",
     "File not Found": "ファイルが見つかりません",
     "Open": "開く",
     "Reveal in Finder": "Finderで確認する",

--- a/src/locale/ja.json
+++ b/src/locale/ja.json
@@ -47,7 +47,7 @@
   "Dev Tools has been disabled! Please contact your system administrator to enable it!": "開発ツールが無効になっています。システム管理者に連絡して、有効にしてください。",
   "Disable Hamburger menu": "ハンバーガーメニューを無効にする",
   "DownloadManager": {
-    "Downloaded": "ダウンロード済み",
+    "downloaded": "ダウンロード済み",
     "File not Found": "ファイルが見つかりません",
     "Open": "開く",
     "Reveal in Finder": "Finderで確認する",

--- a/src/renderer/components/download-manager.tsx
+++ b/src/renderer/components/download-manager.tsx
@@ -107,7 +107,7 @@ export default class DownloadManager extends React.Component<{}, IManagerState> 
                             {fileDisplayName}
                         </h1>
                         <span id='per'>
-                            {total}{i18n.t('Downloaded', DOWNLOAD_MANAGER_NAMESPACE)()}
+                            {total} {i18n.t('downloaded', DOWNLOAD_MANAGER_NAMESPACE)()}
                         </span>
                     </div>
                 </div>


### PR DESCRIPTION
## Description
Fix spacing issue in the download manager b/w the `unit (KB, MB)` & `downloaded` string.
[ELECTRON-1373](https://perzoinc.atlassian.net/browse/ELECTRON-1373)

## Solution Approach
Add a space b/w the strings and localise it.

## Related PRs
N/A