### PR TITLE
fix: ELECTRON-1346 & ELECTRON-1370 (Fix notification text & background color)

### DIFF
--- a/src/renderer/components/notification-comp.tsx
+++ b/src/renderer/components/notification-comp.tsx
@@ -53,8 +53,8 @@ export default class NotificationComp extends React.Component<{}, IState> {
      */
     public render(): JSX.Element {
         const { title, company, body, image, icon, id, color } = this.state;
-        const colorHex = color ? '#' + color : undefined;
-        const isLightTheme = colorHex ? colorHex.match(whiteColorRegExp) : true;
+        const colorHex = (color && !color.startsWith('#')) ? '#' + color : color;
+        const isLightTheme = (colorHex && colorHex.match(whiteColorRegExp)) || true;
 
         const theme = classNames({ light: isLightTheme, dark: !isLightTheme });
         const bgColor = { backgroundColor: colorHex || '#ffffff' };


### PR DESCRIPTION
## Description
Fixes notification text & background color
[ELECTRON-1346](https://perzoinc.atlassian.net/browse/ELECTRON-1346)
[ELECTRON-1370](https://perzoinc.atlassian.net/browse/ELECTRON-1370)

## Solution Approach
Convert colors to `hex` which fixes the issue

## Before
![Screenshot 2019-07-11 at 3 22 52 PM](https://user-images.githubusercontent.com/13243259/61043957-31d70180-a3f5-11e9-8927-20711c460bf9.png)

## After
![Screenshot 2019-07-11 at 3 20 45 PM](https://user-images.githubusercontent.com/13243259/61043966-36031f00-a3f5-11e9-97e7-0933ad4a5a1f.png)
