### PR TITLE
chore: ELECTRON-1362 (Bump electron version to 3.1.12 to fix notification crash issue)

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "browserify": "16.2.3",
     "cross-env": "5.2.0",
     "del": "3.0.0",
-    "electron": "3.1.11",
+    "electron": "3.1.12",
     "electron-builder": "20.38.4",
     "electron-builder-squirrel-windows": "20.38.3",
     "electron-rebuild": "1.8.2",


### PR DESCRIPTION
## Description
Bump electron version to 3.1.12 to fix notification crash issue
[JIRA-ticket](https://perzoinc.atlassian.net/browse/JIRA-ticket)

## Solution Approach
Bump electron version to `3.1.12` that fixes https://github.com/electron/electron/issues/19081
