### PR TITLE
fix: ELECTRON-1369 (Set custom title bar's title once)

### DIFF
--- a/src/renderer/components/windows-title-bar.tsx
+++ b/src/renderer/components/windows-title-bar.tsx
@@ -13,6 +13,7 @@ const TITLE_BAR_NAMESPACE = 'TitleBar';
 
 export default class WindowsTitleBar extends React.Component<{}, IState> {
     private readonly window: Electron.BrowserWindow;
+    private readonly title: string;
     private readonly eventHandlers = {
         onClose: () => this.close(),
         onMaximize: () => this.maximize(),
@@ -24,6 +25,7 @@ export default class WindowsTitleBar extends React.Component<{}, IState> {
     constructor(props) {
         super(props);
         this.window = remote.getCurrentWindow();
+        this.title = document.title || 'Symphony';
         this.state = {
             isFullScreen: this.window.isFullScreen(),
             isMaximized: this.window.isMaximized(),
@@ -77,7 +79,7 @@ export default class WindowsTitleBar extends React.Component<{}, IState> {
                 </div>
                 <div className='title-container'>
                     {this.getSymphonyLogo()}
-                    <p id='title-bar-title'>{document.title || 'Symphony'}</p>
+                    <p id='title-bar-title'>{this.title}</p>
                 </div>
                 <div className='title-bar-button-container'>
                     <button


### PR DESCRIPTION
## Description
Update custom title bar's title only once
[ELECTRON-1369](https://perzoinc.atlassian.net/browse/ELECTRON-1369)

## Solution Approach
Set the title once the window is loaded and ignore other `document.title` updates

## Screenshot
![Screenshot 2019-07-12 at 12 12 18 PM](https://user-images.githubusercontent.com/13243259/61107955-b2057180-a49e-11e9-82a9-afa2b7e48825.png)
