### PR TITLE
fix: ELECTRON-1381: fix localisation for file not found cases

### DIFF
--- a/src/app/window-utils.ts
+++ b/src/app/window-utils.ts
@@ -33,6 +33,7 @@ const networkStatusCheckInterval = 10 * 1000;
 let networkStatusCheckIntervalId;
 
 const styles: IStyles[] = [];
+const DOWNLOAD_MANAGER_NAMESPACE = 'DownloadManager';
 
 /**
  * Checks if window is valid and exists
@@ -316,6 +317,8 @@ export const getBounds = (winPos: ICustomRectangle | Electron.Rectangle | undefi
  */
 export const downloadManagerAction = (type, filePath): void => {
     const focusedWindow = electron.BrowserWindow.getFocusedWindow();
+    const message = i18n.t('The file you are trying to open cannot be found in the specified path.', DOWNLOAD_MANAGER_NAMESPACE)();
+    const title = i18n.t('File not Found', DOWNLOAD_MANAGER_NAMESPACE)();
 
     if (!focusedWindow || !windowExists(focusedWindow)) {
         return;
@@ -325,8 +328,8 @@ export const downloadManagerAction = (type, filePath): void => {
         const openResponse = electron.shell.openExternal(`file:///${filePath}`);
         if (!openResponse && focusedWindow && !focusedWindow.isDestroyed()) {
             electron.dialog.showMessageBox(focusedWindow, {
-                message: i18n.t('The file you are trying to open cannot be found in the specified path.')(),
-                title: i18n.t('File not Found')(),
+                message,
+                title,
                 type: 'error',
             });
         }
@@ -336,8 +339,8 @@ export const downloadManagerAction = (type, filePath): void => {
     const showResponse = electron.shell.showItemInFolder(filePath);
     if (!showResponse) {
         electron.dialog.showMessageBox(focusedWindow, {
-            message: i18n.t('The file you are trying to open cannot be found in the specified path.')(),
-            title: i18n.t('File not Found')(),
+            message,
+            title,
             type: 'error',
         });
     }


### PR DESCRIPTION
## Description
Fix localisation for file not found cases in download manager 
[ELECTRON-1381](https://perzoinc.atlassian.net/browse/JIRA-ticket)

## Solution Approach
Add missing `DOWNLOAD_MANAGER_NAMESPACE` for the file not found i18n.t calls.
