### PR TITLE
fix: ELECTRON-1379: fix localisation for "Version" string

### DIFF
--- a/spec/__snapshots__/aboutApp.spec.ts.snap
+++ b/spec/__snapshots__/aboutApp.spec.ts.snap
@@ -5,6 +5,7 @@ exports[`about app should render correctly 1`] = `
   className="AboutApp"
 >
   <img
+    alt="Symphony"
     className="AboutApp-logo"
     src="../renderer/assets/symphony-logo.png"
   />

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -406,8 +406,10 @@ export class WindowHandler {
             if (!this.aboutAppWindow || !windowExists(this.aboutAppWindow)) {
                 return;
             }
+            const ABOUT_SYMPHONY_NAMESPACE = 'AboutSymphony';
+            const versionLocalised = i18n.t('Version', ABOUT_SYMPHONY_NAMESPACE)();
             const { clientVersion, buildNumber }: IVersionInfo = await versionHandler.getClientVersion();
-            this.aboutAppWindow.webContents.send('about-app-data', { buildNumber, clientVersion });
+            this.aboutAppWindow.webContents.send('about-app-data', { buildNumber, clientVersion, versionLocalised });
         });
     }
 

--- a/src/renderer/components/about-app.tsx
+++ b/src/renderer/components/about-app.tsx
@@ -6,6 +6,7 @@ interface IState {
     copyWrite?: string;
     clientVersion: string;
     buildNumber: string;
+    versionLocalised?: string;
 }
 
 /**
@@ -19,6 +20,7 @@ export default class AboutApp extends React.Component<{}, IState> {
             appName: 'Symphony',
             buildNumber: '',
             clientVersion: '0',
+            versionLocalised: 'Version',
         };
         this.updateState = this.updateState.bind(this);
     }
@@ -27,13 +29,13 @@ export default class AboutApp extends React.Component<{}, IState> {
      * main render function
      */
     public render(): JSX.Element {
-        const { clientVersion, buildNumber } = this.state;
+        const { clientVersion, buildNumber, versionLocalised } = this.state;
         const appName = remote.app.getName() || 'Symphony';
-        const versionString = `Version ${clientVersion} (${buildNumber})`;
+        const versionString = `${versionLocalised} ${clientVersion} (${buildNumber})`;
         const copyright = `Copyright \xA9 ${new Date().getFullYear()} ${appName}`;
         return (
             <div className='AboutApp'>
-                <img className='AboutApp-logo' src='../renderer/assets/symphony-logo.png'/>
+                <img className='AboutApp-logo' src='../renderer/assets/symphony-logo.png' alt='Symphony'/>
                 <span className='AboutApp-name'>{appName}</span>
                 <span className='AboutApp-versionText'>{versionString}</span>
                 <span className='AboutApp-copyrightText'>{copyright}</span>


### PR DESCRIPTION
## Description
Fix localisation for "Version" string in the "About Symphony" window.
[ELECTRON-1379](https://perzoinc.atlassian.net/browse/ELECTRON-1379)

## Solution Approach
Add version string through localisation in the about-app component.