### PR TITLE
fix: ELECTRON-1388: fix typo in notification setting radio button text

### DIFF
--- a/src/renderer/components/notification-settings.tsx
+++ b/src/renderer/components/notification-settings.tsx
@@ -72,7 +72,7 @@ export default class NotificationSettings extends React.Component<{}, IState> {
                             </div>
                             <div className='second-set'>
                                 {this.renderRadioButtons('upper-right', 'Top Right')}
-                                {this.renderRadioButtons('lower-right', 'Bottom Left')}
+                                {this.renderRadioButtons('lower-right', 'Bottom Right')}
                             </div>
                         </div>
                     </form>


### PR DESCRIPTION
## Description
Fix typo in notification setting radio button text
[ELECTRON-1388](https://perzoinc.atlassian.net/browse/ELECTRON-1388)

## Solution Approach
Update text in the notification configure component