### PR TITLE
fix: ELECTRON-1408: fix toggle dev tools menu item

### DIFF
--- a/src/app/app-menu.ts
+++ b/src/app/app-menu.ts
@@ -385,7 +385,7 @@ export class AppMenu {
                         label: i18n.t('Toggle Developer Tools')(),
                         accelerator: isMac ? 'Alt+Command+I' : 'Ctrl+Shift+I',
                         click(_item, focusedWindow) {
-                            const devToolsEnabled = config.getGlobalConfigFields([ 'devToolsEnabled' ]);
+                            const { devToolsEnabled } = config.getGlobalConfigFields([ 'devToolsEnabled' ]);
                             if (!focusedWindow || !windowExists(focusedWindow)) {
                                 return;
                             }


### PR DESCRIPTION
## Description
Fix issue where toggle dev tools wasn't working as per the global config
[ELECTRON-1408](https://perzoinc.atlassian.net/browse/ELECTRON-1408)

## Solution Approach
Destructure the config object correctly to get the devToolsEnabled config value in app menu component