### PR TITLE
fix: ELECTRON-1409 (Identify screens based on name instead of display_id for Windows)

### DIFF
--- a/spec/screenPicker.spec.ts
+++ b/spec/screenPicker.spec.ts
@@ -283,6 +283,40 @@ describe('screen picker', () => {
             expect(wrapper.find(applicationTabCustomSelector)).toHaveLength(0);
         });
 
+        it('should show `screen-tab` for Windows when source name is Entire screen and display_id is not present', () => {
+            const env = require('../src/common/env');
+            const wrapper = shallow(React.createElement(ScreenPicker));
+            const entireScreenStateMock = {
+                sources: [
+                    { display_id: '', id: '1', name: 'Entire screen', thumbnail: undefined },
+                    { display_id: '', id: '2', name: 'Screen 2', thumbnail: undefined },
+                    { display_id: '', id: '3', name: 'screen 3', thumbnail: undefined },
+                ],
+            };
+            env.isWindowsOS = true;
+            env.isMac = false;
+            wrapper.setState(entireScreenStateMock);
+            expect(wrapper.find(screenTabCustomSelector)).toHaveLength(1);
+            expect(wrapper.find(applicationTabCustomSelector)).toHaveLength(0);
+        });
+
+        it('should not show `screen-tab` for Mac when source name is Entire screen and display_id is not present', () => {
+            const env = require('../src/common/env');
+            const wrapper = shallow(React.createElement(ScreenPicker));
+            const entireScreenStateMock = {
+                sources: [
+                    { display_id: '', id: '1', name: 'Entire screen', thumbnail: undefined },
+                    { display_id: '', id: '2', name: 'Screen 2', thumbnail: undefined },
+                    { display_id: '', id: '3', name: 'screen 3', thumbnail: undefined },
+                ],
+            };
+            env.isWindowsOS = false;
+            env.isMac = true;
+            wrapper.setState(entireScreenStateMock);
+            expect(wrapper.find(screenTabCustomSelector)).toHaveLength(0);
+            expect(wrapper.find(applicationTabCustomSelector)).toHaveLength(1);
+        });
+
         it('should show `screen-tab` and `application-tab` when `isScreensAvailable` and `isApplicationsAvailable` is true', () => {
             const wrapper = shallow(React.createElement(ScreenPicker));
             const customState = {

--- a/src/renderer/components/screen-picker.tsx
+++ b/src/renderer/components/screen-picker.tsx
@@ -3,7 +3,7 @@ import { ipcRenderer } from 'electron';
 import * as React from 'react';
 
 import { apiCmds, apiName } from '../../common/api-interface';
-import { isWindowsOS } from '../../common/env';
+import { isMac, isWindowsOS } from '../../common/env';
 import { i18n } from '../../common/i18n-preload';
 
 const screenRegExp = new RegExp(/^Screen \d+$/gmi);
@@ -131,7 +131,7 @@ export default class ScreenPicker extends React.Component<{}, IState> {
                 'ScreenPicker-item-container',
                 { 'ScreenPicker-selected': this.shouldHighlight(source.id) },
             );
-            if (source.display_id !== '') {
+            if ((isMac && source.display_id !== '') || (isWindowsOS && (source.name === 'Entire screen' || screenRegExp.exec(source.name)))) {
                 source.fileName = 'fullscreen';
                 let sourceName;
                 if (source.name === 'Entire screen') {


### PR DESCRIPTION
## Description
Identify screens based on the name instead of `display_id` for Windows
[ELECTRON-1409](https://perzoinc.atlassian.net/browse/ELECTRON-1409)

## Solution Approach
- **Windows** Identify screens based on `source.name` using regex
- **Mac** Identify screens based on `source.display_id`

## Issue
Open issue https://github.com/electron/electron/issues/15111
