### PR TITLE
fix: SEARCH-1621 - Index Version in the config file gets updated immediately before lz4 file gets updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,6 @@
   },
   "optionalDependencies": {
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.6",
-    "swift-search": "1.55.3"
+    "swift-search": "1.55.3-1"
   }
 }


### PR DESCRIPTION
## Description
Index Version in the config file gets updated immediately before the lz4 file gets updated
[SEARCH-1621](https://perzoinc.atlassian.net/browse/SEARCH-1621)

## Solution Approach
When there is index version bump the version is updated on the config file on bootstrap which is causing to use the old index on a new library.

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
SwiftSearch | [#34](https://github.com/symphonyoss/SwiftSearch/pull/34)
