### PR TITLE
fix: ELECTRON-1445: fix minimise on close behaviour on macOS

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -244,9 +244,16 @@ export class WindowHandler {
             const {minimizeOnClose} = config.getConfigFields(['minimizeOnClose']);
             if (minimizeOnClose) {
                 event.preventDefault();
-                isMac ? this.mainWindow.hide() : this.mainWindow.minimize();
+                this.mainWindow.minimize();
                 return;
             }
+
+            if (isMac) {
+                event.preventDefault();
+                this.mainWindow.hide();
+                return;
+            }
+
             app.quit();
         });
 


### PR DESCRIPTION
## Description
When Minimize On Close option is not selected and if we try to close the app by clicking on x button, the app should be in the minimize position.
[ELECTRON-1445](https://perzoinc.atlassian.net/browse/ELECTRON-1445)

## Solution Approach
Update logic to customise close behaviour for macOS