### PR TITLE
fix: SEARCH-1627 - FreeDiskSpace check uses FREE instead of AVAILABLE

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,6 @@
   },
   "optionalDependencies": {
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.7",
-    "swift-search": "1.55.3-1"
+    "swift-search": "1.55.3-2"
   }
 }


### PR DESCRIPTION
## Description
FreeDiskSpace check uses FREE instead of AVAILABLE
[SEARCH-1627](https://perzoinc.atlassian.net/browse/SEARCH-1627)

## Before
![Screenshot 2019-07-25 at 1 54 44 PM](https://user-images.githubusercontent.com/596478/61872020-ea299d00-aeff-11e9-9a3e-c3a8899c4844.png)

## After
![Screenshot 2019-07-25 at 5 12 26 PM](https://user-images.githubusercontent.com/596478/61872037-f4e43200-aeff-11e9-8c35-9bf104f67e76.png)
![Screenshot 2019-07-25 at 5 13 51 PM](https://user-images.githubusercontent.com/596478/61872038-f4e43200-aeff-11e9-9ad7-d260ab816478.png)


## Solution Approach
Using the free as a source will affect the disk space check. If the root system has allocated some amount of space that will be added to the free. So we need to use available in instead of free 

The calculation for available is `available = free - reserved filesystem blocks(for root)`

## Related PRs
List related PRs against other branches / repositories:

branch | PR
------ | ------
SwiftSearch | [#35](https://github.com/symphonyoss/SwiftSearch/pull/35)

## QA Checklist
- [x] Unit-Tests