### PR TITLE
fix: ELECTRON-1464 (Update custom title bar's title correctly)

### DIFF
--- a/spec/windowsTitleBar.spec.ts
+++ b/spec/windowsTitleBar.spec.ts
@@ -3,6 +3,12 @@ import * as React from 'react';
 import WindowsTitleBar from '../src/renderer/components/windows-title-bar';
 import { ipcRenderer, remote } from './__mocks__/electron';
 
+// @ts-ignore
+global.MutationObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    disconnect: jest.fn(),
+}));
+
 describe('windows title bar', () => {
     beforeEach(() => {
         // state initial
@@ -96,7 +102,7 @@ describe('windows title bar', () => {
         const wrapper = shallow(React.createElement(WindowsTitleBar));
         const event = {
             preventDefault: jest.fn(),
-        }
+        };
         const spy = jest.spyOn(event, 'preventDefault');
         wrapper.find(customSelector).simulate('mouseDown', event);
         expect(spy).toBeCalled();


### PR DESCRIPTION
## Description
Update custom title bar's title based on `document.title`
[ELECTRON-1464](https://perzoinc.atlassian.net/browse/ELECTRON-1464)

## Solution Approach
- User `MutationObserver` to observe the document title changes and update CTB's title

#### Screencast
![2019-08-01 10 31 37](https://user-images.githubusercontent.com/13243259/62291064-80ba0900-b480-11e9-8485-cc071241f866.gif)
