### PR TITLE
fix: ELECTRON-1459 (Update screen snippet image type to png from jpg)

### DIFF
--- a/src/app/screen-snippet-handler.ts
+++ b/src/app/screen-snippet-handler.ts
@@ -39,9 +39,9 @@ class ScreenSnippet {
      */
     public async capture(webContents: Electron.webContents) {
         logger.info(`screen-snippet-handler: Starting screen capture!`);
-        this.outputFileName = path.join(this.tempDir, 'symphonyImage-' + Date.now() + '.jpg');
+        this.outputFileName = path.join(this.tempDir, 'symphonyImage-' + Date.now() + '.png');
         this.captureUtilArgs = isMac
-            ? [ '-i', '-s', '-t', 'jpg', this.outputFileName ]
+            ? [ '-i', '-s', '-t', 'png', this.outputFileName ]
             : [ this.outputFileName, i18n.getLocale() ];
 
         logger.info(`screen-snippet-handler: Capturing snippet with file ${this.outputFileName} and args ${this.captureUtilArgs}!`);
@@ -85,7 +85,7 @@ class ScreenSnippet {
      *
      * @param captureUtil {string}
      * @param captureUtilArgs {captureUtilArgs}
-     * @example execCmd('-i -s', '/user/desktop/symphonyImage-1544025391698.jpg')
+     * @example execCmd('-i -s', '/user/desktop/symphonyImage-1544025391698.png')
      */
     private execCmd(captureUtil: string, captureUtilArgs: ReadonlyArray<string>): Promise<ChildProcess> {
         return new Promise<ChildProcess>((resolve, reject) => {


### PR DESCRIPTION
## Description
Change the screen snippet image extension to `.png`
[ELECTRON-1459](https://perzoinc.atlassian.net/browse/ELECTRON-1459)

## Solution Approach
Rename the `temp` file extension to `.png`

### Screenshot
![Screenshot 2019-08-02 at 10 50 04 AM](https://user-images.githubusercontent.com/13243259/62346505-00dd7e80-b514-11e9-8508-4688494c5a78.png)

