### PR TITLE
fix: ELECTRON-1465 (Persist locale changes to the user config file)

### DIFF
--- a/src/app/config-handler.ts
+++ b/src/app/config-handler.ts
@@ -40,6 +40,7 @@ export interface IConfig {
     permissions: IPermission;
     customFlags: ICustomFlag;
     mainWinPos?: ICustomRectangle;
+    locale?: string;
 }
 
 export interface IPermission {

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -6,7 +6,7 @@ import { format, parse } from 'url';
 
 import { apiName, WindowTypes } from '../common/api-interface';
 import { isDevEnv, isMac, isWindowsOS } from '../common/env';
-import { i18n } from '../common/i18n';
+import { i18n, LocaleType } from '../common/i18n';
 import { logger } from '../common/logger';
 import { getCommandLineArgs, getGuid } from '../common/utils';
 import { notification } from '../renderer/notification';
@@ -88,7 +88,7 @@ export class WindowHandler {
 
     constructor(opts?: Electron.BrowserViewConstructorOptions) {
         // Use these variables only on initial setup
-        this.config = config.getConfigFields(['isCustomTitleBar', 'mainWinPos', 'minimizeOnClose', 'notificationSettings', 'alwaysOnTop']);
+        this.config = config.getConfigFields([ 'isCustomTitleBar', 'mainWinPos', 'minimizeOnClose', 'notificationSettings', 'alwaysOnTop', 'locale' ]);
         this.globalConfig = config.getGlobalConfigFields(['url', 'contextIsolation', 'customFlags']);
         const {url, contextIsolation, customFlags}: IConfig = this.globalConfig;
 
@@ -112,6 +112,8 @@ export class WindowHandler {
         this.isOnline = true;
 
         this.appMenu = null;
+        const locale: LocaleType = (this.config.locale || app.getLocale()) as LocaleType;
+        i18n.setLocale(locale);
 
         try {
             const extra = {podUrl: url, process: 'main'};

--- a/src/app/window-utils.ts
+++ b/src/app/window-utils.ts
@@ -235,7 +235,7 @@ export const isValidWindow = (browserWin: Electron.BrowserWindow): boolean => {
  *
  * @param locale {LocaleType}
  */
-export const updateLocale = (locale: LocaleType): void => {
+export const updateLocale = async (locale: LocaleType): Promise<void> => {
     logger.info(`window-utils: updating locale to ${locale}!`);
     // sets the new locale
     i18n.setLocale(locale);
@@ -243,6 +243,11 @@ export const updateLocale = (locale: LocaleType): void => {
     if (appMenu) {
         logger.info(`window-utils: updating app menu with locale ${locale}!`);
         appMenu.update(locale);
+    }
+
+    if (i18n.isValidLocale(locale)) {
+        // Update user config file with latest locale changes
+        await config.updateUserConfig({ locale });
     }
 };
 

--- a/src/common/i18n.ts
+++ b/src/common/i18n.ts
@@ -52,6 +52,9 @@ class Translation {
      * @param locale {LocaleType}
      */
     public isValidLocale(locale: LocaleType): boolean {
+        if (!locale) {
+            return false;
+        }
         const localeMatch: string[] | null = locale.match(localeCodeRegex);
         return !(!locale && (!localeMatch || localeMatch.length < 1));
     }

--- a/src/common/i18n.ts
+++ b/src/common/i18n.ts
@@ -30,8 +30,7 @@ class Translation {
      * @param locale
      */
     public setLocale(locale: LocaleType): void {
-        const localeMatch: string[] | null = locale.match(localeCodeRegex);
-        if (!locale && (!localeMatch || localeMatch.length < 1)) {
+        if (!this.isValidLocale(locale)) {
             return;
         }
 
@@ -45,6 +44,16 @@ class Translation {
      */
     public getLocale(): LocaleType {
         return this.locale;
+    }
+
+    /**
+     * Validates the locale using Regex
+     *
+     * @param locale {LocaleType}
+     */
+    public isValidLocale(locale: LocaleType): boolean {
+        const localeMatch: string[] | null = locale.match(localeCodeRegex);
+        return !(!locale && (!localeMatch || localeMatch.length < 1));
     }
 
     /**


### PR DESCRIPTION
## Description
Persist locale changes to the user config file
[ELECTRON-1465](https://perzoinc.atlassian.net/browse/ELECTRON-1465)

## Solution Approach
- Save the locale changes to the user config file
- Use the locale from the config file for the initial launch
