### PR TITLE
fix: Migrate to napi version of node-ffi/ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,6 @@
   },
   "optionalDependencies": {
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet.git#v1.0.7",
-    "swift-search": "1.55.2-beta.1"
+    "swift-search": "2.0.1"
   }
 }


### PR DESCRIPTION
## Description
Migrate to napi version of node-ffi

## Solution Approach
Change the `ffi` module to use the napi version as there is no subsequent release for `ffi`.
This bumps both `ffi` and `ref` modules.

## Related PRs
List related PRs against other branches / repositories:

branch | PR
------ | ------
SwiftSearch | [#39](https://github.com/symphonyoss/SwiftSearch/pull/39)