### PR TITLE
fix: ELECTRON-1478: remove dev tools menu item via configuration

### DIFF
--- a/src/app/app-menu.ts
+++ b/src/app/app-menu.ts
@@ -1,4 +1,4 @@
-import { app, dialog, Menu, MenuItemConstructorOptions, session, shell } from 'electron';
+import { app, Menu, MenuItemConstructorOptions, session, shell } from 'electron';
 
 import { isLinux, isMac, isWindowsOS } from '../common/env';
 import { i18n, LocaleType } from '../common/i18n';
@@ -65,6 +65,8 @@ const menuItemsArray = Object.keys(menuSections)
     .map((key) => menuSections[ key ])
     .filter((value) => isMac ?
         true : value !== menuSections.about);
+
+const { devToolsEnabled } = config.getGlobalConfigFields([ 'devToolsEnabled' ]);
 
 export class AppMenu {
     private menu: Electron.Menu | undefined;
@@ -403,7 +405,6 @@ export class AppMenu {
                         label: i18n.t('Toggle Developer Tools')(),
                         accelerator: isMac ? 'Alt+Command+I' : 'Ctrl+Shift+I',
                         click(_item, focusedWindow) {
-                            const { devToolsEnabled } = config.getGlobalConfigFields([ 'devToolsEnabled' ]);
                             if (!focusedWindow || !windowExists(focusedWindow)) {
                                 return;
                             }
@@ -411,12 +412,6 @@ export class AppMenu {
                                 focusedWindow.webContents.toggleDevTools();
                                 return;
                             }
-                            dialog.showMessageBox(focusedWindow, {
-                                type: 'warning',
-                                buttons: [ 'Ok' ],
-                                title: i18n.t('Dev Tools disabled')(),
-                                message: i18n.t('Dev Tools has been disabled! Please contact your system administrator to enable it!')(),
-                            });
                         },
                     }, {
                         click: () => windowHandler.createMoreInfoWindow(),

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -43,6 +43,8 @@ export interface ICustomBrowserWindow extends Electron.BrowserWindow {
 const DEFAULT_WIDTH: number = 900;
 const DEFAULT_HEIGHT: number = 900;
 
+const {devToolsEnabled} = config.getGlobalConfigFields(['devToolsEnabled']);
+
 export class WindowHandler {
 
     /**
@@ -792,7 +794,6 @@ export class WindowHandler {
      */
     private onRegisterDevtools(): void {
         const focusedWindow = BrowserWindow.getFocusedWindow();
-        const {devToolsEnabled} = config.getGlobalConfigFields(['devToolsEnabled']);
         if (!focusedWindow || !windowExists(focusedWindow)) {
             return;
         }
@@ -801,13 +802,7 @@ export class WindowHandler {
             return;
         }
         focusedWindow.webContents.closeDevTools();
-        logger.info(`window-handler: dev tools disabled by admin, showing error dialog to user!`);
-        electron.dialog.showMessageBox(focusedWindow, {
-            type: 'warning',
-            buttons: ['Ok'],
-            title: i18n.t('Dev Tools disabled')(),
-            message: i18n.t('Dev Tools has been disabled! Please contact your system administrator to enable it!')(),
-        });
+        logger.info(`window-handler: dev tools disabled by admin, not opening it for the user!`);
     }
 
     /**


### PR DESCRIPTION
## Description
Currently, even if the dev tools is disabled in the Symphony config file, we show the menu item and display an error message. This change fixes the confusion of showing the error message and instead just doesn't bring up the dev tools if it is disabled in the configuration file
[ELECTRON-1478](https://perzoinc.atlassian.net/browse/ELECTRON-1478)

## Solution Approach
Remove the error message & hide menu item

## Related PRs
N/A