### PR TITLE
fix: SDA-1347 (Group multiple processes into a single task bar icon)

### DIFF
--- a/src/app/init.ts
+++ b/src/app/init.ts
@@ -10,6 +10,10 @@ import { appStats } from './stats';
 const userDataPathArg: string | null = getCommandLineArgs(process.argv, '--userDataPath=', false);
 const userDataPath = userDataPathArg && userDataPathArg.substring(userDataPathArg.indexOf('=') + 1);
 
+// need to set this explicitly if using Squirrel
+// https://www.electron.build/configuration/configuration#Configuration-squirrelWindows
+app.setAppUserModelId('com.symphony.electron-desktop');
+
 // Set user data path before app ready event
 if (isDevEnv) {
     const devDataPath = path.join(app.getPath('appData'), 'Symphony-dev');


### PR DESCRIPTION
## Description
Group multiple processes into a single taskbar icon
[SDA-1347](https://perzoinc.atlassian.net/browse/SDA-1347)

## Solution Approach
- Set `setAppUserModelId` to `com.symphony.electron-desktop` so Windows makes sure any processes created will be merged into single taskbar icon.

## Read more
- https://docs.microsoft.com/en-us/windows/win32/shell/appids
- https://www.electron.build/configuration/configuration#Configuration-squirrelWindows