### PR TITLE
fix: SDA-1526: remove support for opening non http(s) links

### DIFF
--- a/spec/childWindowHandle.spec.ts
+++ b/spec/childWindowHandle.spec.ts
@@ -98,6 +98,6 @@ describe('child window handle', () => {
         const spy = jest.spyOn(windowHandler, 'openUrlInDefaultBrowser');
         handleChildWindow(ipcRenderer as any);
         ipcRenderer.send('new-window', ...args);
-        expect(spy).toBeCalledWith('invalid');
+        expect(spy).not.toBeCalledWith('invalid');
     });
 });


### PR DESCRIPTION
## Description
Currently, in the Symphony message list, we supporting any link (ftp) that is non http(s), this PR fixes that by supporting opening of just http(s) links.
[SDA-1526](https://perzoinc.atlassian.net/browse/SDA-1526)

## Solution Approach
Add filter to check the protocol of a url to verify if it is http(s)

## Related PRs
N/A
