### PR TITLE
feat: SDA-1525: add support for pod whitelisting

### DIFF
--- a/config/Symphony.config
+++ b/config/Symphony.config
@@ -10,6 +10,7 @@
     "devToolsEnabled": true,
     "contextIsolation": false,
     "ctWhitelist": [],
+    "podWhitelist": [],
     "notificationSettings": {
         "position": "upper-right",
         "display": ""

--- a/docs/features/pod-whitelisting.md
+++ b/docs/features/pod-whitelisting.md
@@ -1,0 +1,23 @@
+# Intro
+Allow admins to whitelist pod urls
+
+# Platforms Supported
+macOS, Windows 10, Windows 7
+
+# Purpose
+For admins to whitelist pod urls allowed to be passed via command line 
+
+# Details
+Any url passed via command line needs to be validated. To support this, we add a "podWhitelist" parameter in the config file that allows admins to configure what pod urls can be passed via command line. And, only those URLs will be supported to be loaded via command line
+
+To make this work, you need to add urls under the "podWhitelist" parameter in the "Symphony.config" file.
+
+If you still need to allow passing any urls, just leave the "podWhitelist" parameter blank in the "Symphony.config" file.
+
+# Examples
+- If your app is installed in C:\Program Files\Symphony\Symphony, you need to edit the file "Symphony.config" under the "config" sub-directory and set domains in the "podWhitelist" parameter to ["https://demo.symphony.com"]. Note that you need to pass the exact url from command line.
+
+- If you want to allow any url, set the "podWhitelist" parameter to [] which is the default.
+
+# Other Info
+N/A

--- a/src/app/chrome-flags.ts
+++ b/src/app/chrome-flags.ts
@@ -8,7 +8,7 @@ logger.info(`chrome-flags: Setting mandatory chrome flags`, { flag: { 'ssl-versi
 app.commandLine.appendSwitch('ssl-version-fallback-min', 'tls1.2');
 
 // Special args that need to be excluded as part of the chrome command line switch
-const specialArgs = [ '--url', '--multiInstance', '--userDataPath=', 'symphony://', '--inspect-brk', '--inspect', '--logPath' ];
+const specialArgs = [ '--url', '--multiInstance', '--userDataPath=', 'symphony://', '--inspect-brk', '--inspect', '--logPath', '--no-sandbox' ];
 
 /**
  * Sets chrome flags

--- a/src/app/config-handler.ts
+++ b/src/app/config-handler.ts
@@ -22,6 +22,7 @@ export interface IConfig {
     devToolsEnabled: boolean;
     contextIsolation: boolean;
     ctWhitelist: string[];
+    podWhitelist: string[];
     configVersion: string;
     buildNumber: string;
     autoLaunchPath: string;


### PR DESCRIPTION
## Description
Currently, any url passed via command line is not validated, and, SDA essentially acts as a browser. To counter this, we add a "podWhitelist" parameter in the config file that allows admins to configure what pod urls can be passed via command line. And, only those URLs will be supported to be loaded via command line.
[SDA-1525](https://perzoinc.atlassian.net/browse/SDA-1525)

## Solution Approach
Add configurable parameter to whitelist urls passed from command line.

## Related PRs
N/A