### PR TITLE
fix: SDA-1530 (Fix url validation check)

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "electron-dl": "1.14.0",
     "electron-fetch": "1.3.0",
     "electron-log": "3.0.7",
-    "electron-spellchecker": "git+https://github.com/symphonyoss/electron-spellchecker.git#v2.2.1",
+    "electron-spellchecker": "git+https://github.com/symphonyoss/electron-spellchecker.git#v2.3.0",
     "ffi-napi": "2.4.5",
     "filesize": "4.1.2",
     "react": "16.9.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "electron-dl": "1.14.0",
     "electron-fetch": "1.3.0",
     "electron-log": "3.0.7",
-    "electron-spellchecker": "git+https://github.com/symphonyoss/electron-spellchecker.git#v2.0.1",
+    "electron-spellchecker": "git+https://github.com/symphonyoss/electron-spellchecker.git#v2.2.1",
     "ffi-napi": "2.4.5",
     "filesize": "4.1.2",
     "react": "16.9.0",

--- a/src/app/child-window-handler.ts
+++ b/src/app/child-window-handler.ts
@@ -39,11 +39,13 @@ const verifyProtocolForNewUrl = (url: string): boolean => {
         return false;
     }
 
+    // url parse returns protocol with :
     if (parsedUrl.protocol === 'https:') {
         logger.info(`child-window-handler: The url ${url} is a https url! Returning true for verification!`);
         return true;
     }
 
+    // url parse returns protocol with :
     if (parsedUrl.protocol === 'http:') {
         logger.info(`child-window-handler: The url ${url} is a http url! Returning true for verification!`);
         return true;

--- a/src/app/child-window-handler.ts
+++ b/src/app/child-window-handler.ts
@@ -39,12 +39,12 @@ const verifyProtocolForNewUrl = (url: string): boolean => {
         return false;
     }
 
-    if (parsedUrl.protocol === 'https') {
+    if (parsedUrl.protocol === 'https:') {
         logger.info(`child-window-handler: The url ${url} is a https url! Returning true for verification!`);
         return true;
     }
 
-    if (parsedUrl.protocol === 'http') {
+    if (parsedUrl.protocol === 'http:') {
         logger.info(`child-window-handler: The url ${url} is a http url! Returning true for verification!`);
         return true;
     }


### PR DESCRIPTION
## Description
Fix validation check
[SDA-1530](https://perzoinc.atlassian.net/browse/SDA-1530)

## Solution Approach
Replace `http` with `http:` as URL parser returns protocol with a colon


## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
Spellchecker | [link](https://github.com/symphonyoss/electron-spellchecker/pull/9)
