### PR TITLE
fix: SDA-1487: add support for creating custom log folders on the fly

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/enzyme": "3.9.0",
     "@types/ffi-napi": "2.4.1",
     "@types/jest": "23.3.12",
-    "@types/node": "10.11.4",
+    "@types/node": "11.13.22",
     "@types/react": "16.8.3",
     "@types/react-dom": "16.0.9",
     "@types/ref-napi": "1.4.0",

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -54,11 +54,6 @@ class Logger {
             transports.file.level = 'debug';
             transports.file.format = '{y}-{m}-{d} {h}:{i}:{s}:{ms} {z} | {level} | {text}';
             transports.file.appName = 'Symphony';
-        } else {
-            transports.file.file = path.join(this.logPath, `app_${Date.now()}.log`);
-            transports.file.level = 'debug';
-            transports.file.format = '{y}-{m}-{d} {h}:{i}:{s}:{ms} {z} | {level} | {text}';
-            transports.file.appName = 'Symphony-dev';
         }
 
         const logLevel = getCommandLineArgs(process.argv, '--logLevel=', false);
@@ -74,7 +69,9 @@ class Logger {
         }
 
         // cleans up old logs if there are any
-        this.cleanupOldLogs();
+        if (app.isPackaged) {
+            this.cleanupOldLogs();
+        }
     }
 
     /**


### PR DESCRIPTION
## Description
- Currently, if we use custom logs path and a directory doesn't exist, logs are created in the default Electron path.
- This change fixes that by creating the custom logs directory (recursively) on the fly
- This change also fixes issue with clearing old log files. Now, we keep the log files for the last 5 days instead of 10 days
[SDA-1487](https://perzoinc.atlassian.net/browse/SDA-1487)

## Solution Approach
- Use nodeJS `mkdirSync` api recursively to create the custom logs folder if it doesn't exist.

## Related PRs
N/A
