### PR TITLE
feat: SDA-1292: unpack all .node files in asar

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,7 @@
     "unpacked-win-x86": "npm run prebuild && npm run test && build --win --ia32 --dir"
   },
   "build": {
-    "asarUnpack": [
-      "node_modules/@nornagon/cld/build/Release/cld.node",
-      "node_modules/@nornagon/spellchecker/build/Release/spellchecker.node",
-      "node_modules/keyboard-layout/build/Release/keyboard-layout-manager.node"
-    ],
+    "asarUnpack": "**/*.node",
     "files": [
       "!coverage/*",
       "!installer/*",


### PR DESCRIPTION
## Description
Some of our customers need all DLL files to be extracted within the installation directory rather than dynamically being done in the temp folder on Windows.
This change addresses the requirement. 
[SDA-1292](https://perzoinc.atlassian.net/browse/SDA-1292)

## Solution Approach
Use electron-builder configuration to extract all DLL files to the installation directory.

## Related PRs
N/A
