### PR TITLE
feat: SDA-1557: unpack asar DLL files locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,7 @@
   "build": {
     "appId": "com.symphony.electron-desktop",
     "asar": true,
-    "asarUnpack": [
-      "node_modules/@nornagon/cld/build/Release/cld.node",
-      "node_modules/@nornagon/spellchecker/build/Release/spellchecker.node",
-      "node_modules/keyboard-layout/build/Release/keyboard-layout-manager.node"
-    ],
+    "asarUnpack": "**/*.node",
     "files": [
       "!coverage/*",
       "!installer/*",


### PR DESCRIPTION
## Description
This PR addresses issues with DLL files getting unpacked in temp directories on Windows.
[SDA-1557](https://perzoinc.atlassian.net/browse/SDA-1557)

## Solution Approach
As part of the build process, we unpack all the asar DLL files in the installation folder

## Related PRs

branch | PR
------ | ------
3.8.x | [https://github.com/symphonyoss/SymphonyElectron/pull/794 ](3.8.x)
