### PR TITLE
feat: SDA-1561: move app data to local profile

### DIFF
--- a/spec/childWindowHandle.spec.ts
+++ b/spec/childWindowHandle.spec.ts
@@ -21,6 +21,7 @@ jest.mock('../src/common/env', () => {
     return {
         isWindowsOS: true,
         isMac: false,
+        isElectronQA: true,
     };
 });
 

--- a/src/app/init.ts
+++ b/src/app/init.ts
@@ -1,15 +1,10 @@
 import { app } from 'electron';
 import * as path from 'path';
 
-import { isDevEnv, isWindowsOS } from '../common/env';
+import { isDevEnv } from '../common/env';
 import { logger } from '../common/logger';
 import { getCommandLineArgs } from '../common/utils';
 import { appStats } from './stats';
-
-if (isWindowsOS && process.env.LOCALAPPDATA) {
-    app.setPath('appData', process.env.LOCALAPPDATA);
-    app.setPath('userData', path.join(app.getPath('appData'), app.getName()));
-}
 
 // Handle custom user data path from process.argv
 const userDataPathArg: string | null = getCommandLineArgs(process.argv, '--userDataPath=', false);

--- a/src/app/init.ts
+++ b/src/app/init.ts
@@ -1,10 +1,15 @@
 import { app } from 'electron';
 import * as path from 'path';
 
-import { isDevEnv } from '../common/env';
+import { isDevEnv, isWindowsOS } from '../common/env';
 import { logger } from '../common/logger';
 import { getCommandLineArgs } from '../common/utils';
 import { appStats } from './stats';
+
+if (isWindowsOS && process.env.LOCALAPPDATA) {
+    app.setPath('appData', process.env.LOCALAPPDATA);
+    app.setPath('userData', path.join(app.getPath('appData'), app.getName()));
+}
 
 // Handle custom user data path from process.argv
 const userDataPathArg: string | null = getCommandLineArgs(process.argv, '--userDataPath=', false);

--- a/src/app/reports-handler.ts
+++ b/src/app/reports-handler.ts
@@ -66,7 +66,7 @@ const generateArchiveForDirectory = (source: string, destination: string, fileEx
 export const exportLogs = (): void => {
     const FILE_EXTENSIONS = [ '.log' ];
     const MAC_LOGS_PATH = '/Library/Logs/Symphony/';
-    const WINDOWS_LOGS_PATH = '\\AppData\\Roaming\\Symphony\\logs';
+    const WINDOWS_LOGS_PATH = '\\AppData\\Local\\Symphony\\logs';
 
     const logsPath = isMac ? MAC_LOGS_PATH : WINDOWS_LOGS_PATH;
     const source = app.getPath('home') + logsPath;

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as util from 'util';
 
-import { isElectronQA } from './env';
+import { isElectronQA, isWindowsOS } from './env';
 import { getCommandLineArgs } from './utils';
 
 export interface ILogMsg {
@@ -21,6 +21,16 @@ interface IClientLogMsg {
 }
 
 const MAX_LOG_QUEUE_LENGTH = 100;
+
+if (isWindowsOS && process.env.LOCALAPPDATA) {
+    app.setPath('appData', process.env.LOCALAPPDATA);
+    app.setPath('userData', path.join(app.getPath('appData'), app.getName()));
+    const logPath = path.join(app.getPath('appData'), app.getName(), 'logs');
+    if (!fs.existsSync(logPath)) {
+        fs.mkdirSync(logPath);
+    }
+    app.setPath('logs', logPath);
+}
 
 class Logger {
     private readonly showInConsole: boolean = false;

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -229,6 +229,9 @@ class Logger {
      * Cleans up logs older than a day
      */
     private cleanupOldLogs(): void {
+        if (!fs.existsSync(this.logPath)) {
+            return;
+        }
         const files = fs.readdirSync(this.logPath);
         const deleteTimeStamp = new Date().getTime() + (10 * 24 * 60 * 60 * 1000);
         files.forEach((file) => {

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -29,7 +29,7 @@ if (isWindowsOS && process.env.LOCALAPPDATA) {
     // We need to create the logs directory manually because
     // Electron 3.1.x doesn't support this
     const logPath = path.join(app.getPath('appData'), app.getName(), 'logs');
-    if (!fs.existsSync(logPath)) {
+    if (!fs.existsSync(logPath) && !isElectronQA) {
         fs.mkdirSync(logPath);
     }
     app.setPath('logs', logPath);

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -25,6 +25,9 @@ const MAX_LOG_QUEUE_LENGTH = 100;
 if (isWindowsOS && process.env.LOCALAPPDATA) {
     app.setPath('appData', process.env.LOCALAPPDATA);
     app.setPath('userData', path.join(app.getPath('appData'), app.getName()));
+
+    // We need to create the logs directory manually because
+    // Electron 3.1.x doesn't support this
     const logPath = path.join(app.getPath('appData'), app.getName(), 'logs');
     if (!fs.existsSync(logPath)) {
         fs.mkdirSync(logPath);


### PR DESCRIPTION
## Description
Some of the customers use roaming profiles mapped to network drives, this creates issues when trying to run SDA in different VMs.

This PR addresses the issue by moving app / user data and logs to the local profile
[SDA-1561](https://perzoinc.atlassian.net/browse/SDA-1561)

## Solution Approach
Move app / user data and logs to local profile from roaming profile

## Related PRs

branch | PR
------ | ------
master | https://github.com/symphonyoss/SymphonyElectron/pull/795
