### PR TITLE
fix: SDA-1581 (Set document title for all the window)

### DIFF
--- a/src/renderer/preload-component.ts
+++ b/src/renderer/preload-component.ts
@@ -43,21 +43,26 @@ const load = () => {
             break;
         case components.screenPicker:
             loadStyle(components.screenPicker);
+            document.title = 'Screen Picker - Symphony';
             component = ScreenPicker;
             break;
         case components.screenSharingIndicator:
             loadStyle(components.screenSharingIndicator);
+            document.title = 'Screen Sharing Indicator - Symphony';
             component = ScreenSharingIndicator;
             break;
         case components.basicAuth:
             loadStyle(components.basicAuth);
+            document.title = 'Basic Authentication - Symphony';
             component = BasicAuth;
             break;
         case components.notification:
             loadStyle(components.notification);
+            document.title = 'Notification - Symphony';
             component = NotificationComp;
             break;
         case components.notificationSettings:
+            document.title = 'Notification Settings - Symphony';
             loadStyle(components.notificationSettings);
             component = NotificationSettings;
             break;


### PR DESCRIPTION
## Description
Set document title for all the window
[SDA-1581](https://perzoinc.atlassian.net/browse/SDA-1581)

## Solution Approach
Set `document.title` for all the frameless window

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
3.8.x | [link](https://github.com/symphonyoss/SymphonyElectron/pull/802)
