### PR TITLE
SDA-1498 Update test for full screen for french & japanese

### DIFF
--- a/src/locale/fr-FR.json
+++ b/src/locale/fr-FR.json
@@ -159,9 +159,9 @@
   "Show Logs in File Manager": "Afficher les journaux dans le gestionnaire de fichiers",
   "Show Logs in Finder": "Montrer dans l'application 'Finder' le journal d'évènements",
   "SnackBar": {
-    " to exit full screen": " pour quitter le plein écran",
+    " to exit full screen": " pour quitter le mode plein écran",
     "esc": "Esc",
-    "Press ": "Appuyer sur "
+    "Press ": "Appuyez sur "
   },
   "Sorry, this is a test build and it has expired. Please contact your administrator to get a production build.": "Désolé, ceci est une version de test et elle a expiré. Veuillez contacter votre administrateur pour obtenir une version de production.",
   "Sorry, you are not allowed to access this website": "Désolé, vous n'êtes pas autorisé à accéder à ce site.",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -159,9 +159,9 @@
   "Show Logs in File Manager": "Afficher les journaux dans le gestionnaire de fichiers",
   "Show Logs in Finder": "Montrer dans l'application 'Finder' le journal d'évènements",
   "SnackBar": {
-    " to exit full screen": " pour quitter le plein écran",
+    " to exit full screen": " pour quitter le mode plein écran",
     "esc": "Esc",
-    "Press ": "Appuyer sur "
+    "Press ": "Appuyez sur "
   },
   "Sorry, this is a test build and it has expired. Please contact your administrator to get a production build.": "Désolé, ceci est une version de test et elle a expiré. Veuillez contacter votre administrateur pour obtenir une version de production.",
   "Sorry, you are not allowed to access this website": "Désolé, vous n'êtes pas autorisé à accéder à ce site.",

--- a/src/locale/ja-JP.json
+++ b/src/locale/ja-JP.json
@@ -159,9 +159,9 @@
   "Show Logs in File Manager": "ファイルマネージャに表示ログ",
   "Show Logs in Finder": "ファインダーにログを表示",
   "SnackBar": {
-    " to exit full screen": " を押します",
+    " to exit full screen": " を押して全画面表示を終了します",
     "esc": "Esc",
-    "Press ": "全画面表示を終了するには "
+    "Press ": " "
   },
   "Sorry, this is a test build and it has expired. Please contact your administrator to get a production build.": "申し訳ありませんが、これはテストビルドであり、期限切れです。プロダクションビルドを入手するには、管理者に連絡してください。",
   "Sorry, you are not allowed to access this website": "申し訳ありませんが、このウェブサイトへのアクセスは許可されていません",

--- a/src/locale/ja.json
+++ b/src/locale/ja.json
@@ -159,9 +159,9 @@
   "Show Logs in File Manager": "ファイルマネージャに表示ログ",
   "Show Logs in Finder": "ファインダーにログを表示",
   "SnackBar": {
-    " to exit full screen": " を押します",
+    " to exit full screen": " を押して全画面表示を終了します",
     "esc": "Esc",
-    "Press ": "全画面表示を終了するには "
+    "Press ": " "
   },
   "Sorry, this is a test build and it has expired. Please contact your administrator to get a production build.": "申し訳ありませんが、これはテストビルドであり、期限切れです。プロダクションビルドを入手するには、管理者に連絡してください。",
   "Sorry, you are not allowed to access this website": "申し訳ありませんが、このウェブサイトへのアクセスは許可されていません",


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits. 
Describe the problem or feature in addition to a link to the 
https://perzoinc.atlassian.net/browse/sda-1498 L10N: "Press Esc to exit full screen" not localized

## Solution Approach
Describe the approach you've taken to implement this change / resolve the issue

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
other_pr_dev | [link]()
