### PR TITLE
fix: INFOSEC-392 (Fix a security vulnerability with pupa an internal dependency of electron-dl)

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "async.map": "0.5.2",
     "auto-launch": "5.0.5",
     "classnames": "2.2.6",
-    "electron-dl": "1.14.0",
+    "electron-dl": "git+https://github.com/symphonyoss/electron-dl.git#v1.15.0",
     "electron-fetch": "1.3.0",
     "electron-log": "3.0.7",
     "electron-spellchecker": "git+https://github.com/symphonyoss/electron-spellchecker.git#v2.0.1",


### PR DESCRIPTION
## Description
Fix security vulnerability in a third-party module
[INFOSEC-392](https://perzoinc.atlassian.net/browse/INFOSEC-392)

## Solution Approach
Upgrade electron-dl's internal dependency `pupa` to `2.0.0` 

Read more: https://snyk.io/vuln/SNYK-JS-PUPA-174563%5D

