### PR TITLE
fix: SDA-48 (Port changes from 3.8.x & force sandbox for all BrowserWindow instances)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "main": "lib/src/app/init.js",
   "types": "lib/src/app/init.d.ts",
   "scripts": {
-    "browserify-preload": "browserify -o lib/src/renderer/_preload-main.js -x electron --insert-global-vars=__filename,__dirname lib/src/renderer/preload-main.js",
+    "browserify-preload": "browserify -o lib/src/renderer/_preload-main.js -x electron --insert-global-vars=__filename,__dirname lib/src/renderer/preload-main.js && npm run browserify-preload-component",
+    "browserify-preload-component": "browserify -o lib/src/renderer/_preload-component.js -x electron --insert-global-vars=__filename,__dirname lib/src/renderer/preload-component.js",
     "compile": "npm run lint && gulp build",
     "dev": "npm run prebuild && cross-env ELECTRON_DEV=true electron .",
     "demo-win": "npm run prebuild && cross-env ELECTRON_DEV=true electron . --url=file:///src/demo/index.html",
@@ -94,7 +95,7 @@
     "browserify": "16.2.3",
     "cross-env": "5.2.0",
     "del": "3.0.0",
-    "electron": "6.1.2",
+    "electron": "6.1.5",
     "electron-builder": "21.2.0",
     "electron-builder-squirrel-windows": "20.38.3",
     "electron-icon-maker": "0.0.4",

--- a/src/app/init.ts
+++ b/src/app/init.ts
@@ -10,6 +10,9 @@ import { appStats } from './stats';
 const userDataPathArg: string | null = getCommandLineArgs(process.argv, '--userDataPath=', false);
 const userDataPath = userDataPathArg && userDataPathArg.substring(userDataPathArg.indexOf('=') + 1);
 
+// force sandbox: true for all BrowserWindow instances.
+app.enableSandbox();
+
 // need to set this explicitly if using Squirrel
 // https://www.electron.build/configuration/configuration#Configuration-squirrelWindows
 app.setAppUserModelId('com.symphony.electron-desktop');

--- a/src/app/window-utils.ts
+++ b/src/app/window-utils.ts
@@ -117,7 +117,7 @@ export const createComponentWindow = (
         width: 300,
         ...opts,
         webPreferences: {
-            preload: path.join(__dirname, '../renderer/preload-component'),
+            preload: path.join(__dirname, '../renderer/_preload-component.js'),
             devTools: false,
         },
     };


### PR DESCRIPTION
## Description
Port changes from 3.8.x branch to master
[SDA-48](https://perzoinc.atlassian.net/browse/SDA-48)

## Solution Approach
- Port changes from 3.8.x branch to 6.0.0
- Enable full sandbox for all the `browseWindow`
- Upgrade electron version to `6.1.5`
