### PR TITLE
fix: Disable zoom of screen-picker

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -506,10 +506,16 @@ export class WindowHandler {
         }
 
         this.screenPickerWindow = createComponentWindow('screen-picker', opts);
+
         this.screenPickerWindow.webContents.once('did-finish-load', () => {
             if (!this.screenPickerWindow || !windowExists(this.screenPickerWindow)) {
                 return;
             }
+
+            this.screenPickerWindow.webContents.setZoomFactor(1);
+            this.screenPickerWindow.webContents.setVisualZoomLevelLimits(1, 1);
+            this.screenPickerWindow.webContents.setLayoutZoomLevelLimits(0, 0);
+
             this.screenPickerWindow.webContents.send('screen-picker-data', {sources, id});
             this.addWindow(opts.winKey, this.screenPickerWindow);
         });


### PR DESCRIPTION
## Description
User have zoom in the screen-picker so the buttons are not visible

https://perzoinc.atlassian.net/browse/sda-1608 RTC: Missing Cancel % Select Screen buttons when sharing screen (MacOS)

## Solution Approach
Disable zoom functionality for screen picker

