### PR TITLE
fix: Fix Ctrl +, plus shortcut visible in menu's

### DIFF
--- a/src/app/app-menu.ts
+++ b/src/app/app-menu.ts
@@ -36,14 +36,14 @@ const windowsAccelerator = Object.assign({
     cut: 'Ctrl+X',
     minimize: 'Ctrl+M',
     paste: 'Ctrl+V',
-    pasteandmatchstyle: 'Ctrl+Shift+V',
+    pasteAndMatchStyle: 'Ctrl+Shift+V',
     redo: 'Ctrl+Y',
-    resetzoom: 'Ctrl+0',
-    selectall: 'Ctrl+A',
+    resetZoom: 'Ctrl+0',
+    selectAll: 'Ctrl+A',
     togglefullscreen: 'F11',
     undo: 'Ctrl+Z',
-    zoomin: 'Ctrl+Shift+Plus',
-    zoomout: 'Ctrl+-',
+    zoomIn: 'Ctrl+Plus',
+    zoomOut: 'Ctrl+-',
 });
 
 let {

--- a/src/app/app-menu.ts
+++ b/src/app/app-menu.ts
@@ -42,7 +42,7 @@ const windowsAccelerator = Object.assign({
     selectAll: 'Ctrl+A',
     togglefullscreen: 'F11',
     undo: 'Ctrl+Z',
-    zoomIn: 'Ctrl+Plus',
+    zoomIn: 'Ctrl++',
     zoomOut: 'Ctrl+-',
 });
 


### PR DESCRIPTION
## Description

For windows I fixed
  - ZoomIn to "Ctrl +" (was Ctrl Shift +)
  - Short cuts in menu

https://perzoinc.atlassian.net/browse/sda-1102 Zoom: Resizing content/fonts with Command (+) fails (Mac only)
