### PR TITLE
fix: SDA-1284 (Add logic to close screen snippet tool)

### DIFF
--- a/src/app/screen-snippet-handler.ts
+++ b/src/app/screen-snippet-handler.ts
@@ -65,22 +65,16 @@ class ScreenSnippet {
         // only allow one screen capture at a time.
         if (this.child) {
             logger.info(`screen-snippet-handler: Child screen capture exists, killing it and keeping only 1 instance!`);
-            this.child.kill();
+            this.killChildProcess();
         }
         try {
             await this.execCmd(this.captureUtil, this.captureUtilArgs);
             const { message, data, type }: IScreenSnippet = await this.convertFileToData();
             logger.info(`screen-snippet-handler: Snippet captured! Sending data to SFE`);
             webContents.send('screen-snippet-data', { message, data, type });
-            if (this.shouldUpdateAlwaysOnTop) {
-                await updateAlwaysOnTop(true, false);
-                this.shouldUpdateAlwaysOnTop = false;
-            }
+            await this.verifyAndUpdateAlwaysOnTop();
         } catch (error) {
-            if (this.shouldUpdateAlwaysOnTop) {
-                await updateAlwaysOnTop(true, false);
-                this.shouldUpdateAlwaysOnTop = false;
-            }
+            await this.verifyAndUpdateAlwaysOnTop();
             logger.error(`screen-snippet-handler: screen capture failed with error: ${error}!`);
         }
     }
@@ -94,7 +88,9 @@ class ScreenSnippet {
 
         try {
             await this.execCmd(this.captureUtil, []);
+            await this.verifyAndUpdateAlwaysOnTop();
         } catch (error) {
+            await this.verifyAndUpdateAlwaysOnTop();
             logger.error(`screen-snippet-handler: screen capture cancel failed with error: ${error}!`);
         }
     }
@@ -172,6 +168,16 @@ class ScreenSnippet {
                     }
                 });
             }
+        }
+    }
+
+    /**
+     * Verify and updates always on top
+     */
+    private async verifyAndUpdateAlwaysOnTop(): Promise<void> {
+        if (this.shouldUpdateAlwaysOnTop) {
+            await updateAlwaysOnTop(true, false);
+            this.shouldUpdateAlwaysOnTop = false;
         }
     }
 }

--- a/src/app/screen-snippet-handler.ts
+++ b/src/app/screen-snippet-handler.ts
@@ -83,6 +83,9 @@ class ScreenSnippet {
      * Cancels a screen capture and closes the snippet window
      */
     public async cancelCapture() {
+        if (!isWindowsOS) {
+            return;
+        }
         logger.info(`screen-snippet-handler: Cancel screen capture!`);
         this.focusedWindow = BrowserWindow.getFocusedWindow();
 

--- a/src/renderer/ssf-api.ts
+++ b/src/renderer/ssf-api.ts
@@ -336,8 +336,6 @@ export class SSFApi {
 
     /**
      * Cancel a screen capture in progress
-     *
-     * @param screenSnippetCallback {function}
      */
     public closeScreenSnippet(): void {
         local.ipcRenderer.send(apiName.symphonyApi, {


### PR DESCRIPTION
## Description
Add logic to close screen snippet tool
[SDA-1284](https://perzoinc.atlassian.net/browse/SDA-1284)

## Solution Approach
- Add logic close the screen snippet tool from the client app
- optimize the codebase

#### Screencast
![Room](https://user-images.githubusercontent.com/13243259/72317039-07287700-36be-11ea-94db-3ce960c9d33c.gif)
![Wallpost](https://user-images.githubusercontent.com/13243259/72317040-07c10d80-36be-11ea-9243-bae4d6de9535.gif)


## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
SFE-Client-App | [16362](https://github.com/SymphonyOSF/SFE-Client-App/pull/16362)
