### PR TITLE
fix: SDA-1668: add entitlements for macOS catalina

### DIFF
--- a/entitlements.mac.plist
+++ b/entitlements.mac.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key><true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key><true/>
+  <key>com.apple.security.device.audio-input</key><true/>
+  <key>com.apple.security.device.camera</key><true/>
+  <key>com.apple.security.files.user-selected.read-write</key><true/>
+  <key>com.apple.security.network.client</key><true/>
+</dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
     ],
     "mac": {
       "category": "public.app-category.business",
-      "icon": "images/icon.icns"
+      "icon": "images/icon.icns",
+      "entitlements": "entitlements.mac.plist",
+      "entitlementsInherit": "entitlements.mac.plist"
     },
     "win": {
       "icon": "images/icon.ico",


### PR DESCRIPTION
## Description
macOS Catalina requires that we add entitlements to enable camera & microphone. This PR addresses that concern.
[SDA-1668](https://perzoinc.atlassian.net/browse/JIRA-ticket)

## Solution Approach
- Add entitlements file
- Include the entitlements files for build with electron-builder.

## Related PRs
N/A