### PR TITLE
fix: SDA-1673 Bumping version number for screen snippet tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "shell-path": "2.1.0"
   },
   "optionalDependencies": {
-    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#v1.0.1",
+    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#v1.0.5",
     "screen-share-indicator-frame": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#v1.0.0",
     "swift-search": "2.0.1"
   }


### PR DESCRIPTION
## Description
Screen snippet version is set to an old version
[SDA-1673](https://perzoinc.atlassian.net/browse/SDA-1673)

## Solution Approach
Bumping the version in package.json

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
other_pr_dev | [link]()
