### PR TITLE
fix: SDA-1704 (Make screen sharing indicator window closable)

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -752,7 +752,6 @@ export class WindowHandler {
                 titleBarStyle: 'customButtonsOnHover',
                 minimizable: false,
                 maximizable: false,
-                closable: false,
             }, {
                 devTools: false,
             }), ...{winKey: streamId},


### PR DESCRIPTION
## Description
Fix a regression caused by this commit 4484d44528a16816b1e435148c35faf7f8e10394
[SDA-1704](https://perzoinc.atlassian.net/browse/SDA-1704)

## Solution Approach
 - Remove the window `closable` property

#### Screencast
![2020-01-22 12 12 17](https://user-images.githubusercontent.com/13243259/72871662-7e3eba80-3d11-11ea-91cf-58bcf0c74cf1.gif)


## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
SymphonyElectron | [#798](https://github.com/symphonyoss/SymphonyElectron/pull/798)
