### PR TITLE
fix: SDA-1703: fix issue with opening deleted files in download manager

### DIFF
--- a/src/app/window-utils.ts
+++ b/src/app/window-utils.ts
@@ -358,7 +358,7 @@ export const downloadManagerAction = (type, filePath): void => {
     }
 
     if (type === 'open') {
-        const openResponse = electron.shell.openExternal(`file:///${filePath}`);
+        const openResponse = electron.shell.openItem(`${filePath}`);
         if (!openResponse && focusedWindow && !focusedWindow.isDestroyed()) {
             electron.dialog.showMessageBox(focusedWindow, {
                 message,


### PR DESCRIPTION
## Description
On SDA 6.x, when we try to open a deleted file in the download manager, there's no error message shown. This PR fixes that issue.
[SDA-1703](https://perzoinc.atlassian.net/browse/SDA-1703)

### Before

![SDA-1703-Before](https://user-images.githubusercontent.com/5968790/72901844-7c481c00-3d50-11ea-986c-b5ac05f6b649.gif)

### After

![SDA-1703-After](https://user-images.githubusercontent.com/5968790/72901861-82d69380-3d50-11ea-9022-cb9145bc1978.gif)

## Solution Approach
Change the electron api from `electron.shell.openExternal` to `electron.shell.openItem`

## Related PRs
N/A
