### PR TITLE
fix: SDA-1666 (Make screen sharing indicator window focusable)

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -743,7 +743,7 @@ export class WindowHandler {
                 show: false,
                 modal: true,
                 frame: false,
-                focusable: false,
+                focusable: true,
                 transparent: true,
                 autoHideMenuBar: true,
                 resizable: false,


### PR DESCRIPTION
## Description
Make screen sharing indicator window focusable to fix the focus issue
[SDA-1666](https://perzoinc.atlassian.net/browse/SDA-1666)

## Solution Approach
- Set `focusable` to true for screen sharing indicator window

#### Screencast
![2020-01-23 09 57 47](https://user-images.githubusercontent.com/13243259/72956813-2c586c00-3dc7-11ea-8681-5073cc7c528b.gif)
