### PR TITLE
fix: SDA-1708 Move screen-sharing indicator to the same screen as Symphony…

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -440,7 +440,7 @@ export class WindowHandler {
     /**
      * Move window to the same screen as main window
      */
-    public moveWindow(windowToMove: BrowserWindow) {
+    public moveWindow(windowToMove: BrowserWindow, fixedYPosition?: number) {
         if (this.mainWindow && windowExists(this.mainWindow)) {
             const display = electron.screen.getDisplayMatching(this.mainWindow.getBounds());
 
@@ -460,7 +460,14 @@ export class WindowHandler {
                 positionX = display.workArea.x;
             }
 
-            let positionY = Math.trunc(display.workArea.y + display.workArea.height / 2 - windowToMove.getBounds().height / 2);
+            let positionY;
+            if (fixedYPosition) {
+                positionY = Math.trunc(display.workArea.y + fixedYPosition);
+            } else {
+                // Center the window in y-axis
+                positionY = Math.trunc(display.workArea.y + display.workArea.height / 2 - windowToMove.getBounds().height / 2);
+            }
+
             if (positionY < display.workArea.y) {
                 positionY = display.workArea.y;
             }
@@ -785,6 +792,7 @@ export class WindowHandler {
         }
 
         this.screenSharingIndicatorWindow = createComponentWindow('screen-sharing-indicator', opts);
+        this.moveWindow(this.screenSharingIndicatorWindow, topPositionOfIndicatorScreen);
         this.screenSharingIndicatorWindow.setVisibleOnAllWorkspaces(true);
         this.screenSharingIndicatorWindow.webContents.once('did-finish-load', () => {
             if (!this.screenSharingIndicatorWindow || !windowExists(this.screenSharingIndicatorWindow)) {


### PR DESCRIPTION

https://perzoinc.atlassian.net/browse/sda-1708 CLONE - RTC -  Screen sharing indicator always shown on primary screen when sharing Application on second screen

Move screen-sharing indicator to the same screen as Symphony Application