### PR TITLE
fix: SDA-1395 (Disable context menu for action buttons)

### DIFF
--- a/spec/__snapshots__/windowsTitleBar.spec.ts.snap
+++ b/spec/__snapshots__/windowsTitleBar.spec.ts.snap
@@ -16,6 +16,7 @@ exports[`windows title bar should render correctly 1`] = `
     <button
       className="hamburger-menu-button"
       onClick={[Function]}
+      onContextMenu={[Function]}
       onMouseDown={[Function]}
       title="Menu"
     >
@@ -93,6 +94,7 @@ exports[`windows title bar should render correctly 1`] = `
     <button
       className="title-bar-button"
       onClick={[Function]}
+      onContextMenu={[Function]}
       onMouseDown={[Function]}
       title="Minimize"
     >
@@ -115,6 +117,7 @@ exports[`windows title bar should render correctly 1`] = `
     <button
       className="title-bar-button"
       onClick={[Function]}
+      onContextMenu={[Function]}
       onMouseDown={[Function]}
       title="Maximize"
     >
@@ -136,6 +139,7 @@ exports[`windows title bar should render correctly 1`] = `
     <button
       className="title-bar-button"
       onClick={[Function]}
+      onContextMenu={[Function]}
       onMouseDown={[Function]}
       title="Close"
     >

--- a/src/renderer/components/windows-title-bar.tsx
+++ b/src/renderer/components/windows-title-bar.tsx
@@ -20,6 +20,7 @@ export default class WindowsTitleBar extends React.Component<{}, IState> {
         onMinimize: () => this.minimize(),
         onShowMenu: () => this.showMenu(),
         onUnmaximize: () => this.unmaximize(),
+        onDisableContextMenu: (event) => this.disableContextMenu(event),
     };
     private observer: MutationObserver | undefined;
 
@@ -83,6 +84,7 @@ export default class WindowsTitleBar extends React.Component<{}, IState> {
                         title={i18n.t('Menu', TITLE_BAR_NAMESPACE)()}
                         className='hamburger-menu-button'
                         onClick={this.eventHandlers.onShowMenu}
+                        onContextMenu={this.eventHandlers.onDisableContextMenu}
                         onMouseDown={this.handleMouseDown}
                     >
                         <svg x='0px' y='0px' viewBox='0 0 15 10'>
@@ -101,6 +103,7 @@ export default class WindowsTitleBar extends React.Component<{}, IState> {
                         className='title-bar-button'
                         title={i18n.t('Minimize', TITLE_BAR_NAMESPACE)()}
                         onClick={this.eventHandlers.onMinimize}
+                        onContextMenu={this.eventHandlers.onDisableContextMenu}
                         onMouseDown={this.handleMouseDown}
                     >
                         <svg x='0px' y='0px' viewBox='0 0 14 1'>
@@ -116,6 +119,7 @@ export default class WindowsTitleBar extends React.Component<{}, IState> {
                         className='title-bar-button'
                         title={i18n.t('Close', TITLE_BAR_NAMESPACE)()}
                         onClick={this.eventHandlers.onClose}
+                        onContextMenu={this.eventHandlers.onDisableContextMenu}
                         onMouseDown={this.handleMouseDown}
                     >
                         <svg x='0px' y='0px' viewBox='0 0 14 10.2'>
@@ -143,6 +147,7 @@ export default class WindowsTitleBar extends React.Component<{}, IState> {
                     className='title-bar-button'
                     title={i18n.t('Restore', TITLE_BAR_NAMESPACE)()}
                     onClick={this.eventHandlers.onUnmaximize}
+                    onContextMenu={this.eventHandlers.onDisableContextMenu}
                     onMouseDown={this.handleMouseDown}
                 >
                     <svg x='0px' y='0px' viewBox='0 0 14 10.2'>
@@ -159,6 +164,7 @@ export default class WindowsTitleBar extends React.Component<{}, IState> {
                 className='title-bar-button'
                 title={i18n.t('Maximize', TITLE_BAR_NAMESPACE)()}
                 onClick={this.eventHandlers.onMaximize}
+                onContextMenu={this.eventHandlers.onDisableContextMenu}
                 onMouseDown={this.handleMouseDown}
             >
                 <svg x='0px' y='0px' viewBox='0 0 14 10.2'>
@@ -304,6 +310,16 @@ export default class WindowsTitleBar extends React.Component<{}, IState> {
                 </defs>
             </svg>
         );
+    }
+
+    /**
+     * Disables context menu for action buttons
+     *
+     * @param event
+     */
+    private disableContextMenu(event): boolean {
+        event.preventDefault();
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Description
Disable context menu for action buttons in the custom title bar
[SDA-1395](https://perzoinc.atlassian.net/browse/SDA-1395)

## Solution Approach
- Prevent default for context menu action on buttons
