### PR TITLE
fix: SDA-1743 Use display id to identify screen instead of display position

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
   },
   "optionalDependencies": {
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#v1.0.5",
-    "screen-share-indicator-frame": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#v1.0.0",
+    "screen-share-indicator-frame": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#v1.1.0",
     "swift-search": "2.0.1"
   }
 }

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -785,9 +785,7 @@ export class WindowHandler {
                 if (displayId === element.id.toString()) {
                     if (isWindowsOS) {
                         logger.info(`window-handler: element:`, element);
-                        const winX: string = element.bounds.x.toString();
-                        const winY: string = element.bounds.y.toString();
-                        this.execCmd(this.screenShareIndicatorFrameUtil, [ winX, winY ]);
+                        this.execCmd(this.screenShareIndicatorFrameUtil, [ displayId ]);
                     } else {
                         this.createScreenSharingFrameWindow('screen-sharing-frame',
                         element.workArea.width,


### PR DESCRIPTION
## Description
Use display id to identify screen instead of display position
[SDA-1743](https://perzoinc.atlassian.net/browse/SDA-1743)

## Solution Approach
Describe the approach you've taken to implement this change / resolve the issue

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
other_pr_dev | [link]()
