### PR TITLE
fix: SDA-1501 Using ellipsis for notification title overflow

### DIFF
--- a/src/renderer/styles/notification-comp.less
+++ b/src/renderer/styles/notification-comp.less
@@ -62,13 +62,18 @@ body {
 
 .title {
   font-family: sans-serif;
-  font-size: 14px;
   font-weight: 700;
-  color: var(--text-color);
+  width: 100%;
+  overflow-wrap: break-word;
+  font-size: 14px;
+  margin-top: 5px;
   overflow: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
+  cursor: default;
+  text-overflow: ellipsis;
+  color: var(--text-color);
 }
 
 .company {

--- a/src/renderer/styles/notification-comp.less
+++ b/src/renderer/styles/notification-comp.less
@@ -66,7 +66,6 @@ body {
   width: 100%;
   overflow-wrap: break-word;
   font-size: 14px;
-  margin-top: 5px;
   overflow: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 1;


### PR DESCRIPTION
## Description
Adding text-overflow: ellipsis was not enough, so copied all the styles from "message", which was already working

[SDA-1501](https://perzoinc.atlassian.net/browse/SDA-1501)

## Solution Approach
Describe the approach you've taken to implement this change / resolve the issue

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
other_pr_dev | [link]()
