### PR TITLE
fix: SDA-1778 - Load the complete pod url instead of hostname

### DIFF
--- a/src/app/window-utils.ts
+++ b/src/app/window-utils.ts
@@ -517,7 +517,7 @@ export const isSymphonyReachable = (window: ICustomBrowserWindow | null) => {
         fetch(podUrl, { method: 'GET' }).then((rsp) => {
             if (rsp.status === 200 && windowHandler.isOnline) {
                 logger.info(`window-utils: pod ${podUrl} is reachable, loading main window!`);
-                window.loadURL(podUrl);
+                window.loadURL(configUrl);
                 if (networkStatusCheckIntervalId) {
                     clearInterval(networkStatusCheckIntervalId);
                     networkStatusCheckIntervalId = null;


### PR DESCRIPTION
## Description
Load the complete pod URL instead of hostname
[SDA-1778](https://perzoinc.atlassian.net/browse/SDA-1778)

## Solution Approach
Load the complete config pod URL instead of just the hostname

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
SymphonyElectron | [link](https://github.com/symphonyoss/SymphonyElectron/pull/893)
