### PR TITLE
fix: SDA-1847: fix french translation for restart dialog message

### DIFF
--- a/src/locale/fr-FR.json
+++ b/src/locale/fr-FR.json
@@ -197,7 +197,7 @@
   "Updating Title bar style requires Symphony to relaunch.": "La mise à jour du style de la barre de titre nécessite le redémarrage de Symphony.",
   "View": "Visualiser",
   "Window": "Fenêtre",
-  "Would you like to restart and apply these new settings now?": "Would you like to restart and apply these new settings now?",
+  "Would you like to restart and apply these new settings now?": "Voulez-vous redémarrer et appliquer ce nouveau paramètre maintenant?",
   "Your administrator has disabled": "Votre administrateur a désactivé",
   "Zoom": "Zoom",
   "Zoom In": "Zoom Avant",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -196,7 +196,7 @@
   "Updating Title bar style requires Symphony to relaunch.": "La mise à jour du style de la barre de titre nécessite le redémarrage de Symphony.",
   "View": "Visualiser",
   "Window": "Fenêtre",
-  "Would you like to restart and apply these new settings now?": "Would you like to restart and apply these new settings now?",
+  "Would you like to restart and apply these new settings now?": "Voulez-vous redémarrer et appliquer ce nouveau paramètre maintenant?",
   "Your administrator has disabled": "Votre administrateur a désactivé",
   "Zoom": "Zoom",
   "Zoom In": "Zoom Avant",


### PR DESCRIPTION
# Description
Fix the restart dialog message for French translation.
[SDA-1847](https://perzoinc.atlassian.net/browse/SDA-1847)

## Solution Approach
Add translation to the French language files.

## Related PRs
https://github.com/symphonyoss/SymphonyElectron/pull/884
