### PR TITLE
fix: SDA-1847: fix French translations for GPU dialog

### DIFF
--- a/src/locale/fr-FR.json
+++ b/src/locale/fr-FR.json
@@ -31,7 +31,6 @@
   "Build expired": "Construit expiré",
   "Cancel": "Annuler",
   "Certificate Error": "Erreur de certificat",
-  "Changing GPU settings requires Symphony to relaunch.": "La modification des paramètres du GPU nécessite la relance de Symphony.",
   "Clear cache and Reload": "Vider le cache et rafraîchir Symphony",
   "Close": "Fermer",
   "ContextMenu": {
@@ -197,7 +196,7 @@
   "Updating Title bar style requires Symphony to relaunch.": "La mise à jour du style de la barre de titre nécessite le redémarrage de Symphony.",
   "View": "Visualiser",
   "Window": "Fenêtre",
-  "Would you like to restart and apply these new settings now?": "Would you like to restart and apply these new settings now?",
+  "Would you like to restart and apply these new settings now?": "Voulez-vous redémarrer et appliquer ce nouveau paramètre maintenant?",
   "Your administrator has disabled": "Votre administrateur a désactivé",
   "Zoom": "Zoom",
   "Zoom In": "Zoom Avant",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -196,7 +196,7 @@
   "Updating Title bar style requires Symphony to relaunch.": "La mise à jour du style de la barre de titre nécessite le redémarrage de Symphony.",
   "View": "Visualiser",
   "Window": "Fenêtre",
-  "Would you like to restart and apply these new settings now?": "Would you like to restart and apply these new settings now?",
+  "Would you like to restart and apply these new settings now?": "Voulez-vous redémarrer et appliquer ce nouveau paramètre maintenant?",
   "Your administrator has disabled": "Votre administrateur a désactivé",
   "Zoom": "Zoom",
   "Zoom In": "Zoom Avant",


### PR DESCRIPTION
Backport of #899 