### PR TITLE
fix: SDA-1857 for us keyboard we should also zoom in for command and =

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -1019,7 +1019,9 @@ export class WindowHandler {
         if (!focusedWindow || !windowExists(focusedWindow)) {
             return;
         }
-        focusedWindow.webContents.zoomLevel += 0.5;
+        // electron/lib/browser/api/menu-item-roles.js row 159
+        const zoomLevelConstantFromElectron = 0.5;
+        focusedWindow.webContents.zoomLevel += zoomLevelConstantFromElectron;
     }
 
     /**

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -964,6 +964,11 @@ export class WindowHandler {
     private registerGlobalShortcuts(): void {
         logger.info(`window-handler: registering global shortcuts!`);
         globalShortcut.register(isMac ? 'Cmd+Alt+I' : 'Ctrl+Shift+I', this.onRegisterDevtools);
+
+        if (isMac) {
+            globalShortcut.register('Cmd+=' , this.onZoomIn);
+        }
+
         globalShortcut.register('CmdOrCtrl+R', this.onReload);
 
         app.on('browser-window-focus', () => {
@@ -1004,6 +1009,17 @@ export class WindowHandler {
             return;
         }
         reloadWindow(focusedWindow as ICustomBrowserWindow);
+    }
+
+    /**
+     * Zoom in
+     */
+    private onZoomIn(): void {
+        const focusedWindow = BrowserWindow.getFocusedWindow();
+        if (!focusedWindow || !windowExists(focusedWindow)) {
+            return;
+        }
+        focusedWindow.webContents.zoomLevel += 0.5;
     }
 
     /**


### PR DESCRIPTION
https://perzoinc.atlassian.net/browse/sda-1857 Shortcuts: Zoom in hot keys not functional (Mac only)

Add so US keyboard can zoom in with "Command" and "="