### PR TITLE
fix: SDA-1866 (Filter out empty strings in cloud config)

### DIFF
--- a/src/app/config-handler.ts
+++ b/src/app/config-handler.ts
@@ -268,9 +268,9 @@ class Config {
         const { acpFeatureLevelEntitlements, podLevelEntitlements, pmpEntitlements } = this.cloudConfig as ICloudConfig;
 
         // Filter out some values
-        const filteredACP = filterOutSelectedValues(acpFeatureLevelEntitlements, [ true, 'NOT_SET' ]);
-        const filteredPod = filterOutSelectedValues(podLevelEntitlements, [ true, 'NOT_SET' ]);
-        const filteredPMP = filterOutSelectedValues(pmpEntitlements, [ true, 'NOT_SET' ]);
+        const filteredACP = filterOutSelectedValues(acpFeatureLevelEntitlements, [ true, 'NOT_SET', '' ]);
+        const filteredPod = filterOutSelectedValues(podLevelEntitlements, [ true, 'NOT_SET', '' ]);
+        const filteredPMP = filterOutSelectedValues(pmpEntitlements, [ true, 'NOT_SET', '' ]);
 
         // priority is PMP > ACP > SDA
         this.filteredCloudConfig = { ...filteredACP, ...filteredPod, ...filteredPMP };


### PR DESCRIPTION
## Description
Filter out empty strings in cloud-config 
[SDA-1866](https://perzoinc.atlassian.net/browse/SDA-1866)

## Solution Approach
- Filter out empty strings so the values will fall back to the user or global config files

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
SymphonyElectron | [master](https://github.com/symphonyoss/SymphonyElectron/pull/908)
