### PR TITLE
fix: SDA-1857 (Add accelerator for zoom in for MacOS)

### DIFF
--- a/src/app/app-menu.ts
+++ b/src/app/app-menu.ts
@@ -41,6 +41,10 @@ const windowsAccelerator = Object.assign({
     zoomOut: 'Ctrl+-',
 });
 
+const macAccelerator = Object.assign({
+    zoomIn: 'CommandOrControl+=',
+});
+
 let {
     minimizeOnClose,
     launchOnStartup,
@@ -490,8 +494,13 @@ export class AppMenu {
      */
     private assignRoleOrLabel({ role, label }: MenuItemConstructorOptions): MenuItemConstructorOptions {
         logger.info(`app-menu: assigning role & label respectively for ${role} & ${label}`);
-        if (isMac || isLinux) {
+        if (isLinux) {
             return label ? { role, label } : { role };
+        }
+
+        if (isMac) {
+            return label ? { role, label, accelerator: role ? macAccelerator[ role ] : '' }
+                : { role, accelerator: role ? macAccelerator[ role ] : '' };
         }
 
         if (isWindowsOS) {


### PR DESCRIPTION
## Description
Fix shortcut issue specific to macOS
[SDA-1857](https://perzoinc.atlassian.net/browse/SDA-1857)

## Solution Approach
- Manually assign the accelerator for `ZoomIn`

#### Screencast
![2020-03-12 18 57 11](https://user-images.githubusercontent.com/13243259/76528117-4db80900-6496-11ea-8502-d3268577de84.gif)

#### Open issue in Electorn
https://github.com/electron/electron/issues/15496

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
SymphonyElectron | [master](https://github.com/symphonyoss/SymphonyElectron/pull/913#issue-387255915)
