### PR TITLE
fix: SDA-1857 (Add accelerator for zoom in for MacOS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13158,8 +13158,8 @@
       }
     },
     "screen-share-indicator-frame": {
-      "version": "1.4.1",
-      "resolved": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#891c5846fcdb1e2788bebf062f0ddb1b44eec67d",
+      "version": "1.4.3",
+      "resolved": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#701e3dc3fd2fa49e8d9cba3acdb30481c0bc0edf",
       "optional": true,
       "requires": {
         "run-script-os": "1.0.7"

--- a/src/app/app-menu.ts
+++ b/src/app/app-menu.ts
@@ -41,6 +41,10 @@ const windowsAccelerator = Object.assign({
     zoomOut: 'Ctrl+-',
 });
 
+const macAccelerator = Object.assign({
+    zoomIn: 'CommandOrControl+=',
+});
+
 let {
     minimizeOnClose,
     launchOnStartup,
@@ -489,8 +493,13 @@ export class AppMenu {
      */
     private assignRoleOrLabel({ role, label }: MenuItemConstructorOptions): MenuItemConstructorOptions {
         logger.info(`app-menu: assigning role & label respectively for ${role} & ${label}`);
-        if (isMac || isLinux) {
+        if (isLinux) {
             return label ? { role, label } : { role };
+        }
+
+        if (isMac) {
+            return label ? { role, label, accelerator: role ? macAccelerator[ role ] : '' }
+                : { role, accelerator: role ? macAccelerator[ role ] : '' };
         }
 
         if (isWindowsOS) {


### PR DESCRIPTION
## Description
Fix shortcut issue specific to macOS
[SDA-1857](https://perzoinc.atlassian.net/browse/SDA-1857)

## Solution Approach
- Manually assign the accelerator for `ZoomIn`

#### Screencast
![2020-03-12 18 57 11](https://user-images.githubusercontent.com/13243259/76528117-4db80900-6496-11ea-8502-d3268577de84.gif)

#### Open issue in Electron
https://github.com/electron/electron/issues/15496

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
SymphonyElectron | [6.1.x](https://github.com/symphonyoss/SymphonyElectron/pull/913)
