### PR TITLE
fix: SDA-1859 & SDA-1857 (Add cloud config installer changes for MacOS & fix ZoomIn shortcut menu item)

### DIFF
--- a/installer/mac/postinstall.sh
+++ b/installer/mac/postinstall.sh
@@ -19,21 +19,13 @@ if [ "$pod_url" == "" ]; then
     pod_url="https://my.symphony.com"
 fi
 
-if [ "$minimize_on_close" == "" ]; then
-    minimize_on_close=true;
-fi
+if [ "$minimize_on_close" == "" ] || [ "$minimize_on_close" == 'true' ]; then minimize_on_close='ENABLED'; else minimize_on_close='DISABLED'; fi
 
-if [ "$launch_on_startup" == "" ]; then
-    launch_on_startup=true;
-fi
+if [ "$launch_on_startup" == "" ] || [ "$launch_on_startup" == 'true' ]; then launch_on_startup='ENABLED'; else launch_on_startup='DISABLED'; fi
 
-if [ "$always_on_top" == "" ]; then
-    always_on_top=false;
-fi
+if [ "$always_on_top" == "" ] || [ "$always_on_top" == 'false' ]; then always_on_top='DISABLED'; else always_on_top='ENABLED'; fi
 
-if [ "$bring_to_front" == "" ]; then
-    bring_to_front=false;
-fi
+if [ "$bring_to_front" == "" ] || [ "$bring_to_front" == 'false' ]; then bring_to_front='DISABLED'; else bring_to_front='ENABLED'; fi
 
 if [ "$dev_tools_enabled" == "" ]; then
     dev_tools_enabled=true;
@@ -43,10 +35,10 @@ pod_url_escaped=$(sed 's#[&/\]#\\&#g' <<<"$pod_url")
 
 ## Replace the default settings with the user selected settings ##
 sed -i "" -E "s#\"url\" ?: ?\".*\"#\"url\"\: \"$pod_url_escaped\"#g" ${newPath}
-sed -i "" -E "s#\"minimizeOnClose\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"minimizeOnClose\":\ $minimize_on_close#g" ${newPath}
-sed -i "" -E "s#\"alwaysOnTop\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"alwaysOnTop\":\ $always_on_top#g" ${newPath}
-sed -i "" -E "s#\"launchOnStartup\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"launchOnStartup\":\ $launch_on_startup#g" ${newPath}
-sed -i "" -E "s#\"bringToFront\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"bringToFront\":\ $bring_to_front#g" ${newPath}
+sed -i "" -E "s#\"minimizeOnClose\" ?: ?([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])#\"minimizeOnClose\":\ $minimize_on_close#g" ${newPath}
+sed -i "" -E "s#\"alwaysOnTop\" ?: ?([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])#\"alwaysOnTop\":\ $always_on_top#g" ${newPath}
+sed -i "" -E "s#\"launchOnStartup\" ?: ?([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])#\"launchOnStartup\":\ $launch_on_startup#g" ${newPath}
+sed -i "" -E "s#\"bringToFront\" ?: ?([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])#\"bringToFront\":\ $bring_to_front#g" ${newPath}
 sed -i "" -E "s#\"devToolsEnabled\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"devToolsEnabled\":\ $dev_tools_enabled#g" ${newPath}
 
 ## Remove the temp settings file created ##

--- a/installer/mac/postinstall.sh
+++ b/installer/mac/postinstall.sh
@@ -35,10 +35,10 @@ pod_url_escaped=$(sed 's#[&/\]#\\&#g' <<<"$pod_url")
 
 ## Replace the default settings with the user selected settings ##
 sed -i "" -E "s#\"url\" ?: ?\".*\"#\"url\"\: \"$pod_url_escaped\"#g" ${newPath}
-sed -i "" -E "s#\"minimizeOnClose\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"minimizeOnClose\":\ $minimize_on_close#g" ${newPath}
-sed -i "" -E "s#\"alwaysOnTop\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"alwaysOnTop\":\ $always_on_top#g" ${newPath}
-sed -i "" -E "s#\"launchOnStartup\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"launchOnStartup\":\ $launch_on_startup#g" ${newPath}
-sed -i "" -E "s#\"bringToFront\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"bringToFront\":\ $bring_to_front#g" ${newPath}
+sed -i "" -E "s#\"minimizeOnClose\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"minimizeOnClose\":\ \"$minimize_on_close\"#g" ${newPath}
+sed -i "" -E "s#\"alwaysOnTop\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"alwaysOnTop\":\ \"$always_on_top\"#g" ${newPath}
+sed -i "" -E "s#\"launchOnStartup\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"launchOnStartup\":\ \"$launch_on_startup\"#g" ${newPath}
+sed -i "" -E "s#\"bringToFront\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"bringToFront\":\ \"$bring_to_front\"#g" ${newPath}
 sed -i "" -E "s#\"devToolsEnabled\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"devToolsEnabled\":\ $dev_tools_enabled#g" ${newPath}
 
 ## Remove the temp settings file created ##

--- a/installer/mac/postinstall.sh
+++ b/installer/mac/postinstall.sh
@@ -35,10 +35,10 @@ pod_url_escaped=$(sed 's#[&/\]#\\&#g' <<<"$pod_url")
 
 ## Replace the default settings with the user selected settings ##
 sed -i "" -E "s#\"url\" ?: ?\".*\"#\"url\"\: \"$pod_url_escaped\"#g" ${newPath}
-sed -i "" -E "s#\"minimizeOnClose\" ?: ?([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])#\"minimizeOnClose\":\ $minimize_on_close#g" ${newPath}
-sed -i "" -E "s#\"alwaysOnTop\" ?: ?([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])#\"alwaysOnTop\":\ $always_on_top#g" ${newPath}
-sed -i "" -E "s#\"launchOnStartup\" ?: ?([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])#\"launchOnStartup\":\ $launch_on_startup#g" ${newPath}
-sed -i "" -E "s#\"bringToFront\" ?: ?([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])#\"bringToFront\":\ $bring_to_front#g" ${newPath}
+sed -i "" -E "s#\"minimizeOnClose\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"minimizeOnClose\":\ $minimize_on_close#g" ${newPath}
+sed -i "" -E "s#\"alwaysOnTop\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"alwaysOnTop\":\ $always_on_top#g" ${newPath}
+sed -i "" -E "s#\"launchOnStartup\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"launchOnStartup\":\ $launch_on_startup#g" ${newPath}
+sed -i "" -E "s#\"bringToFront\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"bringToFront\":\ $bring_to_front#g" ${newPath}
 sed -i "" -E "s#\"devToolsEnabled\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"devToolsEnabled\":\ $dev_tools_enabled#g" ${newPath}
 
 ## Remove the temp settings file created ##

--- a/src/app/app-menu.ts
+++ b/src/app/app-menu.ts
@@ -42,7 +42,7 @@ const windowsAccelerator = Object.assign({
 });
 
 const macAccelerator = Object.assign({
-    zoomIn: 'CommandOrControl+=',
+    zoomIn: 'CommandOrControl+Plus',
 });
 
 let {

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -1025,7 +1025,6 @@ export class WindowHandler {
      * https://github.com/electron/electron/issues/15496
      */
     private onZoomIn(): void {
-        logger.error(`came here`);
         const focusedWindow = BrowserWindow.getFocusedWindow();
         if (!focusedWindow || !windowExists(focusedWindow)) {
             return;

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -966,14 +966,27 @@ export class WindowHandler {
         globalShortcut.register(isMac ? 'Cmd+Alt+I' : 'Ctrl+Shift+I', this.onRegisterDevtools);
         globalShortcut.register('CmdOrCtrl+R', this.onReload);
 
+        if (isMac) {
+            globalShortcut.register('CmdOrCtrl+Plus', this.onZoomIn);
+            globalShortcut.register('CmdOrCtrl+=', this.onZoomIn);
+        }
+
         app.on('browser-window-focus', () => {
             globalShortcut.register(isMac ? 'Cmd+Alt+I' : 'Ctrl+Shift+I', this.onRegisterDevtools);
             globalShortcut.register('CmdOrCtrl+R', this.onReload);
+            if (isMac) {
+                globalShortcut.register('CmdOrCtrl+Plus', this.onZoomIn);
+                globalShortcut.register('CmdOrCtrl+=', this.onZoomIn);
+            }
         });
 
         app.on('browser-window-blur', () => {
             globalShortcut.unregister(isMac ? 'Cmd+Alt+I' : 'Ctrl+Shift+I');
             globalShortcut.unregister('CmdOrCtrl+R');
+            if (isMac) {
+                globalShortcut.unregister('CmdOrCtrl+Plus');
+                globalShortcut.unregister('CmdOrCtrl+=');
+            }
         });
     }
 
@@ -1004,6 +1017,22 @@ export class WindowHandler {
             return;
         }
         reloadWindow(focusedWindow as ICustomBrowserWindow);
+    }
+
+    /**
+     * This is a workarround untill we have a
+     * fix on the electron framework
+     * https://github.com/electron/electron/issues/15496
+     */
+    private onZoomIn(): void {
+        logger.error(`came here`);
+        const focusedWindow = BrowserWindow.getFocusedWindow();
+        if (!focusedWindow || !windowExists(focusedWindow)) {
+            return;
+        }
+        // electron/lib/browser/api/menu-item-roles.js row 159
+        const currentZoomLevel = focusedWindow.webContents.getZoomLevel();
+        focusedWindow.webContents.setZoomLevel(currentZoomLevel + 0.5);
     }
 
     /**


### PR DESCRIPTION
## Description
Add cloud-config installer changes for macOS & fix ZoomIn shortcut menu item
[SDA-1859](https://perzoinc.atlassian.net/browse/SDA-1859)
[SDA-1857](https://perzoinc.atlassian.net/browse/SDA-1857)

## Solution Approach
- Update macOS installer script to use `ENABLED/DISABLED` instead of boolean values
- Set the ZoomIn accelerator as ⌘+ and also register global shortcuts for both `⌘+ & ⌘=`

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
SymphonyElectron | [6.1.x](https://github.com/symphonyoss/SymphonyElectron/pull/918)
