### PR TITLE
fix: SDA-1880 & SDA-1882 (Fix background Throttling changes for cloud config)

### DIFF
--- a/config/Symphony.config
+++ b/config/Symphony.config
@@ -20,7 +20,7 @@
     "customFlags": {
         "authServerWhitelist": "",
         "authNegotiateDelegateWhitelist": "",
-        "disableThrottling": false
+        "disableThrottling": "DISABLED"
     },
     "permissions": {
         "media": true,

--- a/src/app/config-handler.ts
+++ b/src/app/config-handler.ts
@@ -94,7 +94,7 @@ export interface IPermission {
 export interface ICustomFlag {
     authServerWhitelist: string;
     authNegotiateDelegateWhitelist: string;
-    disableThrottling: boolean;
+    disableThrottling: CloudConfigDataTypes;
 }
 
 export interface INotificationSetting {
@@ -150,8 +150,9 @@ class Config {
      * @param fields
      */
     public getConfigFields(fields: string[]): IConfig {
-        logger.info(`config-handler: Trying to get cloud config values for the fields`, fields);
-        return { ...this.getGlobalConfigFields(fields), ...this.getUserConfigFields(fields), ...this.getFilteredCloudConfigFields(fields) } as IConfig;
+        const configFields = { ...this.getGlobalConfigFields(fields), ...this.getUserConfigFields(fields), ...this.getFilteredCloudConfigFields(fields) } as IConfig;
+        logger.info(`config-handler: getting combined config values for the fields ${fields}`, configFields);
+        return configFields;
     }
 
     /**
@@ -160,8 +161,9 @@ class Config {
      * @param fields {Array}
      */
     public getUserConfigFields(fields: string[]): IConfig {
-        logger.info(`config-handler: Trying to get user config values for the fields`, fields);
-        return pick(this.userConfig, fields) as IConfig;
+        const userConfigData = pick(this.userConfig, fields) as IConfig;
+        logger.info(`config-handler: getting user config values for the fields ${fields}`, userConfigData);
+        return userConfigData;
     }
 
     /**
@@ -170,8 +172,9 @@ class Config {
      * @param fields {Array}
      */
     public getGlobalConfigFields(fields: string[]): IGlobalConfig {
-        logger.info(`config-handler: Trying to get global config values for the fields`, fields);
-        return pick(this.globalConfig, fields) as IGlobalConfig;
+        const globalConfigData = pick(this.globalConfig, fields) as IGlobalConfig;
+        logger.info(`config-handler: getting global config values for the fields ${fields}`, globalConfigData);
+        return globalConfigData;
     }
 
     /**
@@ -180,7 +183,9 @@ class Config {
      * @param fields {Array}
      */
     public getFilteredCloudConfigFields(fields: string[]): IConfig | {} {
-        return pick(this.filteredCloudConfig, fields) as IConfig;
+        const filteredCloudConfigData = pick(this.filteredCloudConfig, fields) as IConfig;
+        logger.info(`config-handler: getting filtered cloud config values for the ${fields}`, filteredCloudConfigData);
+        return filteredCloudConfigData;
     }
 
     /**
@@ -190,7 +195,10 @@ class Config {
     public getCloudConfigFields(fields: string[]): IConfig {
         const { acpFeatureLevelEntitlements, podLevelEntitlements, pmpEntitlements } = this.cloudConfig as ICloudConfig;
         const cloudConfig = { ...acpFeatureLevelEntitlements, ...podLevelEntitlements, ...pmpEntitlements };
-        return pick(cloudConfig, fields) as IConfig;
+        logger.info(`config-handler: prioritized cloud config data`, cloudConfig);
+        const cloudConfigData = pick(cloudConfig, fields) as IConfig;
+        logger.info(`config-handler: getting prioritized cloud config values for the fields ${fields}`, cloudConfigData);
+        return cloudConfigData;
     }
 
     /**
@@ -223,7 +231,7 @@ class Config {
         logger.info(`config-handler: prioritized and filtered cloud config: `, this.filteredCloudConfig);
         try {
             await writeFile(this.cloudConfigPath, JSON.stringify(this.cloudConfig), { encoding: 'utf8' });
-            logger.info(`config-handler: writting cloud config values to file`);
+            logger.info(`config-handler: writing cloud config values to file`);
         } catch (error) {
             logger.error(`config-handler: failed to update cloud config file with ${data}`, error);
         }

--- a/src/app/perf-handler.ts
+++ b/src/app/perf-handler.ts
@@ -1,11 +1,12 @@
 import { powerSaveBlocker } from 'electron';
 import { logger } from '../common/logger';
-import { config, IConfig } from './config-handler';
+import { CloudConfigDataTypes, config, IConfig } from './config-handler';
 
 export const handlePerformanceSettings = () => {
     const { customFlags } = config.getCloudConfigFields([ 'customFlags' ]) as IConfig;
+    const { disableThrottling } = config.getCloudConfigFields([ 'disableThrottling' ]) as any;
 
-    if (customFlags && customFlags.disableThrottling) {
+    if ((customFlags && customFlags.disableThrottling === CloudConfigDataTypes.ENABLED) || disableThrottling === CloudConfigDataTypes.ENABLED) {
         logger.info(`perf-handler: Disabling power throttling!`);
         powerSaveBlocker.start('prevent-display-sleep');
         return;

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -96,12 +96,13 @@ export class WindowHandler {
         this.config = config.getConfigFields([ 'isCustomTitleBar', 'mainWinPos', 'minimizeOnClose', 'notificationSettings', 'alwaysOnTop', 'locale', 'customFlags' ]);
         logger.info(`window-handler: main windows initialized with following config data`, this.config);
         this.globalConfig = config.getGlobalConfigFields([ 'url', 'contextIsolation' ]);
+        const { disableThrottling } = config.getCloudConfigFields([ 'disableThrottling' ]) as any;
         const { url, contextIsolation }: IGlobalConfig = this.globalConfig;
         const { customFlags } = this.config;
 
         this.windows = {};
         this.contextIsolation = contextIsolation || false;
-        this.backgroundThrottling = !customFlags.disableThrottling;
+        this.backgroundThrottling = (customFlags.disableThrottling !== CloudConfigDataTypes.ENABLED || disableThrottling !== CloudConfigDataTypes.ENABLED);
         this.contextIsolation = contextIsolation || false;
         this.isCustomTitleBar = isWindowsOS && this.config.isCustomTitleBar === CloudConfigDataTypes.ENABLED;
         this.windowOpts = {


### PR DESCRIPTION
## Description
Enabling `disableThrottling` makes the main window go blank when creating a child windows
[SDA-1880](https://perzoinc.atlassian.net/browse/SDA-1880)
[SDA-1882](https://perzoinc.atlassian.net/browse/SDA-1882)

## Issue on Electron
https://github.com/electron/electron/issues/22551

## Solution Approach
 - Disable background Throttling only when the cloud-config is `disableThrottling` field is "ENABLED"
 - Fix log message to make the data and the fields clear
 - Add unit test cases for `disableThrottling`

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
SymphonyElectron | [master](https://github.com/symphonyoss/SymphonyElectron/pull/925)
