### PR TITLE
fix: SDA-1893: upgrade electron to 6.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "browserify": "16.2.3",
     "cross-env": "5.2.0",
     "del": "3.0.0",
-    "electron": "6.1.5",
+    "electron": "6.1.9",
     "electron-builder": "21.2.0",
     "electron-builder-squirrel-windows": "20.38.3",
     "electron-icon-maker": "0.0.4",


### PR DESCRIPTION
# Description
Upgrade electron to 6.1.9
[SDA-1893](https://perzoinc.atlassian.net/browse/SDA-1893)
