### PR TITLE
fix: SDA-1268 (Workaround to exit fullscreen when notification is clicked)[RTC]

### DIFF
--- a/src/renderer/notification.ts
+++ b/src/renderer/notification.ts
@@ -341,7 +341,7 @@ class Notification extends NotificationHandler {
             if (Object.prototype.hasOwnProperty.call(browserWindows, win)) {
                 const browserWin = browserWindows[ win ];
                 if (browserWin && windowExists(browserWin) && browserWin.winName === apiName.mainWindowName && browserWin.isFullScreen()) {
-                    browserWin.setFullScreen(false);
+                    browserWin.webContents.send('exit-html-fullscreen');
                     return;
                 }
             }

--- a/src/renderer/notification.ts
+++ b/src/renderer/notification.ts
@@ -1,4 +1,4 @@
-import { app, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain } from 'electron';
 
 import { config } from '../app/config-handler';
 import { createComponentWindow, windowExists } from '../app/window-utils';
@@ -243,6 +243,7 @@ class Notification extends NotificationHandler {
                 callback(NotificationActions.notificationClicked, data);
             }
             this.hideNotification(clientId);
+            this.exitFullScreen();
         }
     }
 
@@ -328,6 +329,23 @@ class Notification extends NotificationHandler {
                     browserWindow.moveTop();
                 }
             });
+    }
+
+    /**
+     * SDA-1268 - Workaround to exit window
+     * fullscreen state when notification is clicked
+     */
+    public exitFullScreen(): void {
+        const browserWindows: ICustomBrowserWindow[] = BrowserWindow.getAllWindows() as ICustomBrowserWindow[];
+        for (const win in browserWindows) {
+            if (Object.prototype.hasOwnProperty.call(browserWindows, win)) {
+                const browserWin = browserWindows[ win ];
+                if (browserWin && windowExists(browserWin) && browserWin.winName === apiName.mainWindowName && browserWin.isFullScreen()) {
+                    browserWin.setFullScreen(false);
+                    return;
+                }
+            }
+        }
     }
 
     /**

--- a/src/renderer/preload-main.ts
+++ b/src/renderer/preload-main.ts
@@ -140,3 +140,9 @@ ipcRenderer.on('show-banner', (_event, { show, bannerType, url }) => {
 ipcRenderer.on('initialize-memory-refresh', () => {
     monitorMemory(getRandomTime(minMemoryFetchInterval, maxMemoryFetchInterval));
 });
+
+ipcRenderer.on('exit-html-fullscreen', async () => {
+    if (document && typeof document.exitFullscreen === 'function') {
+        await document.exitFullscreen();
+    }
+});


### PR DESCRIPTION
## Description
Workaround to fix an issue with exiting fullscreen when in an active RTC session
[SDA-1268](https://perzoinc.atlassian.net/browse/SDA-1268)

## Solution Approach
- exit HTML fullscreen whenever the notifications are clicked

## Screencast
![2020-03-23 15 56 47](https://user-images.githubusercontent.com/13243259/77309634-03028080-6d23-11ea-8826-2553c26ca664.gif)

