### PR TITLE
fix: SDA-1877 (Fix blank pop-out issue in 8.x electron version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "start": "run-s compile browserify && cross-env ELECTRON_DEV=true electron .",
     "test": "run-s lint test:unit",
     "test:unit": "cross-env ELECTRON_QA=true jest --config jest-config.json --runInBand --detectOpenHandles",
-    "test:spectron": "npm run copy && run-s lint compile browserify && npx ava --verbose --serial",
+    "test:spectron": "npm run copy && run-s lint compile browserify && cross-env ELECTRON_QA=true npx ava --verbose --serial",
     "copy": "run-os",
     "copy:darwin": "ncp config 'node_modules/electron/dist/Electron.app/Contents/config'",
     "copy:win32": "ncp config node_modules\\electron\\dist\\config",

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -2,7 +2,7 @@ import { app } from 'electron';
 import * as electronDownloader from 'electron-dl';
 import * as shellPath from 'shell-path';
 
-import { isDevEnv, isLinux, isMac } from '../common/env';
+import { isDevEnv, isElectronQA, isLinux, isMac } from '../common/env';
 import { logger } from '../common/logger';
 import { getCommandLineArgs } from '../common/utils';
 import { cleanUpAppCache, createAppCacheFile } from './app-cache-handler';
@@ -51,7 +51,9 @@ setChromeFlags();
 
 // Need this to prevent blank pop-out from 8.x versions
 // Refer - SDA-1877 - https://github.com/electron/electron/issues/18397
-app.allowRendererProcessReuse = true;
+if (!isElectronQA) {
+    app.allowRendererProcessReuse = true;
+}
 
 // Electron sets the default protocol
 if (!isDevEnv) {

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -49,6 +49,10 @@ electronDownloader();
 handlePerformanceSettings();
 setChromeFlags();
 
+// Need this to prevent blank pop-out from 8.x versions
+// Refer - SDA-1877 - https://github.com/electron/electron/issues/18397
+app.allowRendererProcessReuse = true;
+
 // Electron sets the default protocol
 if (!isDevEnv) {
     app.setAsDefaultProtocolClient('symphony');


### PR DESCRIPTION
## Description
Fixes blank pop-out issue in 8.x versions of Electron
[SDA-1877](https://perzoinc.atlassian.net/browse/SDA-1877)

### Electron  - https://github.com/electron/electron/issues/18397

## Solution Approach
 - Set `allowRendererProcessReuse` to `true`. 
 - Starting from Electron version `9` this will default to `true`

