### PR TITLE
fix: SDA-1895 (Escape backslash characters for autoLaunchPath)

### DIFF
--- a/src/app/main-api-handler.ts
+++ b/src/app/main-api-handler.ts
@@ -171,6 +171,9 @@ ipcMain.on(apiName.symphonyApi, async (event: Electron.IpcMainEvent, arg: IApiAr
             break;
         case apiCmds.setCloudConfig:
             const { podLevelEntitlements, acpFeatureLevelEntitlements, pmpEntitlements, ...rest } = arg.cloudConfig as ICloudConfig;
+            if (podLevelEntitlements && podLevelEntitlements.autoLaunchPath && podLevelEntitlements.autoLaunchPath.match(/\\\\/g)) {
+                podLevelEntitlements.autoLaunchPath = podLevelEntitlements.autoLaunchPath.replace(/\\+/g, '\\');
+            }
             logger.info('main-api-handler: ignored other values from SFE', rest);
             await config.updateCloudConfig({ podLevelEntitlements, acpFeatureLevelEntitlements, pmpEntitlements });
             await updateFeaturesForCloudConfig();


### PR DESCRIPTION
## Description
Escape backslash characters for autoLaunchPath
[SDA-1895](https://perzoinc.atlassian.net/browse/SDA-1895)

## Solution Approach
 - Replace multiple escaped character with a single escape character

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
SymphonyElectron | [link](https://github.com/symphonyoss/SymphonyElectron/pull/945)
