### PR TITLE
fix: SDA-1922: upgrade electron-dl dependency to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6871,12 +6871,13 @@
       }
     },
     "electron-dl": {
-      "version": "1.14.0",
-      "resolved": "git+https://github.com/symphonyoss/electron-dl.git#a9ba9e785b1241b38c864bc74debeac08ee0409c",
+      "version": "3.0.0",
+      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/electron-dl/-/electron-dl-3.0.0.tgz",
+      "integrity": "sha1-QsXLVyr0TpCzqktwmhSr5wG7wxw=",
       "requires": {
         "ext-name": "^5.0.0",
-        "pupa": "^2.0.0",
-        "unused-filename": "^1.0.0"
+        "pupa": "^2.0.1",
+        "unused-filename": "^2.1.0"
       }
     },
     "electron-download": {
@@ -12824,9 +12825,9 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.42.0",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/mime-db/-/mime-db-1.42.0.tgz",
-      "integrity": "sha1-PiUpB7THrbkGWXtLZWNics+ee6w="
+      "version": "1.43.0",
+      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha1-ChLgUCZQ5HPXNVNQUOfI9OtPrlg="
     },
     "mime-types": {
       "version": "2.1.21",
@@ -13953,7 +13954,8 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -16176,8 +16178,8 @@
       }
     },
     "screen-share-indicator-frame": {
-      "version": "1.4.3",
-      "resolved": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#701e3dc3fd2fa49e8d9cba3acdb30481c0bc0edf",
+      "version": "1.4.4",
+      "resolved": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#e389ca1e037d174de4b5facb69e435c32c74db76",
       "optional": true,
       "requires": {
         "run-script-os": "1.0.7"
@@ -18076,12 +18078,19 @@
       "integrity": "sha1-HntCsUC8/ZIrIucMoSZb/jY0x8k="
     },
     "unused-filename": {
-      "version": "1.0.0",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/unused-filename/-/unused-filename-1.0.0.tgz",
-      "integrity": "sha1-00CID3GuIRXrqhMlvvBcxmhEacY=",
+      "version": "2.1.0",
+      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/unused-filename/-/unused-filename-2.1.0.tgz",
+      "integrity": "sha1-M3GcTo2WRPMtLewbyFJcaq60ulE=",
       "requires": {
         "modify-filename": "^1.1.0",
-        "path-exists": "^3.0.0"
+        "path-exists": "^4.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM="
+        }
       }
     },
     "upath": {

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "async.map": "0.5.2",
     "auto-launch": "5.0.5",
     "classnames": "2.2.6",
-    "electron-dl": "1.14.0",
+    "electron-dl": "3.0.0",
     "electron-fetch": "1.4.0",
     "electron-log": "4.0.7",
     "electron-spellchecker": "git+https://github.com/symphonyoss/electron-spellchecker.git#v2.3.0",


### PR DESCRIPTION
## Description
Fix medium security vulnerability from `electron-dl` dependency by upgrading it.
[SDA-1922](https://perzoinc.atlassian.net/browse/SDA-1922)

## Solution Approach
Upgrade dependency