### PR TITLE
chore: SDA-1942: skip setting expiry if value is 0

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,6 +53,12 @@ gulp.task('copy', function () {
 gulp.task('setExpiry', function (done) {
     // Set expiry of 15 days for test builds we create from CI
     const expiryDays = process.argv[4] || 15;
+    if (expiryDays < 1) {
+        console.log(`Not setting expiry as the value provided is ${expiryDays}`);
+        done();
+        return;
+    }
+
     console.log(`Setting expiry to ${expiryDays} days`);
     const milliseconds = 24*60*60*1000;
     const expiryTime = new Date().getTime() + (expiryDays * milliseconds);


### PR DESCRIPTION
## Description
Skip setting expiry if value is 0
[SDA-1942](https://perzoinc.atlassian.net/browse/JSDA-1942)

## Solution Approach
Add condition to check if expiry period supplied is lesser than 1 and skip setting expiry if that's the case.

## Related PRs
N/A