### PR TITLE
fix: SDA-1948: write snippet image to user data directory temp folder

### DIFF
--- a/src/app/screen-snippet-handler.ts
+++ b/src/app/screen-snippet-handler.ts
@@ -1,11 +1,12 @@
 import { app, BrowserWindow } from 'electron';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 
 import { ChildProcess, ExecException, execFile } from 'child_process';
 import * as util from 'util';
 import { IScreenSnippet } from '../common/api-interface';
-import { isDevEnv, isLinux, isMac, isWindowsOS } from '../common/env';
+import { isDevEnv, isElectronQA, isLinux, isMac, isWindowsOS } from '../common/env';
 import { i18n } from '../common/i18n';
 import { logger } from '../common/logger';
 import { updateAlwaysOnTop } from './window-actions';
@@ -24,9 +25,13 @@ class ScreenSnippet {
     private shouldUpdateAlwaysOnTop: boolean = false;
 
     constructor() {
-        this.tempDir = path.join(app.getPath('userData'), 'temp');
-        if (!fs.existsSync(this.tempDir)) {
-            fs.mkdirSync(this.tempDir);
+        if (isElectronQA) {
+            this.tempDir = os.tmpdir();
+        } else {
+            this.tempDir = path.join(app.getPath('userData'), 'temp');
+            if (!fs.existsSync(this.tempDir)) {
+                fs.mkdirSync(this.tempDir);
+            }
         }
         this.captureUtil = isMac ? '/usr/sbin/screencapture' : isDevEnv
             ? path.join(__dirname,

--- a/src/app/screen-snippet-handler.ts
+++ b/src/app/screen-snippet-handler.ts
@@ -1,6 +1,5 @@
 import { app, BrowserWindow } from 'electron';
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 
 import { ChildProcess, ExecException, execFile } from 'child_process';
@@ -25,7 +24,10 @@ class ScreenSnippet {
     private shouldUpdateAlwaysOnTop: boolean = false;
 
     constructor() {
-        this.tempDir = os.tmpdir();
+        this.tempDir = path.join(app.getPath('userData'), 'temp');
+        if (!fs.existsSync(this.tempDir)) {
+            fs.mkdirSync(this.tempDir);
+        }
         this.captureUtil = isMac ? '/usr/sbin/screencapture' : isDevEnv
             ? path.join(__dirname,
                 '../../../node_modules/screen-snippet/ScreenSnippet.exe')


### PR DESCRIPTION
## Description
Some customers have reported that ant-virus tools block snipping tool images saved in temp directory. So, we write it to user data directory in a temp folder inside that now.
[SDA-1948](https://perzoinc.atlassian.net/browse/SDA-1948)

## Solution Approach
We write snipping tool output image files to user data directory in a temp folder inside that now

## Related PRs
N/A