### PR TITLE
feat: SDA-1062: warn users before closing running app

### DIFF
--- a/installer/mac/preinstall.sh
+++ b/installer/mac/preinstall.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Kill the existing running instance
-sudo killall Symphony
-
 delete_app()
 {
     # Delete the installed version only if it is older than the installing version

--- a/installer/mac/symphony-mac-packager.pkgproj
+++ b/installer/mac/symphony-mac-packager.pkgproj
@@ -9,7 +9,7 @@
 			<array>
 				<dict>
 					<key>APPLICATION_ID</key>
-					<string>com.symphony.symphony-desktop</string>
+					<string>com.symphony.electron-desktop</string>
 					<key>STATE</key>
 					<true/>
 				</dict>


### PR DESCRIPTION
## Description
- On macOS, currently, when trying to install new version of SDA, we simply kill the app before asking user if they'd like to quit and proceed.
- This fixes the issue and provides a better user experience.
[SDA-1062](https://perzoinc.atlassian.net/browse/SDA-1062)

## Solution Approach
- Add `bundleIdentifier` as part of packages to check if `Symphony` is running.
- Remove the `killall Symphony` command from `preinstall` script.

## Related PRs
N/A
