### PR TITLE
feat: RTC-6968 - Adding a flag to enable getUserMedia patch in SFE-RTC

### DIFF
--- a/src/renderer/preload-main.ts
+++ b/src/renderer/preload-main.ts
@@ -76,6 +76,7 @@ if (ssfWindow.ssf) {
         registerRestartFloater: ssfWindow.ssf.registerRestartFloater,
         setCloudConfig: ssfWindow.ssf.setCloudConfig,
         checkMediaPermission: ssfWindow.ssf.checkMediaPermission,
+        capabilities: {bug19017: true}, // flag to enable RTC patch fixing electron bug https://github.com/electron/electron/issues/19017
     });
 }
 


### PR DESCRIPTION
## Description
SDA recently added an API to work around a bug in electron causing the promise from getUserMedia to resolve immediately, without correctly requesting permission. SFE-RTC patched the function, but needs a feature flag to be able to disable the patch once the bug has been fixed. 
[JIRA-ticket](https://perzoinc.atlassian.net/browse/RTC-6968)

## Solution Approach
This flag is checked by SFE-RTC to conditionally enable the patch when needed.

## Related PRs
List related PRs against other branches/repositories:

repo | PR
------ | ------
SFE-RTC | [link](https://github.com/SymphonyOSF/SFE-RTC/pull/2123)
