### PR TITLE
fix: SDA-2013: fix origin check for simplified installer

### DIFF
--- a/src/app/child-window-handler.ts
+++ b/src/app/child-window-handler.ts
@@ -159,7 +159,7 @@ export const handleChildWindow = (webContents: WebContents): void => {
             // Event needed to hide native menu bar
             childWebContents.once('did-start-loading', () => {
                 const browserWin = BrowserWindow.fromWebContents(childWebContents) as ICustomBrowserWindow;
-                browserWin.origin = config.getGlobalConfigFields([ 'url' ]).url;
+                browserWin.origin = windowHandler.url;
                 if (isWindowsOS && browserWin && !browserWin.isDestroyed()) {
                     browserWin.setMenuBarVisibility(false);
                 }

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -254,7 +254,7 @@ export class WindowHandler {
         // check for build expiry in case of test builds
         this.checkExpiry(this.mainWindow);
         // need this for postMessage origin
-        this.mainWindow.origin = this.globalConfig.url;
+        this.mainWindow.origin = this.url;
 
         // Event needed to hide native menu bar on Windows 10 as we use custom menu bar
         this.mainWindow.webContents.once('did-start-loading', () => {


### PR DESCRIPTION
## Description
After simplified installer was implemented, we were still reading the origin from global config, with this fix, we'll change that by reading the main window url (in cases where we pass the url as a command line argument)
[SDA-2013](https://perzoinc.atlassian.net/browse/SDA-2013)

## Solution Approach
Change origin to main window url

## Related PRs
N/A