### PR TITLE
fix: SDA-2016: fix title bar issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17746,8 +17746,8 @@
       }
     },
     "screen-share-indicator-frame": {
-      "version": "1.4.6",
-      "resolved": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#32472243f7c840c6f1310fde56b5498598eeb0a8",
+      "version": "1.4.7",
+      "resolved": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#91f72807c2e067abf39f5eab32e3fba3f3961a92",
       "optional": true,
       "requires": {
         "run-script-os": "1.0.7"

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -264,14 +264,6 @@ export class WindowHandler {
         if (this.shouldShowWelcomeScreen) {
             this.handleWelcomeScreen();
         }
-        // loads the main window with url from config/cmd line
-        await this.mainWindow.loadURL(this.url);
-        // check for build expiry in case of test builds
-        await this.checkExpiry(this.mainWindow);
-        // update version info from server
-        this.updateVersionInfo();
-        // need this for postMessage origin
-        this.mainWindow.origin = this.url;
 
         // Event needed to hide native menu bar on Windows 10 as we use custom menu bar
         this.mainWindow.webContents.once('did-start-loading', () => {
@@ -426,6 +418,16 @@ export class WindowHandler {
 
         // Handle pop-outs window
         handleChildWindow(this.mainWindow.webContents);
+
+        // loads the main window with url from config/cmd line
+        await this.mainWindow.loadURL(this.url);
+        // check for build expiry in case of test builds
+        await this.checkExpiry(this.mainWindow);
+        // update version info from server
+        this.updateVersionInfo();
+        // need this for postMessage origin
+        this.mainWindow.origin = this.url;
+
         return this.mainWindow;
     }
 

--- a/src/renderer/styles/welcome.less
+++ b/src/renderer/styles/welcome.less
@@ -4,6 +4,10 @@
 @version-text-color: rgb(47, 47, 47, 1);
 @text-padding: 10px;
 
+::-webkit-scrollbar {
+  display: none;
+}
+
 body {
   background-color: white;
   margin: 0;


### PR DESCRIPTION
## Description
Upon implementing welcome screen, displaying custom title bar broken on Windows because we were loading the url on the main window prior to handling events.

This PR fixes that issue.
[SDA-2016](https://perzoinc.atlassian.net/browse/SDA-2016)

## Solution Approach
- Move the main window load url to the end of the sequence after listening on events
- Also disable scrollbars on Windows for the welcome screen

## Related PRs
N/A