### PR TITLE
fix: screen share frame stay

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -507,14 +507,13 @@ export class WindowHandler {
 
                     if (browserWindow && windowExists(browserWindow)) {
                         browserWindow.destroy();
-
-                        if (isWindowsOS || isMac) {
-                            this.execCmd(this.screenShareIndicatorFrameUtil, []);
-                        } else {
-                            if (this.screenSharingFrameWindow && windowExists(this.screenSharingFrameWindow)) {
-                                this.screenSharingFrameWindow.close();
-                            }
-                        }
+                    }
+                }
+                if (isWindowsOS || isMac) {
+                    this.execCmd(this.screenShareIndicatorFrameUtil, []);
+                } else {
+                    if (this.screenSharingFrameWindow && windowExists(this.screenSharingFrameWindow)) {
+                        this.screenSharingFrameWindow.close();
                     }
                 }
                 break;

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -718,6 +718,12 @@ export class WindowHandler {
             this.addWindow(opts.winKey, this.screenPickerWindow);
         });
         ipcMain.once('screen-source-selected', (_event, source) => {
+            const displays = electron.screen.getAllDisplays();
+            logger.info('window-utils: displays.length: ' + displays.length);
+            for (let i = 0, len = displays.length; i < len; i++) {
+                logger.info('window-utils: display[' + i + ']: ' + JSON.stringify(displays[ i ]));
+            }
+
             if (source != null) {
                 logger.info(`window-handler: screen-source-selected`, source, id);
                 if (isWindowsOS || isMac) {

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -739,7 +739,13 @@ export class WindowHandler {
                         if (source.display_id !== '') {
                             this.execCmd(this.screenShareIndicatorFrameUtil, [ source.display_id ]);
                         } else {
-                            this.execCmd(this.screenShareIndicatorFrameUtil, [ '0' ]);
+                            const dispId = source.id.split(':')[1];
+                            const keyId = 'id';
+
+                            logger.info('window-utils: dispId: ' + dispId);
+                            logger.info('window-utils: displays [' + dispId + '] [id]: ' + displays [dispId] [ keyId ]);
+
+                            this.execCmd(this.screenShareIndicatorFrameUtil, [ displays [dispId] [ keyId ].toString() ]);
                         }
                     }
                 }


### PR DESCRIPTION
https://perzoinc.atlassian.net/browse/sda-2009 RTC: Screen sharing red border still showing after call ended

Before the fix this was the steps to reproduce

  - start meeting
  - share screen
  - right click and close screen sharing indicator
  - click leave meeting button

Red indicator frame stayed before