### PR TITLE
fix: SDA-2056: welcome screen on every install

### DIFF
--- a/installer/win/Symphony-x64.aip
+++ b/installer/win/Symphony-x64.aip
@@ -4,9 +4,9 @@
     <ROW Name="HiddenItems" Value="SccmComponent;ActSyncAppComponent;AppXAppDetailsComponent;AppXCapabilitiesComponent;AppXDependenciesComponent;AppXProductDetailsComponent;AppXVisualAssetsComponent;AppXAppDeclarationsComponent;AppXUriRulesComponent;FixupComponent"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiPropsComponent">
-    <ROW Property="AI_APP_ARGS" Value="/start-app=&quot;[#Symphony.pgx]&quot; --enable-media-stream"/>
     <ROW Property="AI_BITMAP_DISPLAY_MODE" Value="0"/>
     <ROW Property="AI_PRODUCTNAME_ARP" Value="[|ProductName]"/>
+    <ROW Property="AI_RUN_AS_ADMIN" Value="0"/>
     <ROW Property="AI_ThemeStyle" Value="default" MsiKey="AI_ThemeStyle"/>
     <ROW Property="AI_UNINSTALLER" Value="msiexec.exe"/>
     <ROW Property="ALLUSERS" Value="1" MultiBuildValue="DefaultBuild:2"/>
@@ -20,27 +20,21 @@
     <ROW Property="ARPURLINFOABOUT" Value="http://www.symphony.com"/>
     <ROW Property="AUTO_LAUNCH_PATH" Value="[|]"/>
     <ROW Property="AUTO_START" Value="ENABLED" Type="4"/>
-    <ROW Property="AUTO_START_CB" Value="true" Type="4"/>
     <ROW Property="AiSkipExitDlg" Value="1"/>
     <ROW Property="BRING_TO_FRONT" Value="DISABLED" Type="4"/>
     <ROW Property="BannerBitmap" Value="banner" MultiBuildValue="DefaultBuild:Banner.jpg" Type="1" MsiKey="BannerBitmap"/>
     <ROW Property="CTRLS" Value="2"/>
     <ROW Property="CUSTOM_TITLE_BAR" Value="ENABLED"/>
-    <ROW Property="CUSTOM_TITLE_BAR_CB" Value="true" Type="4"/>
-    <ROW Property="DEV_TOOLS_CB" Value="true" Type="4"/>
     <ROW Property="DEV_TOOLS_ENABLED" Value="true"/>
     <ROW Property="DialogBitmap" Value="dialog" MultiBuildValue="DefaultBuild:Tabloid.jpg" Type="1" MsiKey="DialogBitmap"/>
     <ROW Property="FULL_SCREEN" Value="true"/>
     <ROW Property="FULL_SCREEN_CB" Value="true"/>
     <ROW Property="FileInUseProcess" Value="Symphony.exe" Type="4"/>
     <ROW Property="LOCATION" Value="true"/>
-    <ROW Property="LOCATION_CB" Value="true" Type="4"/>
     <ROW Property="MEDIA" Value="true"/>
-    <ROW Property="MEDIA_CB" Value="true" Type="4"/>
     <ROW Property="MIDI_SYSEX" Value="true"/>
     <ROW Property="MIDI_SYSEX_CB" Value="true"/>
     <ROW Property="MINIMIZE_ON_CLOSE" Value="ENABLED" Type="4"/>
-    <ROW Property="MINIMIZE_ON_CLOSE_CB" Value="true" Type="4"/>
     <ROW Property="Manufacturer" Value="Symphony"/>
     <ROW Property="NOTIFICATIONS" Value="true"/>
     <ROW Property="OPEN_EXTERNAL" Value="true"/>
@@ -48,7 +42,7 @@
     <ROW Property="POD_URL" Value="https://my.symphony.com" Type="4"/>
     <ROW Property="POINTER_LOCK" Value="true"/>
     <ROW Property="POINTER_LOCK_CB" Value="true"/>
-    <ROW Property="ProductCode" Value="1033:{023C6F54-AAD9-4C55-BAE7-C81D26C1FCDA} " Type="16"/>
+    <ROW Property="ProductCode" Value="1033:{49DECF65-B0D7-4ACB-9B19-A53DEF3AF2CE} " Type="16"/>
     <ROW Property="ProductLanguage" Value="1033"/>
     <ROW Property="ProductName" Value="Symphony"/>
     <ROW Property="ProductVersion" Value="8.0.0" Type="32"/>
@@ -137,7 +131,7 @@
     <ROW Directory="win32x6476_Dir" Directory_Parent="bin_Dir" DefaultDir="WIN32-~1|win32-x64-76"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiCompsComponent">
-    <ROW Component="AI_CustomARPName" ComponentId="{3426F253-C6BB-4A10-9063-03E084A6F8CF}" Directory_="APPDIR" Attributes="4" KeyPath="DisplayName" Options="1"/>
+    <ROW Component="AI_CustomARPName" ComponentId="{83C68D22-B3BF-4F48-B0F1-7B1D9D07EF20}" Directory_="APPDIR" Attributes="4" KeyPath="DisplayName" Options="1"/>
     <ROW Component="AI_DisableModify" ComponentId="{DA4E8013-2F4B-493A-90A8-BD729DA7EE2C}" Directory_="APPDIR" Attributes="260" KeyPath="NoModify" Options="1"/>
     <ROW Component="Jobber.exe" ComponentId="{761861CF-BEB6-4808-9F56-E57E4D6D98A8}" Directory_="jobber_Dir" Attributes="0" KeyPath="Jobber.exe"/>
     <ROW Component="PodUrl" ComponentId="{EA80D82D-BC65-4075-A9A8-F53E2B2513CE}" Directory_="APPDIR" Attributes="260" KeyPath="PodUrl"/>
@@ -351,21 +345,6 @@
     <ROW Name="TxtUpdater.dll" SourcePath="&lt;AI_CUSTACTS&gt;TxtUpdater.dll"/>
     <ROW Name="aicustact.dll" SourcePath="&lt;AI_CUSTACTS&gt;aicustact.dll"/>
   </COMPONENT>
-  <COMPONENT cid="caphyon.advinst.msicomp.MsiCheckBoxComponent">
-    <ROW Property="MINIMIZE_ON_CLOSE_CB" Value="true"/>
-    <ROW Property="AUTO_START_CB" Value="true"/>
-    <ROW Property="ALWAYS_ON_TOP_CB" Value="true"/>
-    <ROW Property="BRING_TO_FRONT_CB" Value="true"/>
-    <ROW Property="MEDIA_CB" Value="true"/>
-    <ROW Property="LOCATION_CB" Value="true"/>
-    <ROW Property="MIDI_SYSEX_CB" Value="true"/>
-    <ROW Property="POINTER_LOCK_CB" Value="true"/>
-    <ROW Property="FULL_SCREEN_CB" Value="true"/>
-    <ROW Property="OPEN_EXTERNAL_CB" Value="true"/>
-    <ROW Property="CUSTOM_TITLE_BAR_CB" Value="true"/>
-    <ROW Property="DEV_TOOLS_CB" Value="true"/>
-    <ROW Property="SSO_CHECKBOX" Value="CheckBox"/>
-  </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiControlComponent">
     <ROW Dialog_="AdminBrowseDlg" Control="Logo" Type="Text" X="4" Y="228" Width="38" Height="12" Attributes="1" Text="Symphony" Order="300" TextLocId="Control.Text.AdminBrowseDlg#Logo" MsiKey="AdminBrowseDlg#Logo"/>
     <ROW Dialog_="AdminBrowseDlg" Control="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" Attributes="1048577" Text="[BannerBitmap]" Order="1200" MsiKey="AdminBrowseDlg#BannerBitmap"/>
@@ -374,33 +353,6 @@
     <ROW Dialog_="AdminInstallPointDlg" Control="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" Attributes="1048577" Text="[BannerBitmap]" Order="900" MsiKey="AdminInstallPointDlg#BannerBitmap"/>
     <ROW Dialog_="AdminWelcomeDlg" Control="Title" Type="Text" X="132" Y="10" Width="220" Height="47" Attributes="196611" Text="Welcome to the [ProductName] [Wizard]" TextStyle="VerdanaBold13" Order="500" TextLocId="Control.Text.AdminWelcomeDlg#Title" MsiKey="AdminWelcomeDlg#Title"/>
     <ROW Dialog_="AdminWelcomeDlg" Control="Description" Type="Text" X="132" Y="61" Width="220" Height="40" Attributes="196611" Text="The [Wizard] will create a server image of [ProductName], at a specified network location.  Click &quot;[Text_Next]&quot; to continue or &quot;Cancel&quot; to exit the [Wizard]." Order="600" TextLocId="Control.Text.AdminWelcomeDlg#Description" MsiKey="AdminWelcomeDlg#Description"/>
-    <ROW Dialog_="AdvanceSettings" Control="Next" Type="PushButton" X="304" Y="243" Width="56" Height="17" Attributes="3" Text="OK" Order="100" TextLocId="-" Options="1"/>
-    <ROW Dialog_="AdvanceSettings" Control="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Attributes="2" Text="[ButtonText_Cancel]" Order="200" TextLocId="-" Options="1"/>
-    <ROW Dialog_="AdvanceSettings" Control="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Attributes="2" Text="[ButtonText_Back]" Order="300" TextLocId="-" Options="1"/>
-    <ROW Dialog_="AdvanceSettings" Control="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" Attributes="1048577" Text="[BannerBitmap]" Order="400"/>
-    <ROW Dialog_="AdvanceSettings" Control="BannerLine" Type="Line" X="0" Y="44" Width="372" Height="0" Attributes="1" Order="500"/>
-    <ROW Dialog_="AdvanceSettings" Control="BottomLine" Type="Line" X="5" Y="234" Width="368" Height="0" Attributes="1" Order="600"/>
-    <ROW Dialog_="AdvanceSettings" Control="Description" Type="Text" X="15" Y="21" Width="280" Height="15" Attributes="196611" Text="Select permissions for your users." Order="700"/>
-    <ROW Dialog_="AdvanceSettings" Control="Logo" Type="Text" X="4" Y="228" Width="70" Height="12" Attributes="1" Text="Advance Settings" Order="800"/>
-    <ROW Dialog_="AdvanceSettings" Control="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Attributes="196611" Text="Advance Settings" TextStyle="[DlgTitleFont]" Order="900"/>
-    <ROW Dialog_="AdvanceSettings" Control="MediaCheckBox" Type="CheckBox" X="29" Y="90" Width="146" Height="13" Attributes="3" Property="MEDIA_CB" Text="Allow" Order="1000"/>
-    <ROW Dialog_="AdvanceSettings" Control="Text_1" Type="Text" X="30" Y="60" Width="75" Height="11" Attributes="65539" Property="TEXT_1_PROP_2" Text="Media" TextStyle="DlgFontBold8" Order="1100"/>
-    <ROW Dialog_="AdvanceSettings" Control="Text_2" Type="Text" X="30" Y="75" Width="161" Height="11" Attributes="65539" Property="TEXT_2_PROP_2" Text="Allow access to Camera, Audio, Microphone" Order="1200"/>
-    <ROW Dialog_="AdvanceSettings" Control="Text_5" Type="Text" X="30" Y="110" Width="75" Height="11" Attributes="65539" Property="TEXT_5_PROP" Text="Geo Location" TextStyle="DlgFontBold8" Order="1300"/>
-    <ROW Dialog_="AdvanceSettings" Control="LocationCheckBox" Type="CheckBox" X="29" Y="140" Width="98" Height="13" Attributes="3" Property="LOCATION_CB" Text="Allow" Order="1400"/>
-    <ROW Dialog_="AdvanceSettings" Control="Text_6" Type="Text" X="30" Y="125" Width="154" Height="11" Attributes="65539" Property="TEXT_6_PROP_2" Text="Allow access to user’s location" Order="1500"/>
-    <ROW Dialog_="AdvanceSettings" Control="Text_3" Type="Text" X="30" Y="165" Width="75" Height="11" Attributes="65539" Property="TEXT_3_PROP" Text="MIDI Sysex" TextStyle="DlgFontBold8" Order="1600"/>
-    <ROW Dialog_="AdvanceSettings" Control="Text_4" Type="Text" X="30" Y="180" Width="161" Height="14" Attributes="65539" Property="TEXT_4_PROP" Text="Allow access to external devices connected" Order="1700"/>
-    <ROW Dialog_="AdvanceSettings" Control="MidiSysexCheckBox" Type="CheckBox" X="30" Y="195" Width="98" Height="13" Attributes="3" Property="MIDI_SYSEX_CB" Text="Allow" Order="1800"/>
-    <ROW Dialog_="AdvanceSettings" Control="Text_7" Type="Text" X="212" Y="60" Width="75" Height="11" Attributes="65539" Property="TEXT_7_PROP_1" Text="Pointer Lock" TextStyle="DlgFontBold8" Order="1900"/>
-    <ROW Dialog_="AdvanceSettings" Control="Text_8" Type="Text" X="212" Y="75" Width="140" Height="11" Attributes="65539" Property="TEXT_8_PROP" Text="Allow locking a pointer" Order="2000"/>
-    <ROW Dialog_="AdvanceSettings" Control="OpinterLockCheckBox" Type="CheckBox" X="212" Y="90" Width="98" Height="13" Attributes="3" Property="POINTER_LOCK_CB" Text="Allow" Order="2100"/>
-    <ROW Dialog_="AdvanceSettings" Control="Text_9" Type="Text" X="212" Y="111" Width="75" Height="11" Attributes="65539" Property="TEXT_9_PROP" Text="Full Screen" TextStyle="DlgFontBold8" Order="2200"/>
-    <ROW Dialog_="AdvanceSettings" Control="Text_10" Type="Text" X="212" Y="125" Width="140" Height="11" Attributes="65539" Property="TEXT_10_PROP" Text="Allow [ProductName] to full screen" Order="2300"/>
-    <ROW Dialog_="AdvanceSettings" Control="FullScreenCheckBox" Type="CheckBox" X="212" Y="140" Width="98" Height="13" Attributes="3" Property="FULL_SCREEN_CB" Text="Allow" Order="2400"/>
-    <ROW Dialog_="AdvanceSettings" Control="Text_11" Type="Text" X="212" Y="165" Width="140" Height="11" Attributes="65539" Property="TEXT_11_PROP" Text="Open External App" TextStyle="DlgFontBold8" Order="2500"/>
-    <ROW Dialog_="AdvanceSettings" Control="Text_12" Type="Text" X="212" Y="180" Width="140" Height="11" Attributes="65539" Property="TEXT_12_PROP" Text="Allow opening an external app" Order="2600"/>
-    <ROW Dialog_="AdvanceSettings" Control="OpenExternalCheckBox" Type="CheckBox" X="212" Y="195" Width="98" Height="13" Attributes="3" Property="OPEN_EXTERNAL_CB" Text="Allow" Order="2700"/>
     <ROW Dialog_="BrowseDlg" Control="Logo" Type="Text" X="4" Y="228" Width="38" Height="12" Attributes="1" Text="Symphony" Order="300" TextLocId="Control.Text.BrowseDlg#Logo" MsiKey="BrowseDlg#Logo"/>
     <ROW Dialog_="BrowseDlg" Control="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" Attributes="1048577" Text="[BannerBitmap]" Order="1200" MsiKey="BrowseDlg#BannerBitmap"/>
     <ROW Dialog_="BrowseDlg" Control="Description" Type="Text" X="17" Y="21" Width="272" Height="14" Attributes="196611" Text="Browse to the destination folder" Order="1400" TextLocId="Control.Text.BrowseDlg#Description" MsiKey="BrowseDlg#Description"/>
@@ -445,15 +397,10 @@
     <ROW Dialog_="InstallationDlg" Control="Bitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="234" Attributes="1048577" Text="[DialogBitmap]" Order="300"/>
     <ROW Dialog_="InstallationDlg" Control="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Attributes="3" Text="[ButtonText_Back]" Order="400" TextLocId="-" Options="1"/>
     <ROW Dialog_="InstallationDlg" Control="BottomLine" Type="Line" X="0" Y="234" Width="372" Height="0" Attributes="1" Order="500"/>
-    <ROW Dialog_="InstallationDlg" Control="FolderEdit" Type="PathEdit" X="129" Y="106" Width="134" Height="18" Attributes="7" Property="APPDIR" Help="|" Order="600" HelpLocId="Control.Help.FolderDlg#FolderEdit"/>
-    <ROW Dialog_="InstallationDlg" Control="Browse" Type="PushButton" X="269" Y="106" Width="90" Height="18" Attributes="3" Text="[ButtonText_Browse]" Help="|" Order="700" TextLocId="-" HelpLocId="Control.Help.FolderDlg#Browse"/>
-    <ROW Dialog_="InstallationDlg" Control="Edit_POD_URL" Type="Edit" X="128" Y="157" Width="232" Height="18" Attributes="3" Property="POD_URL" Text="{260}" Help="Enter pod url in the format &quot;https://corporate.symphony.com&quot;|" Order="800"/>
-    <ROW Dialog_="InstallationDlg" Control="Text_2" Type="Text" X="129" Y="142" Width="131" Height="11" Attributes="65539" Text="[ProductName] Pod URL:" Order="900"/>
-    <ROW Dialog_="InstallationDlg" Control="Text_1" Type="Text" X="129" Y="52" Width="230" Height="23" Attributes="65539" Text="Click Install to install [ProductName] in the folder below. To install to a different folder, enter it below or click Browse." Order="1000"/>
-    <ROW Dialog_="InstallationDlg" Control="Text_3" Type="Text" X="129" Y="90" Width="75" Height="11" Attributes="65539" Text="&amp;Folder:" Order="1100"/>
-    <ROW Dialog_="InstallationDlg" Control="SsoCheckbox" Type="CheckBox" X="129" Y="186" Width="10" Height="12" Attributes="3" Property="SSO_CHECKBOX" Help="Only check this option if your Symphony POD has been configured for SSO, in doubt do not check - contact your Symphony Admin|" Order="1200"/>
-    <ROW Dialog_="InstallationDlg" Control="Text_4" Type="Text" X="142" Y="187" Width="50" Height="12" Attributes="65539" Property="TEXT_4_PROP_1" Text="Enable SSO" Order="1300"/>
-    <ROW Dialog_="InstallationDlg" Control="Text_5" Type="Text" X="129" Y="200" Width="230" Height="31" Attributes="65539" Property="TEXT_5_PROP_2" Text="Only check this option if your Symphony POD has been configured for SSO, in doubt do not check - contact your Symphony Admin" Order="1400"/>
+    <ROW Dialog_="InstallationDlg" Control="FolderEdit" Type="PathEdit" X="130" Y="131" Width="134" Height="18" Attributes="7" Property="APPDIR" Help="|" Order="600" HelpLocId="Control.Help.FolderDlg#FolderEdit"/>
+    <ROW Dialog_="InstallationDlg" Control="Browse" Type="PushButton" X="269" Y="131" Width="90" Height="18" Attributes="3" Text="[ButtonText_Browse]" Help="|" Order="700" TextLocId="-" HelpLocId="Control.Help.FolderDlg#Browse"/>
+    <ROW Dialog_="InstallationDlg" Control="Text_1" Type="Text" X="130" Y="77" Width="230" Height="23" Attributes="65539" Text="Click Install to install [ProductName] in the folder below. To install to a different folder, enter it below or click Browse." Order="800"/>
+    <ROW Dialog_="InstallationDlg" Control="Text_3" Type="Text" X="130" Y="115" Width="75" Height="11" Attributes="65539" Text="&amp;Folder:" Order="900"/>
     <ROW Dialog_="MaintenanceTypeDlg" Control="ChangeLabel" Type="Text" X="105" Y="65" Width="100" Height="10" Attributes="2" Text="&amp;Modify" TextStyle="[DlgTitleFont]" Order="100" TextLocId="Control.Text.MaintenanceTypeDlg#ChangeLabel" MsiKey="MaintenanceTypeDlg#ChangeLabel"/>
     <ROW Dialog_="MaintenanceTypeDlg" Control="ChangeButton" Type="PushButton" X="50" Y="65" Width="38" Height="38" Attributes="5767170" Text="[CustomSetupIcon]" Help="Modify Installation|" Order="200" HelpLocId="Control.Help.MaintenanceTypeDlg#ChangeButton" MsiKey="MaintenanceTypeDlg#ChangeButton"/>
     <ROW Dialog_="MaintenanceTypeDlg" Control="RepairLabel" Type="Text" X="105" Y="92" Width="100" Height="10" Attributes="3" Text="Re&amp;pair" TextStyle="[DlgTitleFont]" Order="300" TextLocId="Control.Text.MaintenanceTypeDlg#RepairLabel" MsiKey="MaintenanceTypeDlg#RepairLabel"/>
@@ -491,32 +438,6 @@
     <ROW Dialog_="ProgressDlg" Control="ProgressBar" Type="ProgressBar" X="35" Y="115" Width="300" Height="10" Attributes="65537" Text="Progress done" Order="1100" TextLocId="Control.Text.ProgressDlg#ProgressBar" MsiKey="ProgressDlg#ProgressBar"/>
     <ROW Dialog_="ResumeDlg" Control="Title" Type="Text" X="132" Y="10" Width="220" Height="47" Attributes="196611" Text="Resuming the [ProductName] [Wizard]" TextStyle="VerdanaBold13" Order="500" TextLocId="Control.Text.ResumeDlg#Title" MsiKey="ResumeDlg#Title"/>
     <ROW Dialog_="ResumeDlg" Control="Description" Type="Text" X="132" Y="61" Width="220" Height="40" Attributes="196611" Text="The [Wizard] will complete the installation of [ProductName] on your computer.  Click &quot;Install&quot; to continue or &quot;Cancel&quot; to exit the [Wizard]." Order="600" TextLocId="Control.Text.ResumeDlg#Description" MsiKey="ResumeDlg#Description"/>
-    <ROW Dialog_="SettingsDlg" Control="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Attributes="3" Text="[ButtonText_Next]" Order="100" TextLocId="-" Options="1"/>
-    <ROW Dialog_="SettingsDlg" Control="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Attributes="3" Text="[ButtonText_Cancel]" Order="200" TextLocId="-" Options="1"/>
-    <ROW Dialog_="SettingsDlg" Control="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Attributes="3" Text="[ButtonText_Back]" Order="300" TextLocId="-" Options="1"/>
-    <ROW Dialog_="SettingsDlg" Control="BottomLine" Type="Line" X="0" Y="234" Width="372" Height="0" Attributes="1" Order="400"/>
-    <ROW Dialog_="SettingsDlg" Control="MinimizeOnCloseCheckBox" Type="CheckBox" X="33" Y="155" Width="98" Height="13" Attributes="3" Property="MINIMIZE_ON_CLOSE_CB" Text="Enable" Order="500"/>
-    <ROW Dialog_="SettingsDlg" Control="LaunchOnStartupCheckBox" Type="CheckBox" X="185" Y="155" Width="98" Height="13" Attributes="3" Property="AUTO_START_CB" Text="Enable" Order="600"/>
-    <ROW Dialog_="SettingsDlg" Control="AlwaysOnTopCheckBox" Type="CheckBox" X="33" Y="101" Width="98" Height="13" Attributes="3" Property="ALWAYS_ON_TOP_CB" Text="Enable" Order="700"/>
-    <ROW Dialog_="SettingsDlg" Control="BringToFrontCheckBox" Type="CheckBox" X="185" Y="101" Width="98" Height="13" Attributes="3" Property="BRING_TO_FRONT_CB" Text="Enable" Order="800"/>
-    <ROW Dialog_="SettingsDlg" Control="Text_1" Type="Text" X="33" Y="62" Width="75" Height="11" Attributes="65539" Property="TEXT_1_PROP_4" Text="Always on Top" TextStyle="DlgFontBold8" Order="900"/>
-    <ROW Dialog_="SettingsDlg" Control="Text_2" Type="Text" X="33" Y="76" Width="135" Height="28" Attributes="65539" Property="TEXT_2_PROP_3" Text="Keeps [ProductName] on top of other applications" Order="1000"/>
-    <ROW Dialog_="SettingsDlg" Control="Text_3" Type="Text" X="33" Y="125" Width="117" Height="11" Attributes="65539" Property="TEXT_3_PROP_5" Text="Minimize on Close" TextStyle="DlgFontBold8" Order="1100"/>
-    <ROW Dialog_="SettingsDlg" Control="Text_4" Type="Text" X="33" Y="140" Width="147" Height="11" Attributes="65539" Property="TEXT_4_PROP_3" Text="Minimize [ProductName] when closed" Order="1200"/>
-    <ROW Dialog_="SettingsDlg" Control="Text_5" Type="Text" X="185" Y="140" Width="175" Height="11" Attributes="65539" Property="TEXT_5_PROP_1" Text="Launch [ProductName] when computer starts" Order="1300"/>
-    <ROW Dialog_="SettingsDlg" Control="Text_6" Type="Text" X="185" Y="125" Width="122" Height="11" Attributes="65539" Property="TEXT_6_PROP_3" Text="Launch on Startup" TextStyle="DlgFontBold8" Order="1400"/>
-    <ROW Dialog_="SettingsDlg" Control="Text_7" Type="Text" X="185" Y="76" Width="175" Height="28" Attributes="65539" Property="TEXT_7_PROP" Text="Flash icon in taskbar when a message is received" Order="1500"/>
-    <ROW Dialog_="SettingsDlg" Control="Text_8" Type="Text" X="185" Y="62" Width="152" Height="11" Attributes="65539" Property="TEXT_8_PROP_1" Text="Flash Notification in Taskbar" TextStyle="DlgFontBold8" Order="1600"/>
-    <ROW Dialog_="SettingsDlg" Control="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" Attributes="1048577" Text="[BannerBitmap]" Help="|" Order="1700" HelpLocId="Control.Help.FolderDlg#BannerBitmap"/>
-    <ROW Dialog_="SettingsDlg" Control="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Attributes="196611" Text="Basic Settings" TextStyle="[DlgTitleFont]" Order="1800" TextLocId="Control.Text.FolderDlg#Title"/>
-    <ROW Dialog_="SettingsDlg" Control="Description" Type="Text" X="17" Y="21" Width="272" Height="14" Attributes="196611" Text="Select features for your users." Order="1900" TextLocId="Control.Text.FolderDlg#Description"/>
-    <ROW Dialog_="SettingsDlg" Control="PushButton_1" Type="PushButton" X="33" Y="243" Width="92" Height="17" Attributes="3" Text="Advance Settings" Order="2000"/>
-    <ROW Dialog_="SettingsDlg" Control="CustomTitleBarCheckBox" Type="CheckBox" X="33" Y="211" Width="98" Height="13" Attributes="3" Property="CUSTOM_TITLE_BAR_CB" Text="Enable" Order="2100"/>
-    <ROW Dialog_="SettingsDlg" Control="Text_9" Type="Text" X="33" Y="181" Width="117" Height="11" Attributes="65539" Property="TEXT_3_PROP_5_1" Text="Enable Hamburger Menu" TextStyle="DlgFontBold8_DlgFontBold8" Order="2200"/>
-    <ROW Dialog_="SettingsDlg" Control="Text_10" Type="Text" X="33" Y="196" Width="147" Height="11" Attributes="65539" Property="TEXT_4_PROP_3_1" Text="Applies Hamburger style menu" Order="2300"/>
-    <ROW Dialog_="SettingsDlg" Control="DevToolsCheckBox" Type="CheckBox" X="185" Y="211" Width="98" Height="13" Attributes="3" Property="DEV_TOOLS_CB" Text="Enable" Order="2400"/>
-    <ROW Dialog_="SettingsDlg" Control="Text_11" Type="Text" X="185" Y="181" Width="117" Height="11" Attributes="65539" Property="TEXT_3_PROP_5_1_1" Text="Enable Dev Tools" TextStyle="DlgFontBold8_DlgFontBold8" Order="2500"/>
-    <ROW Dialog_="SettingsDlg" Control="Text_12" Type="Text" X="185" Y="196" Width="147" Height="11" Attributes="65539" Property="TEXT_4_PROP_3_1_1" Text="Enable dev tools for troubleshooting" Order="2600"/>
     <ROW Dialog_="UrlValidationDlg" Control="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Attributes="1" Text="[ButtonText_Next]" Order="100" TextLocId="-" Options="1"/>
     <ROW Dialog_="UrlValidationDlg" Control="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Attributes="2" Text="[ButtonText_Cancel]" Order="200" TextLocId="-" Options="1"/>
     <ROW Dialog_="UrlValidationDlg" Control="Bitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="234" Attributes="1048577" Text="[DialogBitmap]" Order="300"/>
@@ -537,8 +458,6 @@
     <ATTRIBUTE name="DeletedRows" value="ExitDialog#ViewReadmeText@InstallTypeDlg#BannerLine@InstallTypeDlg#Description@InstallTypeDlg#InstallTypeText@InstallTypeDlg#Logo@InstallTypeDlg#Title@ProgressDlg#Logo"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiControlConditionComponent">
-    <ROW Dialog_="InstallationDlg" Control_="Text_5" Action="Hide" Condition="NOT SSO_CHECKBOX"/>
-    <ROW Dialog_="InstallationDlg" Control_="Text_5" Action="Show" Condition="SSO_CHECKBOX"/>
     <ATTRIBUTE name="DeletedRows" value="ExitDialog#ViewReadmeText#Hide#((NOT AI_INSTALL) AND (NOT AI_PATCH)) OR ((CTRLS &lt;&gt; 1) AND (CTRLS &lt;&gt; 3))"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiControlEventComponent">
@@ -561,20 +480,13 @@
     <ROW Dialog_="VerifyReadyDlg" Control_="Back" Event="NewDialog" Argument="PatchWelcomeDlg" Condition="AI_PATCH" Ordering="203"/>
     <ROW Dialog_="InstallTypeDlg" Control_="Next" Event="EndDialog" Argument="Return" Condition="AI_INSTALL AND ( AI_PROCESS_STATE=&quot;Stopped&quot; )" Ordering="105"/>
     <ROW Dialog_="InstallationDlg" Control_="Cancel" Event="SpawnDialog" Argument="CancelDlg" Condition="1" Ordering="100"/>
-    <ROW Dialog_="SettingsDlg" Control_="PushButton_1" Event="SpawnDialog" Argument="AdvanceSettings" Condition="AI_INSTALL" Ordering="1"/>
+    <ROW Dialog_="InstallationDlg" Control_="Next" Event="EndDialog" Argument="Return" Condition="AI_INSTALL" Ordering="13"/>
     <ROW Dialog_="InstallationDlg" Control_="Browse" Event="[_BrowseProperty]" Argument="APPDIR" Condition="1" Ordering="100"/>
     <ROW Dialog_="InstallationDlg" Control_="Browse" Event="SpawnDialog" Argument="BrowseDlg" Condition="1" Ordering="200"/>
-    <ROW Dialog_="SettingsDlg" Control_="Cancel" Event="SpawnDialog" Argument="CancelDlg" Condition="1" Ordering="100"/>
-    <ROW Dialog_="AdvanceSettings" Control_="Cancel" Event="EndDialog" Argument="Return" Condition="1" Ordering="0"/>
-    <ROW Dialog_="AdvanceSettings" Control_="Next" Event="DoAction" Argument="PodUrlValidation" Condition="1" Ordering="0"/>
-    <ROW Dialog_="AdvanceSettings" Control_="Next" Event="EndDialog" Argument="Return" Condition="1" Ordering="1"/>
     <ROW Dialog_="InstallationDlg" Control_="Back" Event="SpawnDialog" Argument="InstallTypeDlg" Condition="AI_INSTALL" Ordering="1"/>
-    <ROW Dialog_="SettingsDlg" Control_="Back" Event="SpawnDialog" Argument="InstallationDlg" Condition="AI_INSTALL" Ordering="6"/>
+    <ROW Dialog_="InstallTypeDlg" Control_="Next" Event="NewDialog" Argument="InstallationDlg" Condition="AI_INSTALL AND ( AI_PROCESS_STATE=&quot;Stopped&quot; )" Ordering="104"/>
     <ROW Dialog_="InstallationDlg" Control_="Next" Event="SetTargetPath" Argument="APPDIR" Condition="AI_INSTALL" Ordering="3"/>
     <ROW Dialog_="UrlValidationDlg" Control_="Cancel" Event="SpawnDialog" Argument="CancelDlg" Condition="1" Ordering="100"/>
-    <ROW Dialog_="InstallationDlg" Control_="InstallationDlgDialogInitializer" Event="DoAction" Argument="PodUrlValidation" Condition="AI_INSTALL" Ordering="0"/>
-    <ROW Dialog_="InstallationDlg" Control_="Next" Event="SpawnDialog" Argument="UrlValidationDlg" Condition="AI_INSTALL AND ( INVALID_POD_URL = &quot;invalid&quot; )" Ordering="5"/>
-    <ROW Dialog_="InstallationDlg" Control_="Next" Event="DoAction" Argument="PodUrlValidation" Condition="AI_INSTALL" Ordering="4"/>
     <ROW Dialog_="UrlValidationDlg" Control_="Back" Event="EndDialog" Argument="Return" Condition="1" Ordering="0"/>
     <ROW Dialog_="InstallTypeDlg" Control_="Next" Event="DoAction" Argument="AI_AuthorSinglePackage" Condition="AI_INSTALL" Ordering="100" MsiKey="InstallTypeDlg#Next#DoAction#AI_AuthorSinglePackage#AI_INSTALL"/>
     <ROW Dialog_="InstallTypeDlg" Control_="TemplateDlgDialogInitializer" Event="[AI_InstallPerUser]" Argument="0" Condition="1 AND (ALLUSERS=&quot;1&quot;)" Ordering="100" MsiKey="InstallTypeDlg#TemplateDlgDialogInitializer#[AI_InstallPerUser]#0#1 AND (ALLUSERS=&quot;1&quot;)"/>
@@ -643,10 +555,6 @@
     <ROW Dialog_="VerifyRepairDlg" Control_="Repair" Event="ReinstallMode" Argument="ecmus" Condition="OutOfDiskSpace &lt;&gt; 1" Ordering="100" MsiKey="VerifyRepairDlg#Repair#ReinstallMode#ecmus#OutOfDiskSpace &lt;&gt; 1"/>
     <ROW Dialog_="FatalError" Control_="Finish" Event="DoAction" Argument="AI_AiBackupCleanup" Condition="1" Ordering="102"/>
     <ROW Dialog_="UserExit" Control_="Finish" Event="DoAction" Argument="AI_AiBackupCleanup" Condition="1" Ordering="101"/>
-    <ROW Dialog_="InstallationDlg" Control_="SsoCheckbox" Event="[POD_URL]" Argument="[POD_URL]/login/sso/initsso" Condition="AI_INSTALL AND ( SSO_CHECKBOX )" Ordering="0"/>
-    <ROW Dialog_="InstallationDlg" Control_="SsoCheckbox" Event="DoAction" Argument="SsoCheckbox" Condition="AI_INSTALL AND ( NOT SSO_CHECKBOX )" Ordering="1"/>
-    <ROW Dialog_="InstallationDlg" Control_="SsoCheckbox" Event="[AiRefreshDlg]" Argument="1" Condition="AI_INSTALL AND ( NOT SSO_CHECKBOX )" Ordering="2"/>
-    <ROW Dialog_="InstallationDlg" Control_="SsoCheckbox" Event="[AiRefreshDlg]" Argument="1" Condition="AI_INSTALL AND ( SSO_CHECKBOX )" Ordering="3"/>
     <ROW Dialog_="CloseSymphonyDialog" Control_="Cancel" Event="SpawnDialog" Argument="CancelDlg" Condition="1" Ordering="100"/>
     <ROW Dialog_="CloseSymphonyDialog" Control_="Back" Event="EndDialog" Argument="Return" Condition="1" Ordering="0"/>
     <ROW Dialog_="InstallTypeDlg" Control_="TemplateDlgDialogInitializer" Event="DoAction" Argument="DetectSymphony" Condition="AI_INSTALL" Ordering="102"/>
@@ -658,15 +566,16 @@
     <ROW Dialog_="CloseSymphonyDialog" Control_="Back" Event="DoAction" Argument="AI_DATA_SETTER_2" Condition="1" Ordering="1"/>
     <ROW Dialog_="InstallTypeDlg" Control_="Next" Event="DoAction" Argument="AI_DATA_SETTER_2" Condition="AI_INSTALL" Ordering="101"/>
     <ROW Dialog_="InstallTypeDlg" Control_="Next" Event="SpawnDialog" Argument="CloseSymphonyDialog" Condition="AI_INSTALL AND ( AI_PROCESS_STATE=&quot;Running&quot; )" Ordering="103"/>
-    <ROW Dialog_="InstallTypeDlg" Control_="Next" Event="SpawnDialog" Argument="OutOfRbDiskDlg" Condition="AI_INSTALL AND OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST=&quot;P&quot; OR NOT PROMPTROLLBACKCOST)" Ordering="106" Options="2"/>
-    <ROW Dialog_="InstallTypeDlg" Control_="Next" Event="EnableRollback" Argument="False" Condition="AI_INSTALL AND OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST=&quot;D&quot;" Ordering="107" Options="2"/>
-    <ROW Dialog_="InstallTypeDlg" Control_="Next" Event="SpawnDialog" Argument="OutOfDiskDlg" Condition="AI_INSTALL AND ( (OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST=&quot;F&quot;) )" Ordering="108" Options="2"/>
-    <ROW Dialog_="InstallTypeDlg" Control_="TemplateDlgDialogInitializer" Event="[AI_ButtonText_Next_Orig]" Argument="[ButtonText_Next]" Condition="AI_INSTALL" Ordering="103" Options="2"/>
-    <ROW Dialog_="InstallTypeDlg" Control_="TemplateDlgDialogInitializer" Event="[ButtonText_Next]" Argument="[[AI_CommitButton]]" Condition="AI_INSTALL" Ordering="104" Options="2"/>
-    <ROW Dialog_="InstallTypeDlg" Control_="TemplateDlgDialogInitializer" Event="[AI_Text_Next_Orig]" Argument="[Text_Next]" Condition="AI_INSTALL" Ordering="105" Options="2"/>
-    <ROW Dialog_="InstallTypeDlg" Control_="TemplateDlgDialogInitializer" Event="[Text_Next]" Argument="[Text_Install]" Condition="AI_INSTALL" Ordering="106" Options="2"/>
-    <ROW Dialog_="InstallTypeDlg" Control_="Back" Event="[ButtonText_Next]" Argument="[AI_ButtonText_Next_Orig]" Condition="AI_INSTALL" Ordering="0" Options="2"/>
-    <ROW Dialog_="InstallTypeDlg" Control_="Back" Event="[Text_Next]" Argument="[AI_Text_Next_Orig]" Condition="AI_INSTALL" Ordering="1" Options="2"/>
+    <ROW Dialog_="InstallationDlg" Control_="Next" Event="SpawnDialog" Argument="OutOfRbDiskDlg" Condition="AI_INSTALL AND OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST=&quot;P&quot; OR NOT PROMPTROLLBACKCOST)" Ordering="14" Options="2"/>
+    <ROW Dialog_="InstallationDlg" Control_="Next" Event="EnableRollback" Argument="False" Condition="AI_INSTALL AND OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST=&quot;D&quot;" Ordering="15" Options="2"/>
+    <ROW Dialog_="InstallationDlg" Control_="Next" Event="SpawnDialog" Argument="OutOfDiskDlg" Condition="AI_INSTALL AND ( (OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST=&quot;F&quot;) )" Ordering="16" Options="2"/>
+    <ROW Dialog_="InstallationDlg" Control_="InstallationDlgDialogInitializer" Event="[AI_ButtonText_Next_Orig]" Argument="[ButtonText_Next]" Condition="AI_INSTALL" Ordering="1" Options="2"/>
+    <ROW Dialog_="InstallationDlg" Control_="InstallationDlgDialogInitializer" Event="[ButtonText_Next]" Argument="[[AI_CommitButton]]" Condition="AI_INSTALL" Ordering="2" Options="2"/>
+    <ROW Dialog_="InstallationDlg" Control_="InstallationDlgDialogInitializer" Event="[AI_Text_Next_Orig]" Argument="[Text_Next]" Condition="AI_INSTALL" Ordering="3" Options="2"/>
+    <ROW Dialog_="InstallationDlg" Control_="InstallationDlgDialogInitializer" Event="[Text_Next]" Argument="[Text_Install]" Condition="AI_INSTALL" Ordering="4" Options="2"/>
+    <ROW Dialog_="InstallationDlg" Control_="Back" Event="[ButtonText_Next]" Argument="[AI_ButtonText_Next_Orig]" Condition="AI_INSTALL" Ordering="2" Options="2"/>
+    <ROW Dialog_="InstallationDlg" Control_="Back" Event="[Text_Next]" Argument="[AI_Text_Next_Orig]" Condition="AI_INSTALL" Ordering="3" Options="2"/>
+    <ROW Dialog_="InstallationDlg" Control_="Next" Event="DoAction" Argument="SetDefaults" Condition="AI_INSTALL" Ordering="12"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiCreateFolderComponent">
     <ROW Directory_="Symphony_Dir" Component_="Symphony" ManualDelete="false"/>
@@ -679,7 +588,6 @@
     <ROW Action="AI_AiRestoreDeferredImpersonate" Type="9217" Source="ResourceCleaner.dll" Target="OnAiRestoreDeferredImpersonate"/>
     <ROW Action="AI_AiRestoreRollback" Type="11521" Source="ResourceCleaner.dll" Target="OnAiRestoreRollback" WithoutSeq="true"/>
     <ROW Action="AI_AuthorSinglePackage" Type="1" Source="aicustact.dll" Target="AI_AuthorSinglePackage" WithoutSeq="true"/>
-    <ROW Action="AI_DATA_SETTER" Type="51" Source="CustomActionData" Target="Symphony.exe"/>
     <ROW Action="AI_DATA_SETTER_1" Type="51" Source="CustomActionData" Target="AEkAcwA2ADQAQgBpAHQAAgABAFAAYQByAGEAbQBzAAIAAQBTAGMAcgBpAHAAdAACACMAIABCAGwAbwBjAGsAIABmAG8AcgAgAGQAZQBjAGwAYQByAGkAbgBnACAAdABoAGUAIABzAGMAcgBpAHAAdAAgAHAAYQByAGEAbQBlAHQAZQByAHMALgANAAoAUABhAHIAYQBtACgAKQANAAoADQAKACMAIABZAG8AdQByACAAYwBvAGQAZQAgAGcAbwBlAHMAIABoAGUAcgBlAC4ADQAKAFIAZQBtAG8AdgBlAC0ASQB0AGUAbQBQAHIAbwBwAGUAcgB0AHkAIAAtAFAAYQB0AGgAIAAiAEgASwBDAFUAOgBTAG8AZgB0AHcAYQByAGUAXABNAGkAYwByAG8AcwBvAGYAdABcAFcAaQBuAGQAbwB3AHMAXABDAHUAcgByAGUAbgB0AFYAZQByAHMAaQBvAG4AXABSAHUAbgAiACAALQBOAGEAbQBlACAAIgBTAHkAbQBwAGgAbwBuAHkAIgAgAC0ARQByAHIAbwByAEEAYwB0AGkAbwBuACAAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQANAAoAUgBlAG0AbwB2AGUALQBJAHQAZQBtAFAAcgBvAHAAZQByAHQAeQAgAC0AUABhAHQAaAAgACIASABLAEMAVQA6AFMAbwBmAHQAdwBhAHIAZQBcAE0AaQBjAHIAbwBzAG8AZgB0AFwAVwBpAG4AZABvAHcAcwBcAEMAdQByAHIAZQBuAHQAVgBlAHIAcwBpAG8AbgBcAFIAdQBuACIAIAAtAE4AYQBtAGUAIAAiAGMAbwBtAC4AcwB5AG0AcABoAG8AbgB5AC4AZQBsAGUAYwB0AHIAbwBuAC0AZABlAHMAawB0AG8AcAAiACAALQBFAHIAcgBvAHIAQQBjAHQAaQBvAG4AIABTAGkAbABlAG4AdABsAHkAQwBvAG4AdABpAG4AdQBlAA0ACgBSAGUAbQBvAHYAZQAtAEkAdABlAG0AUAByAG8AcABlAHIAdAB5ACAALQBQAGEAdABoACAAIgBIAEsAQwBVADoAUwBvAGYAdAB3AGEAcgBlAFwATQBpAGMAcgBvAHMAbwBmAHQAXABXAGkAbgBkAG8AdwBzAFwAQwB1AHIAcgBlAG4AdABWAGUAcgBzAGkAbwBuAFwAUgB1AG4AIgAgAC0ATgBhAG0AZQAgACIAZQBsAGUAYwB0AHIAbwBuAC4AYQBwAHAALgBTAHkAbQBwAGgAbwBuAHkAIgAgAC0ARQByAHIAbwByAEEAYwB0AGkAbwBuACAAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQANAAoAUgBlAG0AbwB2AGUALQBJAHQAZQBtACAAIgBIAEsAQwBVADoAUwBvAGYAdAB3AGEAcgBlAFwAQwBsAGEAcwBzAGUAcwBcAHMAeQBtAHAAaABvAG4AeQAiACAALQBSAGUAYwB1AHIAcwBlACAALQBFAHIAcgBvAHIAQQBjAHQAaQBvAG4AIABTAGkAbABlAG4AdABsAHkAQwBvAG4AdABpAG4AdQBlAA0ACgANAAoAUgBlAG0AbwB2AGUALQBJAHQAZQBtACAAIgBIAEsATABNADoAUwBPAEYAVABXAEEAUgBFAFwAQwBsAGEAcwBzAGUAcwBcAHMAeQBtAHAAaABvAG4AeQAiACAALQBSAGUAYwB1AHIAcwBlACAALQBFAHIAcgBvAHIAQQBjAHQAaQBvAG4AIABTAGkAbABlAG4AdABsAHkAQwBvAG4AdABpAG4AdQBlAA0ACgANAAoATgBlAHcALQBQAFMARAByAGkAdgBlACAALQBOAGEAbQBlACAASABLAEMAUgAgAC0AUABTAFAAcgBvAHYAaQBkAGUAcgAgAFIAZQBnAGkAcwB0AHIAeQAgAC0AUgBvAG8AdAAgAEgASwBFAFkAXwBDAEwAQQBTAFMARQBTAF8AUgBPAE8AVAAgAC0ARQByAHIAbwByAEEAYwB0AGkAbwBuACAAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQANAAoAUgBlAG0AbwB2AGUALQBpAHQAZQBtACAAIgBIAEsAQwBSADoAXABzAHkAbQBwAGgAbwBuAHkAIgAgAC0AUgBlAGMAdQByAHMAZQAgAC0ARQByAHIAbwByAEEAYwB0AGkAbwBuACAAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQANAAoADQAKAE4AZQB3AC0AUABTAEQAcgBpAHYAZQAgAC0ATgBhAG0AZQAgAEgASwBVACAALQBQAFMAUAByAG8AdgBpAGQAZQByACAAUgBlAGcAaQBzAHQAcgB5ACAALQBSAG8AbwB0ACAASABLAEUAWQBfAFUAUwBFAFIAUwAgAC0ARQByAHIAbwByAEEAYwB0AGkAbwBuACAAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQANAAoAUgBlAG0AbwB2AGUALQBJAHQAZQBtAFAAcgBvAHAAZQByAHQAeQAgAC0AUABhAHQAaAAgACIASABLAFUAOgAuAEQARQBGAEEAVQBMAFQAXABTAG8AZgB0AHcAYQByAGUAXABNAGkAYwByAG8AcwBvAGYAdABcAFcAaQBuAGQAbwB3AHMAXABDAHUAcgByAGUAbgB0AFYAZQByAHMAaQBvAG4AXABSAHUAbgAiACAALQBOAGEAbQBlACAAIgBTAHkAbQBwAGgAbwBuAHkAIgAgAC0ARQByAHIAbwByAEEAYwB0AGkAbwBuACAAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQ=="/>
     <ROW Action="AI_DATA_SETTER_2" Type="51" Source="CustomActionData" Target="Symphony.exe"/>
     <ROW Action="AI_DATA_SETTER_4" Type="51" Source="CustomActionData" Target="Symphony.exe"/>
@@ -700,21 +608,17 @@
     <ROW Action="AI_TxtUpdaterInstall" Type="1" Source="TxtUpdater.dll" Target="OnTxtUpdaterInstall"/>
     <ROW Action="AI_TxtUpdaterRollback" Type="11521" Source="TxtUpdater.dll" Target="OnTxtUpdaterRollback" WithoutSeq="true"/>
     <ROW Action="DetectSymphony" Type="65" Source="aicustact.dll" Target="DetectProcess" WithoutSeq="true" Options="3" AdditionalSeq="AI_DATA_SETTER_2"/>
-    <ROW Action="KillRenderer" Type="65" Source="aicustact.dll" Target="StopProcess" Options="1" AdditionalSeq="AI_DATA_SETTER"/>
-    <ROW Action="PodUrlValidation" Type="101" Target="Script Text" TargetUnformatted="var prefix1 = &quot;https://&quot;;&#13;&#10;var prefix2 = &quot;http://&quot;;&#13;&#10;&#13;&#10;Session.Property(&quot;POD_URL&quot;) = Session.Property(&quot;POD_URL&quot;).replace(/^\s\s*/, &apos;&apos;).replace(/\s\s*$/, &apos;&apos;);&#13;&#10;&#13;&#10;if (!Session.Property(&quot;POD_URL&quot;) || Session.Property(&quot;POD_URL&quot;) === &quot;&quot; || Session.Property(&quot;POD_URL&quot;) === &quot;https://[POD].symphony.com&quot;) {&#13;&#10;&#9;Session.Property(&quot;INVALID_POD_URL&quot;) = &quot;invalid&quot;;&#13;&#10;} else if (Session.Property(&quot;POD_URL&quot;).substr(0, prefix1.length) !== prefix1 &amp;&amp; Session.Property(&quot;POD_URL&quot;).substr(0, prefix2.length) !== prefix2) {&#13;&#10;&#9;Session.Property(&quot;POD_URL&quot;) = prefix1 + Session.Property(&quot;POD_URL&quot;);&#13;&#10;}&#13;&#10;&#13;&#10;var podUrlRE = /^(https:\/\/)(www.)?[a-zA-Z0-9]+([\-\.]{1}[a-zA-Z0-9]+)*\.[a-zA-Z]{2,}(:[0-9]{1,5})?(\/[a-zA-Z0-9-_.+!*&apos;(),;/?:@=&amp;$]*)?$/;&#13;&#10;var podUrlTest = podUrlRE.test(Session.Property(&quot;POD_URL&quot;));&#13;&#10;if (!podUrlTest) {&#13;&#10;&#9;Session.Property(&quot;INVALID_POD_URL&quot;) = &quot;invalid&quot;;&#13;&#10;} else {&#13;&#10;&#9;Session.Property(&quot;INVALID_POD_URL&quot;) = &quot;valid&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;var autoLaunchPath = Session.Property(&quot;AUTO_LAUNCH_PATH&quot;);&#13;&#10;if (autoLaunchPath) {&#13;&#10;&#9;Session.Property(&quot;AUTO_LAUNCH_PATH&quot;) = autoLaunchPath.replace(/\\/g, &quot;/&quot;);&#13;&#10;}&#13;&#10;&#13;&#10;&#13;&#10;if (!Session.Property(&quot;ALWAYS_ON_TOP&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;ALWAYS_ON_TOP&quot;) = &quot;DISABLED&quot;;            &#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;MINIMIZE_ON_CLOSE&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;MINIMIZE_ON_CLOSE&quot;) = &quot;ENABLED&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;AUTO_START&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;AUTO_START&quot;) = &quot;ENABLED&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;BRING_TO_FRONT&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;BRING_TO_FRONT&quot;) = &quot;DISABLED&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;CUSTOM_TITLE_BAR&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;CUSTOM_TITLE_BAR&quot;) = &quot;ENABLED&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;DEV_TOOLS_ENABLED&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;DEV_TOOLS_ENABLED&quot;) = &quot;true&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;MEDIA&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;MEDIA&quot;) = &quot;true&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;LOCATION&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;LOCATION&quot;) = &quot;true&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;NOTIFICATIONS&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;NOTIFICATIONS&quot;) = &quot;true&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;MIDI_SYSEX&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;MIDI_SYSEX&quot;) = &quot;true&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;POINTER_LOCK&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;POINTER_LOCK&quot;) = &quot;true&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;FULL_SCREEN&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;FULL_SCREEN&quot;) = &quot;true&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;OPEN_EXTERNAL&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;OPEN_EXTERNAL&quot;) = &quot;true&quot;;&#13;&#10;}&#13;&#10;" WithoutSeq="true"/>
     <ROW Action="PowerShellScriptInline" Type="65" Source="PowerShellScriptLauncher.dll" Target="RunPowerShellScript" Options="1" AdditionalSeq="AI_DATA_SETTER_1"/>
     <ROW Action="SET_APPDIR" Type="307" Source="APPDIR" Target="[ProgramFilesFolder][Manufacturer]\[ProductName]" MultiBuildTarget="DefaultBuild:[AI_UserProgramFiles][Manufacturer]\[ProductName]"/>
     <ROW Action="SET_SHORTCUTDIR" Type="307" Source="SHORTCUTDIR" Target="[ProgramMenuFolder][ProductName]"/>
     <ROW Action="SET_TARGETDIR_TO_APPDIR" Type="51" Source="TARGETDIR" Target="[APPDIR]"/>
-    <ROW Action="SsoCheckbox" Type="101" Target="Script Text" TargetUnformatted="var ssoUrl = &quot;/login/sso/initsso&quot;;&#13;&#10;Session.Property(&quot;POD_URL&quot;) = Session.Property(&quot;POD_URL&quot;).substr(0, Session.Property(&quot;POD_URL&quot;).length - ssoUrl.length);" WithoutSeq="true"/>
+    <ROW Action="SetDefaults" Type="37" Target="Script Text" TargetUnformatted="if (!Session.Property(&quot;POD_URL&quot;)) {&#13;&#10;&#9;Session.Property(&quot;POD_URL&quot;) = &quot;https://my.symphony.com&quot;;&#13;&#10;} else {&#13;&#10;&#9;Session.Property(&quot;POD_URL&quot;) = Session.Property(&quot;POD_URL&quot;).replace(/^\s\s*/, &apos;&apos;).replace(/\s\s*$/, &apos;&apos;);&#13;&#10;}&#13;&#10;&#13;&#10;var autoLaunchPath = Session.Property(&quot;AUTO_LAUNCH_PATH&quot;);&#13;&#10;if (autoLaunchPath) {&#13;&#10;&#9;Session.Property(&quot;AUTO_LAUNCH_PATH&quot;) = autoLaunchPath.replace(/\\/g, &quot;/&quot;);&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;ALWAYS_ON_TOP&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;ALWAYS_ON_TOP&quot;) = &quot;DISABLED&quot;;            &#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;MINIMIZE_ON_CLOSE&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;MINIMIZE_ON_CLOSE&quot;) = &quot;ENABLED&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;AUTO_START&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;AUTO_START&quot;) = &quot;ENABLED&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;BRING_TO_FRONT&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;BRING_TO_FRONT&quot;) = &quot;DISABLED&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;CUSTOM_TITLE_BAR&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;CUSTOM_TITLE_BAR&quot;) = &quot;ENABLED&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;DEV_TOOLS_ENABLED&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;DEV_TOOLS_ENABLED&quot;) = &quot;true&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;MEDIA&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;MEDIA&quot;) = &quot;true&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;LOCATION&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;LOCATION&quot;) = &quot;true&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;NOTIFICATIONS&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;NOTIFICATIONS&quot;) = &quot;true&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;MIDI_SYSEX&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;MIDI_SYSEX&quot;) = &quot;true&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;POINTER_LOCK&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;POINTER_LOCK&quot;) = &quot;true&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;FULL_SCREEN&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;FULL_SCREEN&quot;) = &quot;true&quot;;&#13;&#10;}&#13;&#10;&#13;&#10;if (!Session.Property(&quot;OPEN_EXTERNAL&quot;))&#13;&#10;{&#13;&#10;&#9;Session.Property(&quot;OPEN_EXTERNAL&quot;) = &quot;true&quot;;&#13;&#10;}&#13;&#10;" WithoutSeq="true"/>
     <ROW Action="StopProcess" Type="65" Source="aicustact.dll" Target="StopProcess" WithoutSeq="true" Options="1" AdditionalSeq="AI_DATA_SETTER_4"/>
     <ROW Action="UninstallPreviousVersions" Type="65" Source="aicustact.dll" Target="UninstallPreviousVersions" Options="1"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiDialogComponent">
-    <ROW Dialog="AdvanceSettings" HCentering="50" VCentering="50" Width="370" Height="270" Attributes="3" Title="[ProductName] [Setup]" Control_Default="Next" Control_Cancel="Cancel"/>
     <ROW Dialog="CloseSymphonyDialog" HCentering="50" VCentering="50" Width="370" Height="270" Attributes="3" Title="[ProductName] [Setup]" Control_Default="Next" Control_Cancel="Cancel"/>
     <ROW Dialog="InstallationDlg" HCentering="50" VCentering="50" Width="370" Height="270" Attributes="3" Title="[ProductName] [Setup]" Control_Default="Next" Control_Cancel="Cancel"/>
-    <ROW Dialog="SettingsDlg" HCentering="50" VCentering="50" Width="370" Height="270" Attributes="3" Title="[ProductName] [Setup]" Control_Default="Next" Control_Cancel="Cancel"/>
     <ROW Dialog="UrlValidationDlg" HCentering="50" VCentering="50" Width="370" Height="270" Attributes="3" Title="[ProductName] [Setup]" Control_Default="Next" Control_Cancel="Cancel"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiIconsComponent">
@@ -726,8 +630,6 @@
     <ROW Action="AI_PREPARE_UPGRADE" Condition="AI_UPGRADE=&quot;No&quot; AND (Not Installed)" Sequence="1399"/>
     <ROW Action="AI_ResolveKnownFolders" Sequence="53"/>
     <ROW Action="AI_GetArpIconPath" Sequence="1402"/>
-    <ROW Action="KillRenderer" Sequence="55"/>
-    <ROW Action="AI_DATA_SETTER" Sequence="54"/>
     <ROW Action="AI_SETMIXINSTLOCATION" Sequence="749"/>
     <ROW Action="AI_AiBackupImmediate" Sequence="1401"/>
     <ROW Action="AI_AiBackupRollback" Sequence="1501"/>
@@ -743,10 +645,11 @@
     <ROW Action="AI_DpiContentScale" Sequence="52"/>
     <ROW Action="ExecuteAction" Sequence="1299" SeqType="0" MsiKey="ExecuteAction"/>
     <ROW Action="AI_SETMIXINSTLOCATION" Sequence="749"/>
+    <ROW Action="InstallTypeDlg" Condition="AI_INSTALL" Sequence="1223" SeqType="3" MsiKey="WelcomeDlg"/>
     <ROW Action="UninstallPreviousVersions" Sequence="1281"/>
+    <ROW Action="InstallationDlg" Condition="AI_INSTALL" Sequence="1227" SeqType="3"/>
     <ROW Action="AI_EnableDebugLog" Sequence="51"/>
     <ROW Action="AI_FinishActions" Condition="AI_INSTALL AND AiSkipExitDlg" Sequence="1300"/>
-    <ATTRIBUTE name="DeletedRows" value="WelcomeDlg"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiLaunchConditionsComponent">
     <ROW Condition="( Version9X OR ( NOT VersionNT64 ) OR ( VersionNT64 AND ((VersionNT64 &lt;&gt; 502) OR (ServicePackLevel &lt;&gt; 2) OR (MsiNTProductType &lt;&gt; 1)) AND ((VersionNT64 &lt;&gt; 502) OR (ServicePackLevel &lt;&gt; 2) OR (MsiNTProductType = 1)) AND ((VersionNT64 &lt;&gt; 600) OR (MsiNTProductType &lt;&gt; 1)) ) )" Description="[ProductName] cannot be installed on the following Windows versions: [WindowsTypeNT64Display]." DescriptionLocId="AI.LaunchCondition.NoSpecificNT64" IsPredefined="true" Builds="DefaultBuild"/>

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -67,9 +67,6 @@ const startApplication = async () => {
     await app.whenReady();
     logger.info(`main: app is ready, performing initial checks`);
     createAppCacheFile();
-    windowHandler.createApplication();
-    logger.info(`main: created application`);
-
     if (config.isFirstTimeLaunch()) {
         logger.info(`main: This is a first time launch! will update config and handle auto launch`);
         await config.setUpFirstTimeLaunch();
@@ -77,9 +74,10 @@ const startApplication = async () => {
             await autoLaunchInstance.handleAutoLaunch();
         }
     }
-
     // Setup session properties only after app ready
     setSessionProperties();
+    await windowHandler.createApplication();
+    logger.info(`main: created application`);
 };
 
 // Handle multiple/single instances

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -85,6 +85,7 @@ export class WindowHandler {
     public screenShareIndicatorFrameUtil: string;
     public shouldShowWelcomeScreen: boolean = false;
 
+    private readonly defaultPodUrl: string = 'https://my.symphony.com';
     private readonly contextIsolation: boolean;
     private readonly backgroundThrottling: boolean;
     private readonly windowOpts: ICustomBrowserWindowConstructorOpts;
@@ -174,8 +175,9 @@ export class WindowHandler {
         this.url = WindowHandler.getValidUrl(this.userConfig.url ? this.userConfig.url : this.globalConfig.url);
         logger.info(`window-handler: setting url ${this.url} from config file!`);
 
-        if (this.globalConfig.url.startsWith('https://my.symphony.com') && !this.userConfig.url) {
+        if (config.isFirstTimeLaunch()) {
             this.shouldShowWelcomeScreen = true;
+            this.url = this.defaultPodUrl;
             isMaximized = false;
             isFullScreen = false;
             DEFAULT_HEIGHT = 333;
@@ -441,7 +443,7 @@ export class WindowHandler {
             return;
         }
 
-        if (this.url.startsWith('https://my.symphony.com')) {
+        if (this.url.startsWith(this.defaultPodUrl)) {
             this.url = format({
                 pathname: require.resolve('../renderer/react-window.html'),
                 protocol: 'file',


### PR DESCRIPTION
## Description
This PR fixes 2 issues:
- Shows welcome screen (setting pod url) on every new install
- Adds dialog back to Windows installer that allows users to close Symphony
[SDA-2056](https://perzoinc.atlassian.net/browse/SDA-2056)
[SDA-2019](https://perzoinc.atlassian.net/browse/SDA-2019)

## Solution Approach
- Show welcome screen based on first time launch

## Related PRs
#972 #973 