### PR TITLE
fix: SDA-2080 (Fix a target CSS issue with SFE-Lite & fix title bar button issue in 9.x)

### DIFF
--- a/src/renderer/components/windows-title-bar.tsx
+++ b/src/renderer/components/windows-title-bar.tsx
@@ -257,7 +257,7 @@ export default class WindowsTitleBar extends React.Component<{}, IState> {
     private updateTitleBar(): void {
         const { isFullScreen, titleBarHeight } = this.state;
         const contentWrapper = document.getElementById('content-wrapper');
-        const appView = document.getElementsByClassName('AppView-root-3')[0] as HTMLElement;
+        const appView = document.getElementsByClassName('jss3')[0] as HTMLElement;
         const root = document.getElementById('root');
         const railContainer = document.getElementsByClassName('ReactRail-container-2')[0] as HTMLElement;
         const railList = document.getElementsByClassName('railList')[0] as HTMLElement;

--- a/src/renderer/styles/title-bar.less
+++ b/src/renderer/styles/title-bar.less
@@ -89,6 +89,7 @@
   border-radius: 0;
   padding: 10px 15px;
   cursor: default;
+  align-content: center;
 
   &:hover {
     background-color: @background_color_1;


### PR DESCRIPTION
## Description
Fix a target CSS issue with SFE-Lite 
Fix title bar button issue in 9.x
[SDA-2080](https://perzoinc.atlassian.net/browse/SDA-2080)

## Solution Approach
- As class names get regenerated by `jss` in the production we need to target `jss` class names
- Add content align to centre to fix the SVG aliment issue In 9.x
