### PR TITLE
fix: SDA-2022 Don't save snippet when annotation is aborted

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "systeminformation": "4.23.0"
   },
   "optionalDependencies": {
-    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#v1.0.8",
+    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#v1.0.9",
     "screen-share-indicator-frame": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#v1.4.8",
     "swift-search": "2.0.2"
   },


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits. 
Describe the problem or feature in addition to a link to the 
[SDA-2022](https://perzoinc.atlassian.net/browse/SDA-2022)

## Solution Approach
Describe the approach you've taken to implement this change / resolve the issue

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
other_pr_dev | [link]()
