### PR TITLE
fix: sda-2115 on windows the screen-share-indicator goes to background

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -973,6 +973,7 @@ export class WindowHandler {
         this.moveWindow(this.screenSharingIndicatorWindow, topPositionOfIndicatorScreen);
         this.screenSharingIndicatorWindow.setVisibleOnAllWorkspaces(true);
         this.screenSharingIndicatorWindow.setSkipTaskbar(true);
+        this.screenSharingIndicatorWindow.setAlwaysOnTop(true, 'screen-saver');
         this.screenSharingIndicatorWindow.webContents.once('did-finish-load', () => {
             if (!this.screenSharingIndicatorWindow || !windowExists(this.screenSharingIndicatorWindow)) {
                 return;


### PR DESCRIPTION
On mac the previous code worked, but for windows the screen share indicator was pushed behind other applications. With this change both on mac and windows the screen share indicator is on top

https://perzoinc.atlassian.net/browse/sda-2115 Screen Sharing: SS indicator disappears when sharing 1st screen