### PR TITLE
fix: SDA-2140: Screen share indicator does not close after reloading/closing SDA

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -562,7 +562,11 @@ export class WindowHandler {
                 if (browserWindow && windowExists(browserWindow)) {
                     // Closes only child windows
                     if (browserWindow.winName !== apiName.mainWindowName && browserWindow.winName !== apiName.notificationWindowName) {
-                        browserWindow.close();
+                        if (browserWindow.closable) {
+                            browserWindow.close();
+                        } else {
+                            browserWindow.destroy();
+                        }
                     }
                 }
             });


### PR DESCRIPTION
https://perzoinc.atlassian.net/browse/sda-2140 CLONE - SDA 9.0.0-392- RTC: Screen share indicator does not close after reloading/closing SDA

screen share indicator is not closeable so we have to destroy it