### PR TITLE
fix: sda-2140 forgot when screen share and than quiting sda

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -404,6 +404,7 @@ export class WindowHandler {
             if (isWindowsOS || isMac) {
                 this.execCmd(this.screenShareIndicatorFrameUtil, []);
             }
+            this.closeAllWindow();
             this.destroyAllWindows();
         });
 


### PR DESCRIPTION
https://perzoinc.atlassian.net/browse/sda-2140 CLONE - SDA 9.0.0-392- RTC: Screen share indicator does not close after reloading/closing SDA

Forgot when screen share and than quitting sda