### PR TITLE
fix: SDA-2215: macos preference override

### DIFF
--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -1,4 +1,4 @@
-import { app } from 'electron';
+import { app, systemPreferences } from 'electron';
 import * as electronDownloader from 'electron-dl';
 import * as shellPath from 'shell-path';
 
@@ -14,6 +14,10 @@ import './main-api-handler';
 import { handlePerformanceSettings } from './perf-handler';
 import { protocolHandler } from './protocol-handler';
 import { ICustomBrowserWindow, windowHandler } from './window-handler';
+
+// Set automatic period substitution to false because of a bug in draft js on the client app
+// See https://perzoinc.atlassian.net/browse/SDA-2215 for more details
+systemPreferences.setUserDefault('NSAutomaticPeriodSubstitutionEnabled', 'boolean', 'false');
 
 logger.info(`App started with the args ${JSON.stringify(process.argv)}`);
 

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -17,7 +17,7 @@ import { ICustomBrowserWindow, windowHandler } from './window-handler';
 
 // Set automatic period substitution to false because of a bug in draft js on the client app
 // See https://perzoinc.atlassian.net/browse/SDA-2215 for more details
-systemPreferences.setUserDefault('NSAutomaticPeriodSubstitutionEnabled', 'boolean', 'false');
+systemPreferences.setUserDefault('NSAutomaticPeriodSubstitutionEnabled', 'string', 'false');
 
 logger.info(`App started with the args ${JSON.stringify(process.argv)}`);
 


### PR DESCRIPTION
## Description
Add logic to disable `NSAutomaticPeriodSubstitutionEnabled` which is causing DraftJS to crash on SFE.
[SDA-2215](https://perzoinc.atlassian.net/browse/SDA-2215)

## Solution Approach
- Use the Electron's `systemPreferences.setUserDefault` API to disable `NSAutomaticPeriodSubstitutionEnabled`

## Related PRs
N/A
