### PR TITLE
fix: SDA-2151: fix network request url reload

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -306,7 +306,7 @@ export class WindowHandler {
             }
             // monitors network connection and
             // displays error banner on failure
-            monitorNetworkInterception();
+            monitorNetworkInterception(this.url || this.userConfig.url || this.globalConfig.url);
         });
 
         this.mainWindow.webContents.on('did-finish-load', async () => {
@@ -358,7 +358,7 @@ export class WindowHandler {
                         if (this.mainWindow && windowExists(this.mainWindow)) {
                             this.mainWindow.webContents.insertCSS(fs.readFileSync(path.join(__dirname, '..', '/renderer/styles/network-error.css'), 'utf8').toString());
                             this.mainWindow.webContents.send('network-error', {error: this.loadFailError});
-                            isSymphonyReachable(this.mainWindow);
+                            isSymphonyReachable(this.mainWindow, this.url || this.userConfig.url || this.globalConfig.url);
                         }
                     }
                 } catch (error) {

--- a/src/app/window-utils.ts
+++ b/src/app/window-utils.ts
@@ -32,7 +32,6 @@ enum styleNames {
 }
 
 const checkValidWindow = true;
-const { url: configUrl } = config.getGlobalConfigFields([ 'url' ]);
 const { ctWhitelist } = config.getConfigFields([ 'ctWhitelist' ]);
 
 // Network status check variables
@@ -518,8 +517,9 @@ export const handleCertificateProxyVerification = (
  * every 10sec, on active reloads the given window
  *
  * @param window {ICustomBrowserWindow}
+ * @param url Pod URL to load
  */
-export const isSymphonyReachable = (window: ICustomBrowserWindow | null) => {
+export const isSymphonyReachable = (window: ICustomBrowserWindow | null, url: string) => {
     if (networkStatusCheckIntervalId) {
         return;
     }
@@ -527,7 +527,7 @@ export const isSymphonyReachable = (window: ICustomBrowserWindow | null) => {
         return;
     }
     networkStatusCheckIntervalId = setInterval(() => {
-        const { hostname, protocol } = parse(configUrl);
+        const { hostname, protocol } = parse(url);
         if (!hostname || !protocol) {
             return;
         }
@@ -536,7 +536,7 @@ export const isSymphonyReachable = (window: ICustomBrowserWindow | null) => {
         fetch(podUrl, { method: 'GET' }).then((rsp) => {
             if (rsp.status === 200 && windowHandler.isOnline) {
                 logger.info(`window-utils: pod ${podUrl} is reachable, loading main window!`);
-                window.loadURL(configUrl);
+                window.loadURL(url);
                 if (networkStatusCheckIntervalId) {
                     clearInterval(networkStatusCheckIntervalId);
                     networkStatusCheckIntervalId = null;
@@ -640,11 +640,10 @@ export const updateFeaturesForCloudConfig = async (): Promise<void> => {
 /**
  * Monitors network requests and displays red banner on failure
  */
-export const monitorNetworkInterception = () => {
+export const monitorNetworkInterception = (url: string) => {
     if (isNetworkMonitorInitialized) {
         return;
     }
-    const { url } = config.getGlobalConfigFields( [ 'url' ] );
     const { hostname, protocol } = parse(url);
 
     if (!hostname || !protocol) {

--- a/src/app/window-utils.ts
+++ b/src/app/window-utils.ts
@@ -639,6 +639,7 @@ export const updateFeaturesForCloudConfig = async (): Promise<void> => {
 
 /**
  * Monitors network requests and displays red banner on failure
+ * @param url: Pod URL to be loaded after network is active again
  */
 export const monitorNetworkInterception = (url: string) => {
     if (isNetworkMonitorInitialized) {


### PR DESCRIPTION
## Description
Currently, if network connection is lost on SDA post the welcome screen implementation, the pod url we load is from the global config file, instead we should load the proper url.
[SDA-2151](https://perzoinc.atlassian.net/browse/SDA-2151)

## Solution Approach
- Pass the correct url to the appropriate methods from within `window-handler`

## Related PRs
N/A