### PR TITLE
fix: SDA-2179 Ensuring screen share indicator frame is turned off when switching client versions

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -1277,6 +1277,7 @@ export class WindowHandler {
                 default:
                     this.url = this.globalConfig.url + `?x-km-csrf-token=${csrfToken}`;
             }
+            this.execCmd(this.screenShareIndicatorFrameUtil, []);
             await this.mainWindow.loadURL(this.url);
         } catch (e) {
             logger.error(`window-handler: failed to switch client because of error ${e}`);

--- a/src/app/window-utils.ts
+++ b/src/app/window-utils.ts
@@ -83,6 +83,8 @@ export const preventWindowNavigation = (browserWindow: BrowserWindow, isPopOutWi
                     logger.info(`window-utils: received ${response} response from dialog`);
                 }
             }
+
+            windowHandler.execCmd(windowHandler.screenShareIndicatorFrameUtil, []);
         }
 
         if (browserWindow.isDestroyed()


### PR DESCRIPTION

## Description
Ensuring screen share indicator frame is turned off when switching client versions, both using hotkeys and menu option

[SDA-2197](https://perzoinc.atlassian.net/browse/SDA-2197)

## Solution Approach
Closing the screen share indicator when the mainwindow url change and when hotkeys are invoked

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
other_pr_dev | [link]()
