### PR TITLE
fix: SDA-2209 Applied consistent font styling

### DIFF
--- a/installer/mac/intro.html
+++ b/installer/mac/intro.html
@@ -3,10 +3,10 @@
 <head>
 	<title>Thanks for downloading Symphony</title>
 </head>
-<body>
+<body style="font-size: 13px; font-family: -apple-system, system-ui, BlinkMacSystemFont, sans-serif; color: rgba(0,0,0,1)">
 <br/>
 <br/>
-<p style="font-size: 13px; font-family: -apple-system, system-ui, BlinkMacSystemFont, sans-serif; color: rgba(0,0,0,1)">
+<p>
 	&nbsp;&nbsp;&nbsp;Symphony allows you to:<br>
 	<ul>
 		<li>Collaborate securely</li>


### PR DESCRIPTION
## Description
All fonts in the installer should be sans-serif and the correct sizes
[SDA-2209](https://perzoinc.atlassian.net/browse/SDA-2209)

## Solution Approach
Moved the styling to apply to the whole html document and not just the first text block.

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
other_pr_dev | [link]()
