### PR TITLE
feat: add parameter to push the renderer logs inside the SDA-logs

### DIFF
--- a/config/Symphony.config
+++ b/config/Symphony.config
@@ -11,6 +11,7 @@
     "devToolsEnabled": true,
     "contextIsolation": true,
     "disableGpu": false,
+    "enableRendererLogs": false,
     "ctWhitelist": [],
     "podWhitelist": [],
     "notificationSettings": {

--- a/docs/features/config-file.md
+++ b/docs/features/config-file.md
@@ -46,6 +46,7 @@ position:
   - authServerWhitelist: This is a list of domains that would be included for auto authentication. More details [here](./ad-sso-authentication.md)
   - authNegotiateDelegateWhitelist: This is a list of domains that would be included for auto authentication. More details [here](./ad-sso-authentication.md)
   - disableGpu: This disables hardware acceleration. The options available are "true" and "false"
+  - enableRendererLogs: This enables printouts from renderer. The options available are "true" and "false"
 - permissions: These are a set of fine grained controls that admins can use to control certain peripherals of the system being used from the SDA.
   - media: This includes the camera, microphone and audio. If set to "true", all these permissions are allowed to be used by the SDA.
   - geolocation: This includes the user location that is requested by the app. If set to "true", this permission is allowed to be used by the SDA.

--- a/src/app/app-menu.ts
+++ b/src/app/app-menu.ts
@@ -77,6 +77,7 @@ export class AppMenu {
 
     private readonly menuItemConfigFields: string[];
     private disableGpu: boolean;
+    private enableRendererLogs: boolean;
 
     constructor() {
         this.menuList = [];
@@ -84,6 +85,7 @@ export class AppMenu {
         this.menuItemConfigFields = [ 'minimizeOnClose', 'launchOnStartup', 'alwaysOnTop', 'bringToFront', 'memoryRefresh', 'isCustomTitleBar', 'devToolsEnabled' ];
         this.cloudConfig = config.getFilteredCloudConfigFields(this.menuItemConfigFields);
         this.disableGpu = config.getConfigFields(['disableGpu']).disableGpu;
+        this.enableRendererLogs = config.getConfigFields(['enableRendererLogs']).enableRendererLogs;
         this.buildMenu();
         // send initial analytic
         if (!initialAnalyticsSent) {
@@ -462,6 +464,21 @@ export class AppMenu {
                             : i18n.t('Disable GPU')(),
                         click: () => {
                             gpuRestartDialog(!this.disableGpu);
+                            },
+                    },
+                    {
+                        label: i18n.t('Enable Renderer Logs')(),
+                        type: 'checkbox',
+                        checked: this.enableRendererLogs,
+                        click: async () => {
+                            if (this.enableRendererLogs) {
+                                this.enableRendererLogs = false;
+                            } else {
+                                this.enableRendererLogs = true;
+                            }
+                            const enableRendererLogs = this.enableRendererLogs;
+                            await config.updateUserConfig({ enableRendererLogs });
+                            logger.info('New value for enableRendererLogs: ' + this.enableRendererLogs);
                         },
                     } ],
                 }, {

--- a/src/app/child-window-handler.ts
+++ b/src/app/child-window-handler.ts
@@ -200,6 +200,25 @@ export const handleChildWindow = (webContents: WebContents): void => {
                 // Update initial bound changes
                 sendInitialBoundChanges(browserWin);
 
+                browserWin.webContents.on('console-message', (_event, level, message, _line, _sourceId) => {
+                    const { enableRendererLogs } = config.getConfigFields([ 'enableRendererLogs' ]);
+                    if (enableRendererLogs) {
+                        if (browserWin) {
+                            if (level === 0) {
+                                logger.debug('renderer ' + browserWin.title + ': ' + message);
+                            } else if (level === 1) {
+                                logger.info('renderer ' + browserWin.title + ': ' + message);
+                            } else if (level === 2) {
+                                logger.warn('renderer ' + browserWin.title + ': ' + message);
+                            } else if (level === 3) {
+                                logger.error('renderer ' + browserWin.title + ': ' + message);
+                            } else {
+                                logger.info('renderer ' + browserWin.title + ': ' + message);
+                            }
+                        }
+                    }
+                });
+
                 // Remove all attached event listeners
                 browserWin.on('close', () => {
                     logger.info(`child-window-handler: close event occurred for window with url ${newWinUrl}!`);

--- a/src/app/config-handler.ts
+++ b/src/app/config-handler.ts
@@ -26,6 +26,7 @@ export interface IConfig {
     memoryRefresh: CloudConfigDataTypes;
     memoryThreshold: string;
     disableGpu: boolean;
+    enableRendererLogs: boolean;
     devToolsEnabled: boolean;
     ctWhitelist: string[];
     podWhitelist: string[];

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -385,6 +385,25 @@ export class WindowHandler {
             response === 0 ? this.mainWindow.reload() : this.mainWindow.close();
         });
 
+        this.mainWindow.webContents.on('console-message', (_event, level, message, _line, _sourceId) => {
+            const { enableRendererLogs } = config.getConfigFields([ 'enableRendererLogs' ]);
+            if (enableRendererLogs) {
+                if (this.mainWindow) {
+                    if (level === 0) {
+                        logger.debug('renderer ' + this.mainWindow.winName + ': ' + message);
+                    } else if (level === 1) {
+                        logger.info('renderer ' + this.mainWindow.winName + ': ' + message);
+                    } else if (level === 2) {
+                        logger.warn('renderer ' + this.mainWindow.winName + ': ' + message);
+                    } else if (level === 3) {
+                        logger.error('renderer ' + this.mainWindow.winName + ': ' + message);
+                    } else {
+                        logger.info('renderer ' + this.mainWindow.winName + ': ' + message);
+                    }
+                }
+            }
+        });
+
         // Handle main window close
         this.mainWindow.on('close', (event) => {
             if (!this.mainWindow || !windowExists(this.mainWindow)) {

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -56,6 +56,7 @@
   "Dev Tools has been disabled! Please contact your system administrator to enable it!": "Dev Tools has been disabled! Please contact your system administrator to enable it!",
   "Disable Hamburger menu": "Disable Hamburger menu",
   "Disable GPU": "Disable GPU",
+  "Enable Renderer Logs": "Enable Renderer Logs",
   "DownloadManager": {
     "downloaded": "downloaded",
     "File not Found": "File not Found",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -56,6 +56,7 @@
   "Dev Tools has been disabled! Please contact your system administrator to enable it!": "Dev Tools has been disabled! Please contact your system administrator to enable it!",
   "Disable Hamburger menu": "Disable Hamburger menu",
   "Disable GPU": "Disable GPU",
+  "Enable Renderer Logs": "Enable Renderer Logs",
   "DownloadManager": {
     "downloaded": "downloaded",
     "File not Found": "File not Found",

--- a/src/locale/fr-FR.json
+++ b/src/locale/fr-FR.json
@@ -57,6 +57,7 @@
   "Dev Tools has been disabled! Please contact your system administrator to enable it!": "Dev Tools a été désactivé ! Veuillez contacter votre administrateur système pour l’activer !",
   "Disable Hamburger menu": "Désactiver le menu Hamburger",
   "Disable GPU": "Désactiver le GPU",
+  "Enable Renderer Logs": "Enable Renderer Logs",
   "DownloadManager": {
     "downloaded": "téléchargé",
     "File not Found": "Fichier non trouvé",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -56,6 +56,7 @@
   "Dev Tools has been disabled! Please contact your system administrator to enable it!": "Dev Tools a été désactivé ! Veuillez contacter votre administrateur système pour l’activer !",
   "Disable Hamburger menu": "Désactiver le menu Hamburger",
   "Disable GPU": "Désactiver le GPU",
+  "Enable Renderer Logs": "Enable Renderer Logs",
   "DownloadManager": {
     "downloaded": "téléchargé",
     "File not Found": "Fichier non trouvé",

--- a/src/locale/ja-JP.json
+++ b/src/locale/ja-JP.json
@@ -56,6 +56,7 @@
   "Dev Tools has been disabled! Please contact your system administrator to enable it!": "開発ツールが無効になっています。システム管理者に連絡して、有効にしてください。",
   "Disable Hamburger menu": "ハンバーガーメニューを無効にする",
   "Disable GPU": "GPUを無効にする",
+  "Enable Renderer Logs": "Enable Renderer Logs",
   "DownloadManager": {
     "downloaded": "ダウンロード済み",
     "File not Found": "ファイルが見つかりません",

--- a/src/locale/ja.json
+++ b/src/locale/ja.json
@@ -56,6 +56,7 @@
   "Dev Tools has been disabled! Please contact your system administrator to enable it!": "開発ツールが無効になっています。システム管理者に連絡して、有効にしてください。",
   "Disable Hamburger menu": "ハンバーガーメニューを無効にする",
   "Disable GPU": "GPUを無効にする",
+  "Enable Renderer Logs": "Enable Renderer Logs",
   "DownloadManager": {
     "downloaded": "ダウンロード済み",
     "File not Found": "ファイルが見つかりません",


### PR DESCRIPTION
Add parameter to push the renderer logs inside the SDA-logs

**Main window**
```
13:01:37.233 › renderer main: symphonyanalytics : register
13:01:41.895 › renderer main: error in chat list, MessageList Error: Large room unqueued
13:01:41.896 › renderer main: error in chat list, MessageList Error: Large room unqueued

```

**Pop-out**
```
15:15:05.548 › renderer SDA devs - Chat Room: Cannot register renderer for custom-message-context-renderer: There is no renderer available under [object Object]
15:15:05.548 › renderer SDA devs - Chat Room: Cannot register renderer for message-from-me: There is no renderer available under [object Object]
```
