### PR TITLE
chore: Bump SDA version to 9.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "symphony",
   "productName": "Symphony",
-  "version": "9.0.1",
+  "version": "9.1.0",
   "clientVersion": "2.0.1",
   "buildNumber": "0",
   "searchAPIVersion": "1.55.3",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "spectron": "^11.0.0",
     "ts-jest": "25.3.0",
     "tslint": "5.11.0",
-    "typescript": "3.1.1"
+    "typescript": "3.9.7"
   },
   "dependencies": {
     "archiver": "3.1.1",

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -727,9 +727,6 @@ export class WindowHandler {
                 cloudConfig,
                 finalConfig,
                 hostname,
-                buildNumber: versionHandler.versionInfo.buildNumber,
-                clientVersion: versionHandler.versionInfo.clientVersion,
-                sfeVersion: versionHandler.versionInfo.sfeVersion,
                 versionLocalised,
                 ...versionHandler.versionInfo,
             };


### PR DESCRIPTION
## Description
Bump SDA version to `9.1.0`

9.0.1 shipping with a fix for memory refresh issue
https://github.com/symphonyoss/SymphonyElectron/pull/1032