### PR TITLE
build: SDA-2285 (Bump typescript version to fix 3rd party lint issues)

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "spectron": "^11.0.0",
     "ts-jest": "25.3.0",
     "tslint": "5.11.0",
-    "typescript": "3.1.1"
+    "typescript": "3.9.7"
   },
   "dependencies": {
     "archiver": "3.1.1",

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -708,9 +708,6 @@ export class WindowHandler {
                 cloudConfig,
                 finalConfig,
                 hostname,
-                buildNumber: versionHandler.versionInfo.buildNumber,
-                clientVersion: versionHandler.versionInfo.clientVersion,
-                sfeVersion: versionHandler.versionInfo.sfeVersion,
                 versionLocalised,
                 ...versionHandler.versionInfo,
             };


### PR DESCRIPTION
## Description

- Bump typescript version to fix 3rd party lint issues
- Fixes the build failing issue 
![Screenshot 2020-07-22 at 2 11 43 AM](https://user-images.githubusercontent.com/13243259/88104860-b2ac0a00-cbc0-11ea-98a0-992f4561cfc7.png)

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
SDA-2285 | [link](https://github.com/symphonyoss/SymphonyElectron/pull/1032)
