### PR TITLE
feat: SDA-2315: add chrome flag for network in process

### DIFF
--- a/spec/chromeFlags.spec.ts
+++ b/spec/chromeFlags.spec.ts
@@ -98,8 +98,8 @@ describe('chrome flags', () => {
         });
         const spy = jest.spyOn(app.commandLine, 'appendSwitch');
         setChromeFlags();
-        expect(spy).nthCalledWith(5, 'disable-renderer-backgrounding', 'true');
-        expect(spy).not.nthCalledWith(6);
+        expect(spy).nthCalledWith(6, 'disable-renderer-backgrounding', 'true');
+        expect(spy).not.nthCalledWith(7);
     });
 
     it('should set `disable-renderer-backgrounding` chrome flag correctly when cloud config PMP setting is ENABLED', () => {
@@ -110,8 +110,8 @@ describe('chrome flags', () => {
         });
         const spy = jest.spyOn(app.commandLine, 'appendSwitch');
         setChromeFlags();
-        expect(spy).nthCalledWith(8, 'disable-renderer-backgrounding', 'true');
-        expect(spy).not.nthCalledWith(9);
+        expect(spy).nthCalledWith(9, 'disable-renderer-backgrounding', 'true');
+        expect(spy).not.nthCalledWith(10);
     });
 
     it('should set `disable-renderer-backgrounding` chrome flag when any one is ENABLED ', () => {
@@ -132,8 +132,8 @@ describe('chrome flags', () => {
         });
         const spy = jest.spyOn(app.commandLine, 'appendSwitch');
         setChromeFlags();
-        expect(spy).nthCalledWith(5, 'disable-renderer-backgrounding', 'true');
-        expect(spy).not.nthCalledWith(6);
+        expect(spy).nthCalledWith(6, 'disable-renderer-backgrounding', 'true');
+        expect(spy).not.nthCalledWith(7);
     });
 
     it('should set `disable-renderer-backgrounding` chrome flag when PMP is ENABLED', () => {
@@ -154,8 +154,8 @@ describe('chrome flags', () => {
         });
         const spy = jest.spyOn(app.commandLine, 'appendSwitch');
         setChromeFlags();
-        expect(spy).nthCalledWith(5, 'disable-renderer-backgrounding', 'true');
-        expect(spy).not.nthCalledWith(6);
+        expect(spy).nthCalledWith(6, 'disable-renderer-backgrounding', 'true');
+        expect(spy).not.nthCalledWith(7);
     });
 
     describe('`isDevEnv`', () => {

--- a/src/app/chrome-flags.ts
+++ b/src/app/chrome-flags.ts
@@ -26,6 +26,7 @@ export const setChromeFlags = () => {
         'disable-gpu': flagsConfig.disableGpu || null,
         'disable-gpu-compositing': flagsConfig.disableGpu || null,
         'enable-experimental-web-platform-features': 'true',
+        'enable-features': 'NetworkService,NetworkServiceInProcess',
     };
     if (flagsConfig.customFlags.disableThrottling === CloudConfigDataTypes.ENABLED || disableThrottling === CloudConfigDataTypes.ENABLED) {
         configFlags['disable-renderer-backgrounding'] = 'true';


### PR DESCRIPTION
## Description
Adds a new flag to allow network service in chromium to run in the same process as the renderer
[SDA-2315](https://perzoinc.atlassian.net/browse/SDA-2315)

## Solution Approach
Add the below flag in `chrome-flags.ts`
```
'enable-features': 'NetworkService,NetworkServiceInProcess',
```

## Related PRs
#1048 
#1049 