### PR TITLE
feat: SDA-2352: add new api for restarting SDA

### DIFF
--- a/src/app/app-state-handler.ts
+++ b/src/app/app-state-handler.ts
@@ -1,0 +1,19 @@
+import { app } from 'electron';
+import { logger } from '../common/logger';
+
+class AppStateHandler {
+
+    /**
+     * Restarts the app with the command line arguments
+     * passed from the previous session
+     */
+    public restart() {
+        logger.info(`Restarting app as per instruction from SFE`);
+        app.relaunch();
+        app.exit();
+    }
+
+}
+
+const appStateHandler = new AppStateHandler();
+export default appStateHandler;

--- a/src/app/main-api-handler.ts
+++ b/src/app/main-api-handler.ts
@@ -5,6 +5,7 @@ import { LocaleType } from '../common/i18n';
 import { logger } from '../common/logger';
 import { activityDetection } from './activity-detection';
 import { analytics } from './analytics-handler';
+import appStateHandler from './app-state-handler';
 import { CloudConfigDataTypes, config, ICloudConfig } from './config-handler';
 import { downloadHandler } from './download-handler';
 import { memoryMonitor } from './memory-monitor';
@@ -163,6 +164,9 @@ ipcMain.on(apiName.symphonyApi, async (event: Electron.IpcMainEvent, arg: IApiAr
             break;
         case apiCmds.clearDownloadedItems:
             downloadHandler.clearDownloadedItems();
+            break;
+        case apiCmds.restartApp:
+            appStateHandler.restart();
             break;
         case apiCmds.isMisspelled:
             if (typeof arg.word === 'string') {

--- a/src/common/api-interface.ts
+++ b/src/common/api-interface.ts
@@ -42,6 +42,7 @@ export enum apiCmds {
     openDownloadedItem = 'open-downloaded-item',
     showDownloadedItem = 'show-downloaded-item',
     clearDownloadedItems = 'clear-downloaded-items',
+    restartApp = 'restart-app',
 }
 
 export enum apiName {

--- a/src/demo/index.html
+++ b/src/demo/index.html
@@ -207,6 +207,7 @@
                 <td id="cpu-arch"></td>
             </tr>
         </table>
+    <input type="button" id="restart-app" value="Restart App"/>
     </body>
     <script>
 
@@ -251,6 +252,7 @@
                 registerRestartFloater: 'register-restart-floater',
                 getCPUUsage: 'get-cpu-usage',
                 checkMediaPermission: 'check-media-permission',
+                restartApp: 'restart-app',
         };
         let requestId = 0;
 
@@ -907,6 +909,14 @@
                 window.ssf.clearDownloadedItems();
             } else {
                 postMessage(apiCmds.clearDownloadedItems);
+            }
+        });
+
+        document.getElementById('restart-app').addEventListener('click', () => {
+            if (window.ssf) {
+                window.ssf.restartApp();
+            } else {
+                postMessage(apiCmds.restartApp);
             }
         });
 

--- a/src/renderer/app-bridge.ts
+++ b/src/renderer/app-bridge.ts
@@ -122,6 +122,9 @@ export class AppBridge {
             case apiCmds.clearDownloadedItems:
                 ssf.clearDownloadedItems();
                 break;
+            case apiCmds.restartApp:
+                ssf.restartApp();
+                break;
             case apiCmds.setLocale:
                 if (typeof data === 'string') {
                     ssf.setLocale(data as string);
@@ -161,13 +164,13 @@ export class AppBridge {
                 ssf.closeScreenSharingIndicator(data.streamId as string);
                 break;
             case apiCmds.getMediaSource:
-                ssf.getMediaSource(data as ICustomSourcesOptions, this.callbackHandlers.onMediaSourceCallback);
+                await ssf.getMediaSource(data as ICustomSourcesOptions, this.callbackHandlers.onMediaSourceCallback);
                 break;
             case apiCmds.notification:
                 notification.showNotification(data as INotificationData, this.callbackHandlers.onNotificationCallback);
                 break;
             case apiCmds.closeNotification:
-                notification.hideNotification(data as number);
+                await notification.hideNotification(data as number);
                 break;
             case apiCmds.showNotificationSettings:
                 ssf.showNotificationSettings();

--- a/src/renderer/preload-main.ts
+++ b/src/renderer/preload-main.ts
@@ -84,6 +84,7 @@ if (ssfWindow.ssf) {
         checkMediaPermission: ssfWindow.ssf.checkMediaPermission,
         showNotification: notification.showNotification,
         closeNotification: notification.hideNotification,
+        restartApp: ssfWindow.ssf.restartApp,
     });
 }
 

--- a/src/renderer/ssf-api.ts
+++ b/src/renderer/ssf-api.ts
@@ -123,6 +123,12 @@ const throttledClearDownloadedItems = throttle(() => {
     });
 }, 1000);
 
+const throttledRestart = throttle(() => {
+    ipcRenderer.send(apiName.symphonyApi, {
+        cmd: apiCmds.restartApp,
+    });
+}, 1000);
+
 let cryptoLib: ICryptoLib | null;
 try {
     cryptoLib = remote.require('../app/crypto-handler.js').cryptoLibrary;
@@ -544,6 +550,13 @@ export class SSFApi {
      */
     public clearDownloadedItems(): void {
         throttledClearDownloadedItems();
+    }
+
+    /**
+     * Restart the app
+     */
+    public restartApp(): void {
+        throttledRestart();
     }
 
     /**


### PR DESCRIPTION
## Description
Exposes an API on the bridge to allow SFE to restart SDA on demand.
[SDA-2352](https://perzoinc.atlassian.net/browse/SDA-2352)

## Solution Approach
- Add a new API in the ssf api
- Expose that on the context bridge and post message as well

## Related PRs
https://github.com/SymphonyOSF/SFE-Client-App/pull/17241
