### PR TITLE
fix: address RTC meeting failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "browserify": "16.5.1",
     "cross-env": "5.2.0",
     "del": "3.0.0",
-    "electron": "9.1.2",
+    "electron": "9.2.1",
     "electron-builder": "22.7.0",
     "electron-builder-squirrel-windows": "20.38.3",
     "electron-icon-maker": "0.0.4",


### PR DESCRIPTION
## Description
Upgrade Electron to the latest 9.2.1 release to fix the RTC meeting failure issue.

## Solution Approach
Upgrade Electron to the latest 9.2.1 release

## Related PRs
#1054 
