### PR TITLE
feat: SDA-2389 Added version number to installer

### DIFF
--- a/installer/win/Symphony.cs
+++ b/installer/win/Symphony.cs
@@ -103,9 +103,12 @@ class Script
             new LaunchCondition("VersionNT>=600 AND WindowsBuild>=6001", "OS not supported")            
         );
         
+        // The build script which calls the wix# builder, will be run from a command environment which has %SYMVER% set.
+        // So we just extract that version string, create a Version object from it, and pass it to out project definition.
+        var version = System.Environment.GetEnvironmentVariable("SYMVER");
+        project.Version = new System.Version(version);
+        
         // Generate an MSI from all settings done above
         Compiler.BuildMsi(project);
     }
 }
-
-


### PR DESCRIPTION
## Description
Using the built in Version property in Wix#, and populating if from the same version string (stored in environment variable SYMVER) as is currently used by Advanced Installer 
[SDA-2389](https://perzoinc.atlassian.net/browse/SDA-2389)

## Solution Approach
Describe the approach you've taken to implement this change / resolve the issue

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
other_pr_dev | [link]()
