### PR TITLE
fix: sda-2261 translate enable console logs

### DIFF
--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -56,7 +56,7 @@
   "Dev Tools has been disabled! Please contact your system administrator to enable it!": "Dev Tools has been disabled! Please contact your system administrator to enable it!",
   "Disable Hamburger menu": "Disable Hamburger menu",
   "Disable GPU": "Disable GPU",
-  "Enable Renderer Logs": "Enable Renderer Logs",
+  "Enable Renderer Logs": "Enable Console logs",
   "DownloadManager": {
     "downloaded": "downloaded",
     "File not Found": "File not Found",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -56,7 +56,7 @@
   "Dev Tools has been disabled! Please contact your system administrator to enable it!": "Dev Tools has been disabled! Please contact your system administrator to enable it!",
   "Disable Hamburger menu": "Disable Hamburger menu",
   "Disable GPU": "Disable GPU",
-  "Enable Renderer Logs": "Enable Renderer Logs",
+  "Enable Renderer Logs": "Enable Console logs",
   "DownloadManager": {
     "downloaded": "downloaded",
     "File not Found": "File not Found",

--- a/src/locale/fr-FR.json
+++ b/src/locale/fr-FR.json
@@ -57,7 +57,7 @@
   "Dev Tools has been disabled! Please contact your system administrator to enable it!": "Dev Tools a été désactivé ! Veuillez contacter votre administrateur système pour l’activer !",
   "Disable Hamburger menu": "Désactiver le menu Hamburger",
   "Disable GPU": "Désactiver le GPU",
-  "Enable Renderer Logs": "Enable Renderer Logs",
+  "Enable Renderer Logs": "Activer les journaux de la Console",
   "DownloadManager": {
     "downloaded": "téléchargé",
     "File not Found": "Fichier non trouvé",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -56,7 +56,7 @@
   "Dev Tools has been disabled! Please contact your system administrator to enable it!": "Dev Tools a été désactivé ! Veuillez contacter votre administrateur système pour l’activer !",
   "Disable Hamburger menu": "Désactiver le menu Hamburger",
   "Disable GPU": "Désactiver le GPU",
-  "Enable Renderer Logs": "Enable Renderer Logs",
+  "Enable Renderer Logs": "Activer les journaux de la Console",
   "DownloadManager": {
     "downloaded": "téléchargé",
     "File not Found": "Fichier non trouvé",

--- a/src/locale/ja-JP.json
+++ b/src/locale/ja-JP.json
@@ -56,7 +56,7 @@
   "Dev Tools has been disabled! Please contact your system administrator to enable it!": "開発ツールが無効になっています。システム管理者に連絡して、有効にしてください。",
   "Disable Hamburger menu": "ハンバーガーメニューを無効にする",
   "Disable GPU": "GPUを無効にする",
-  "Enable Renderer Logs": "Enable Renderer Logs",
+  "Enable Renderer Logs": "コンソールログを有効にする",
   "DownloadManager": {
     "downloaded": "ダウンロード済み",
     "File not Found": "ファイルが見つかりません",

--- a/src/locale/ja.json
+++ b/src/locale/ja.json
@@ -56,7 +56,7 @@
   "Dev Tools has been disabled! Please contact your system administrator to enable it!": "開発ツールが無効になっています。システム管理者に連絡して、有効にしてください。",
   "Disable Hamburger menu": "ハンバーガーメニューを無効にする",
   "Disable GPU": "GPUを無効にする",
-  "Enable Renderer Logs": "Enable Renderer Logs",
+  "Enable Renderer Logs": "コンソールログを有効にする",
   "DownloadManager": {
     "downloaded": "ダウンロード済み",
     "File not Found": "ファイルが見つかりません",


### PR DESCRIPTION
https://perzoinc.atlassian.net/browse/sda-2261 SDA 9.0.0.452 - Localization - Sub -Menu - 'Enable Renderer Logs' is not localized