### PR TITLE
fix: SDA-2279 (Filter out notification windows from desktop capturer)

### DIFF
--- a/src/common/api-interface.ts
+++ b/src/common/api-interface.ts
@@ -51,6 +51,8 @@ export enum apiName {
     notificationWindowName = 'notification-window',
 }
 
+export const NOTIFICATION_WINDOW_TITLE = 'Notification - Symphony';
+
 export interface IApiArgs {
     memoryInfo: Electron.ProcessMemoryInfo;
     word: string;

--- a/src/renderer/desktop-capturer.ts
+++ b/src/renderer/desktop-capturer.ts
@@ -120,7 +120,9 @@ export const getSource = async (options: ICustomSourcesOptions, callback: Callba
 
     }
 
-    const updatedSources = sources.map((source) => {
+    const updatedSources = sources
+        .filter((source) => isWindowsOS ? source.name !== 'Notification - Symphony' : true)
+        .map((source) => {
         return Object.assign({}, source, {
             thumbnail: source.thumbnail.toDataURL(),
         });

--- a/src/renderer/desktop-capturer.ts
+++ b/src/renderer/desktop-capturer.ts
@@ -6,7 +6,7 @@ import {
     SourcesOptions,
 } from 'electron';
 
-import { apiCmds, apiName } from '../common/api-interface';
+import { apiCmds, apiName, NOTIFICATION_WINDOW_TITLE } from '../common/api-interface';
 import { isWindowsOS } from '../common/env';
 import { i18n } from '../common/i18n-preload';
 
@@ -121,7 +121,7 @@ export const getSource = async (options: ICustomSourcesOptions, callback: Callba
     }
 
     const updatedSources = sources
-        .filter((source) => isWindowsOS ? source.name !== 'Notification - Symphony' : true)
+        .filter((source) => isWindowsOS ? source.name !== NOTIFICATION_WINDOW_TITLE : true)
         .map((source) => {
         return Object.assign({}, source, {
             thumbnail: source.thumbnail.toDataURL(),

--- a/src/renderer/desktop-capturer.ts
+++ b/src/renderer/desktop-capturer.ts
@@ -121,7 +121,7 @@ export const getSource = async (options: ICustomSourcesOptions, callback: Callba
     }
 
     const updatedSources = sources
-        .filter((source) => isWindowsOS ? source.name !== NOTIFICATION_WINDOW_TITLE : true)
+        .filter((source) => source.name !== NOTIFICATION_WINDOW_TITLE)
         .map((source) => {
         return Object.assign({}, source, {
             thumbnail: source.thumbnail.toDataURL(),

--- a/src/renderer/notification.ts
+++ b/src/renderer/notification.ts
@@ -3,7 +3,7 @@ import { app, BrowserWindow, ipcMain } from 'electron';
 import { config } from '../app/config-handler';
 import { createComponentWindow, windowExists } from '../app/window-utils';
 import { AnimationQueue } from '../common/animation-queue';
-import { apiName, INotificationData, NotificationActions } from '../common/api-interface';
+import { apiName, INotificationData, NOTIFICATION_WINDOW_TITLE, NotificationActions } from '../common/api-interface';
 import { isNodeEnv, isWindowsOS } from '../common/env';
 import { logger } from '../common/logger';
 import NotificationHandler from './notification-handler';
@@ -470,7 +470,7 @@ class Notification extends NotificationHandler {
             transparent: true,
             fullscreenable: false,
             acceptFirstMouse: true,
-            title: 'Notification - Symphony',
+            title: NOTIFICATION_WINDOW_TITLE,
             webPreferences: {
                 sandbox: !isNodeEnv,
                 nodeIntegration: isNodeEnv,


### PR DESCRIPTION
## Description
Filter out custom notification window from showing up in the screen share application tab
[SDA-2279](https://perzoinc.atlassian.net/browse/SDA-2279)

## Solution Approach
- Filter out all the window with name `Notification - Symphony`

notes: custom notifications will no longer be displayed in screen picker application tab 