### PR TITLE
feat: I18N-978: Add configuration file for Crowdin CLI

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,29 @@
+#
+# Your Crowdin credentials
+#
+"project_id": "420172"                    # Crowdin project Settings > API & Webhooks > API > Project Id
+"api_token_env": "CROWDIN_PERSONAL_TOKEN" # Low priority: superseded by user-specific credentials file ~/.crowdin.yaml
+"base_path": "."
+"base_url": "https://api.crowdin.com"
+
+#
+# Choose file structure in Crowdin
+# e.g. true or false
+#
+"preserve_hierarchy": true
+
+#
+# Files configuration
+#
+files:
+  [
+    {
+      "source": "/src/locale/en-US.json",
+      "translation": "/src/locale/%locale%.json",
+    },
+    # Duplicate file
+    {
+      "source": "/src/locale/en.json",
+      "translation": "/src/locale/%two_letters_code%.json",
+    },
+  ]


### PR DESCRIPTION
## Description

[Crowdin](https://crowdin.com) is a cloud-based localization platform used to manage multilingual content. 

We will use Crowdin to manage the text that appears in the user interface of Symphony client apps. 

Epic [I18N-968](https://perzoinc.atlassian.net/browse/I18N-968) tracks tasks required to integrate the platform with our clients. (For details, see [Crowdin Sync Process](https://docs.google.com/document/d/1kp_j-l6psNEYcRZ0HmFC57y1yeZ0kMi3pA7kLcMg4AE).)

## Required changes

This PR adds a configuration file that describes which resources to manage: the files to be uploaded into Crowdin and the locations of the corresponding translations.

For details, see https://support.crowdin.com/cli-tool/.

✅ Tested with Crowdin CLI, source strings & translations are successfully uploaded.

## JIRA ticket

- Fixes [I18N-978](https://perzoinc.atlassian.net/browse/I18N-978)

## Related PRs

- [x] https://github.com/SymphonyOSF/SFE-Client-App/pull/17198
- [x] https://github.com/SymphonyOSF/SFE-Lite/pull/3226
- [x] https://github.com/SymphonyOSF/SIOS-Client-App/pull/4946
- [x] https://github.com/SymphonyOSF/SAndroid-Client-App/pull/3205 
- [ ] https://github.com/SymphonyOSF/SBE/pull/20877
- [x] https://github.com/SymphonyOSF/SFE-Login/pull/660
- [x] https://github.com/SymphonyOSF/SFE-RTC/pull/2335

notes: Add configuration file for Crowdin CLI