### PR TITLE
fix: SDA-2418: remove capturing all stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,8 +160,7 @@
     "react": "16.13.0",
     "react-dom": "16.13.0",
     "ref-napi": "1.4.3",
-    "shell-path": "2.1.0",
-    "systeminformation": "4.23.0"
+    "shell-path": "2.1.0"
   },
   "optionalDependencies": {
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#v1.0.9",

--- a/src/app/stats.ts
+++ b/src/app/stats.ts
@@ -1,6 +1,5 @@
 import { app } from 'electron';
 import * as os from 'os';
-import * as si from 'systeminformation';
 import { logger } from '../common/logger';
 
 export class AppStats {
@@ -17,7 +16,6 @@ export class AppStats {
         this.logAppMetrics();
         this.logConfigurationData();
         this.logAppEvents();
-        this.logAllStats();
     }
 
     /**
@@ -96,17 +94,6 @@ export class AppStats {
         logger.info(`stats: Resources Path? ${process.resourcesPath}`);
         logger.info(`stats: Chrome Version? ${process.versions.chrome}`);
         logger.info(`stats: Electron Version? ${process.versions.electron}`);
-    }
-
-    /**
-     * Log all system statistics
-     */
-    private async logAllStats() {
-        try {
-            logger.info(`All Data: ${JSON.stringify(await si.getAllData())}`);
-        } catch (e) {
-            logger.error(`Error gathering all data: ${e}`);
-        }
     }
 }
 


### PR DESCRIPTION
## Description
This change removes capturing all system information to decrease startup time.
[SDA-2418](https://perzoinc.atlassian.net/browse/SDA-2418)

## Solution Approach
N/A

## Related PRs
#1073 #1072 

notes: remove capturing extra system information to decrease startup time.