### PR TITLE
feat: SDA-2462 Auto launch symphony after installation complete

### DIFF
--- a/installer/win/WixSharpInstaller/Symphony.cs
+++ b/installer/win/WixSharpInstaller/Symphony.cs
@@ -26,7 +26,7 @@ class Script
         // desired contents of installation, and then we can simplify this bit.
         var project = new ManagedProject(productName,
             new Dir(@"%ProgramFiles%\" + productName,
-                new File(@"..\..\..\dist\win-unpacked\Symphony.exe",
+                new File(new Id("symphony_exe"), @"..\..\..\dist\win-unpacked\Symphony.exe",
                     // Create two shortcuts to the main Symphony.exe file, one on the desktop and one in the program menu
                     new FileShortcut(productName, @"%Desktop%") { IconFile = @"..\..\..\images\icon.ico" },
                     new FileShortcut(productName, @"%ProgramMenu%") { IconFile = @"..\..\..\images\icon.ico" }
@@ -109,9 +109,9 @@ class Script
             // The property values to compare against can be found here:
             //    https://docs.microsoft.com/en-us/windows/win32/msi/operating-system-property-values
             new LaunchCondition("VersionNT>=600 AND WindowsBuild>=6001", "OS not supported"),
-            
+
             // Add registry entry used by protocol handler to launch symphony when opening symphony:// URIs
-            new RegValue(WixSharp.RegistryHive.ClassesRoot, productName + @"\shell\open\command", "", "\"[INSTALLDIR]Symphony.exe\" \"%1\"")            
+            new RegValue(WixSharp.RegistryHive.ClassesRoot, productName + @"\shell\open\command", "", "\"[INSTALLDIR]Symphony.exe\" \"%1\"")
         );
 
         // The build script which calls the wix# builder, will be run from a command environment which has %SYMVER% set.
@@ -173,7 +173,10 @@ class Script
             // We have some registry keys which are added by the SDA application when it is first launched. This custom
             // action will clean up those keys on uninstall. The name/location of keys have changed between different
             // versions of SDA, so we clean up all known variations, and ignore any missing ones.
-            new ElevatedManagedAction(CustomActions.CleanRegistry, Return.ignore, When.After, Step.RemoveFiles, Condition.Installed )
+            new ElevatedManagedAction(CustomActions.CleanRegistry, Return.ignore, When.After, Step.RemoveFiles, Condition.Installed ),
+
+            // Start Symphony after installation is complete
+            new InstalledFileAction("symphony_exe", "", Return.asyncNoWait, When.After, Step.InstallFinalize, Condition.NOT_Installed)
         };
 
         // Use our own Symphony branded bitmap for installation dialogs


### PR DESCRIPTION
## Description
Auto launch symphony after installation complete
[SDA-2462](https://perzoinc.atlassian.net/browse/SDA-2462)

## Solution Approach
By giving the main exe file an Id when added, we can use an InstalledFileAction referring to that Id to launch it no matter where it was installed to.

notes: auto launch symphony after installation complete