### PR TITLE
fix: SDA-2421: copy config on startup

### DIFF
--- a/src/app/config-handler.ts
+++ b/src/app/config-handler.ts
@@ -291,12 +291,12 @@ class Config {
     public async updateUserConfigOnStart() {
         logger.info(`config-handler: updating user config with the latest global config values`);
         const latestGlobalConfig = this.globalConfig as IConfig;
+        // The properties set below are typically controlled by IT admins, so, we copy
+        // all the values from global config to the user config on SDA relaunch
         await this.updateUserConfig({
             whitelistUrl: latestGlobalConfig.whitelistUrl,
             memoryThreshold: latestGlobalConfig.memoryThreshold,
             devToolsEnabled: latestGlobalConfig.devToolsEnabled,
-            disableGpu: latestGlobalConfig.disableGpu,
-            enableRendererLogs: latestGlobalConfig.enableRendererLogs,
             ctWhitelist: latestGlobalConfig.ctWhitelist,
             podWhitelist: latestGlobalConfig.podWhitelist,
             permissions: latestGlobalConfig.permissions,

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -86,6 +86,8 @@ const startApplication = async () => {
             await autoLaunchInstance.handleAutoLaunch();
         }
     }
+    // Picks global config values and updates them in the user config
+    await config.updateUserConfigOnStart();
     // Setup session properties only after app ready
     setSessionProperties();
     await windowHandler.createApplication();


### PR DESCRIPTION
## Description
- Currently, if a user config file is already present, and if any changes are made to any parameter in the global config file, they don't get reflected in the user config file. This can be a problem for IT administrators whose changes to the global config file don't reflect.
- This PR addresses that problem by copying over config values that do not affect user settings but helps IT admins.
[SDA-2421](https://perzoinc.atlassian.net/browse/SDA-2421)

## Solution Approach
- Copy the relevant global config values to user config on startup
- Also format the user config and cloud config files on write

## Related PRs
N/A

notes: copy global config values to user config on startup