### PR TITLE
fix: SDA-2476 Handling user having swapped left/right mouse buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "shell-path": "2.1.0"
   },
   "optionalDependencies": {
-    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#v1.0.9",
+    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#v1.0.10",
     "screen-share-indicator-frame": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#v1.4.10",
     "swift-search": "2.0.2"
   },


### PR DESCRIPTION
## Description
If the user have swapped left/right mouse button in control panel, the snippet tool was behaving incorrectly.
[SDA-2476](https://perzoinc.atlassian.net/browse/SDA-2476)

## Solution Approach
This fix detects if that setting has been changed, and swaps left/right button as necessary when calling GetAsyncKeyState. Note that the use of WM_LBUTTONDOWN does not need to be modified, as that is handled automatically by windows - but GetAsyncKeyState is not (see the Remarks section of https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getasynckeystate)

notes: Handling user having swapped left/right mouse buttons