### PR TITLE
fix: SDA-2524, SDA-2525: upgrade electron to 9.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "browserify": "16.5.1",
     "cross-env": "5.2.0",
     "del": "3.0.0",
-    "electron": "9.2.1",
+    "electron": "9.3.2",
     "electron-builder": "22.7.0",
     "electron-builder-squirrel-windows": "20.38.3",
     "electron-icon-maker": "0.0.4",


### PR DESCRIPTION
## Description
Upgrade electron to the latest version 9.3.2 to mitigate security risks.
[SDA-2524](https://perzoinc.atlassian.net/browse/SDA-2524)
[SDA-2525](https://perzoinc.atlassian.net/browse/SDA-2525)

## Solution Approach
Upgrade electron dependency to the latest 9.3.2 version

## Related PRs
#1089 

notes: upgrade electron to 9.3.2