### PR TITLE
fix: SDA-2171 Fix for screen snippet offset on windows 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "shell-path": "2.1.0"
   },
   "optionalDependencies": {
-    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#v1.0.10",
+    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#v1.0.11",
     "screen-share-indicator-frame": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#v1.4.10",
     "swift-search": "2.0.2"
   },


### PR DESCRIPTION
## Description
When running windows 7 and using the classic theme, the screen snippet gets offset by a small amount. 
[SDA-2171](https://perzoinc.atlassian.net/browse/SDA-2171)

## Solution Approach
I don't know what is causing it, but found that by adding a call to set the position of the window after it's been initialized seems to fix it without any adverse effects on other themes or OS versions.

notes: Fix for screen snippet offset on windows 7