### PR TITLE
fix: SDA-2516 Extract programs folder location into property

### DIFF
--- a/installer/win/WixSharpInstaller/Symphony.cs
+++ b/installer/win/WixSharpInstaller/Symphony.cs
@@ -157,7 +157,8 @@ class Script
             new PublicProperty("OPEN_EXTERNAL", "true"),
             new PublicProperty("POD_URL", "https://my.symphony.com"),
             new PublicProperty("POINTER_LOCK", "true"),
-            new Property("MSIINSTALLPERUSER", "1")
+            new Property("MSIINSTALLPERUSER", "1"),
+            new Property("PROGRAMSFOLDER", System.Environment.ExpandEnvironmentVariables(@"%PROGRAMFILES%"))
         };
 
         // Define the custom actions we want to run, and at what point of the installation we want to execute them.

--- a/installer/win/WixSharpInstaller/WelcomeDlg.cs
+++ b/installer/win/WixSharpInstaller/WelcomeDlg.cs
@@ -51,7 +51,7 @@ namespace Symphony
             {
                 // Install for all users
                 Runtime.Session["MSIINSTALLPERUSER"] = ""; // per-machine
-                Runtime.Session["INSTALLDIR"] = System.Environment.ExpandEnvironmentVariables(@"%PROGRAMFILES%\" + Runtime.ProductName);
+                Runtime.Session["INSTALLDIR"] = Runtime.Session["PROGRAMSFOLDER"] + @"\" + Runtime.ProductName;
             }
 
             Shell.GoNext();


### PR DESCRIPTION
## Description
The windows installer runs UI as 32 bit process even if installer is 32 bit, so the %PROGRAMFILES% resolves to  C:\Program Files(x86) instead of C:\Program Files.
[SDA-2516](https://perzoinc.atlassian.net/browse/SDA-2516)

## Solution Approach
Resolve %PROGRAMFILES% before UI, and pass it through a property instead of resolving it in the UI.

notes: Extract programs folder location into property