### PR TITLE
fix: SDA-2516 Added missing 'Symphony' to paths

### DIFF
--- a/installer/win/WixSharpInstaller/WelcomeDlg.cs
+++ b/installer/win/WixSharpInstaller/WelcomeDlg.cs
@@ -46,12 +46,12 @@ namespace Symphony
             {
                 // Install for current user
                 Runtime.Session["MSIINSTALLPERUSER"] = "1"; // per-user
-                Runtime.Session["INSTALLDIR"] = System.Environment.ExpandEnvironmentVariables(@"%LOCALAPPDATA%\Apps\" + Runtime.ProductName);
+                Runtime.Session["INSTALLDIR"] = System.Environment.ExpandEnvironmentVariables(@"%LOCALAPPDATA%\Apps\Symphony\" + Runtime.ProductName);
             } else if (radioButtonAllUsers.Checked)
             {
                 // Install for all users
                 Runtime.Session["MSIINSTALLPERUSER"] = ""; // per-machine
-                Runtime.Session["INSTALLDIR"] = Runtime.Session["PROGRAMSFOLDER"] + @"\" + Runtime.ProductName;
+                Runtime.Session["INSTALLDIR"] = Runtime.Session["PROGRAMSFOLDER"]  + @"\Symphony\" + Runtime.ProductName;
             }
 
             Shell.GoNext();


### PR DESCRIPTION
## Description
Paths should be on the form CompanyName\ProductName, so in our case Symphony\Symphony, but there is only one Symphony
[SDA-2516](https://perzoinc.atlassian.net/browse/SDA-2516)

## Solution Approach
Added a second Symphony for company name

notes: Added missing 'Symphony' to paths