### PR TITLE
fix: SDA-2511 Making back button work from InstallDir screen

### DIFF
--- a/installer/win/WixSharpInstaller/CloseDlg.cs
+++ b/installer/win/WixSharpInstaller/CloseDlg.cs
@@ -5,6 +5,8 @@ namespace Symphony
 {
     public partial class CloseDlg : WixSharp.UI.Forms.ManagedForm, IManagedDialog
     {
+        const int WelcomeDlgIndex = 0;
+        const int InstallDirIndex = 1;
 
         public CloseDlg()
         {
@@ -20,11 +22,6 @@ namespace Symphony
                 // If it is running, disable the "next" button
                 this.next.Enabled = false;
             }
-            else
-            {
-                // If it is not running, skip this dialog
-                Shell.GoNext();
-            }
 
             // Populate the dynamic UI elements that can't be set at compile time (background image and
             // the enabled/disabled state of the `Close Symphony` button)
@@ -35,17 +32,17 @@ namespace Symphony
         {
             // The "Close Symphony" button is just to get users consent to close the app.
             // Actually closing the app will be done later in the flow.
-            Shell.GoNext();
+            Shell.GoTo(InstallDirIndex);
         }
 
         void back_Click(object sender, System.EventArgs e)
         {
-            Shell.GoPrev();
+            Shell.GoTo(WelcomeDlgIndex);
         }
 
         void next_Click(object sender, System.EventArgs e)
         {
-            Shell.GoNext();
+            Shell.GoTo(InstallDirIndex);
         }
 
         void cancel_Click(object sender, System.EventArgs e)

--- a/installer/win/WixSharpInstaller/Symphony.cs
+++ b/installer/win/WixSharpInstaller/Symphony.cs
@@ -205,10 +205,10 @@ class Script
         // Define our own installation flow, using a mix of custom dialogs (defined in their own files) and built-in dialogs
         project.ManagedUI = new ManagedUI();
         project.ManagedUI.InstallDialogs.Add<Symphony.WelcomeDlg>()
-                                        .Add<Symphony.CloseDlg>()
                                         .Add(Dialogs.InstallDir)
                                         .Add(Dialogs.Progress)
-                                        .Add<Symphony.ExitDlg>();
+                                        .Add<Symphony.ExitDlg>()
+                                        .Add<Symphony.CloseDlg>();
         project.ManagedUI.ModifyDialogs.Add<Symphony.MaintenanceDlg>()
                                        .Add(Dialogs.MaintenanceType)
                                        .Add(Dialogs.Progress)

--- a/installer/win/WixSharpInstaller/WelcomeDlg.cs
+++ b/installer/win/WixSharpInstaller/WelcomeDlg.cs
@@ -54,7 +54,18 @@ namespace Symphony
                 Runtime.Session["INSTALLDIR"] = Runtime.Session["PROGRAMSFOLDER"]  + @"\Symphony\" + Runtime.ProductName;
             }
 
-            Shell.GoNext();
+            // Detect if Symphony is running
+            bool isRunning = System.Diagnostics.Process.GetProcessesByName("Symphony").Length > 0;
+            if (isRunning)
+            {
+                // If it is running, continue to the "Close Symphony" screen
+                Shell.GoTo<Symphony.CloseDlg>();
+            }
+            else
+            {
+                // If it is not running, proceed to InstallDir dialog
+                Shell.GoNext();
+            }
         }
 
         void cancel_Click(object sender, System.EventArgs e)


### PR DESCRIPTION
## Description
The Back button was not working from the Install Dir screen. This was caused by the Close Symphony screen, which would skip past itself if Symphony is not running, giving the appearance that Back button did nothing
[SDA-2511](https://perzoinc.atlassian.net/browse/SDA-2511)

## Solution Approach
Change the flow of the dialogs, to make the Welcome screen go to the Close Symphony screen only when Symphony is running, and manually control the flow from the Close Symphony screen 

notes: Making back button work from InstallDir screen