### PR TITLE
fix: SDA-2559: Delete app cache on Install

### DIFF
--- a/spec/appCacheHandler.spec.ts
+++ b/spec/appCacheHandler.spec.ts
@@ -8,7 +8,7 @@ jest.mock('fs', () => ({
     writeFileSync: jest.fn(),
     existsSync: jest.fn(() => true),
     unlinkSync: jest.fn(),
-    readdirSync: jest.fn(() => ['fake1', 'fake2', 'Symphony.config', 'cloudConfig.config']),
+    readdirSync: jest.fn(() => ['Cache', 'GPUCache', 'Symphony.config', 'cloudConfig.config']),
     lstatSync: jest.fn(() => {
         return {
             isDirectory: jest.fn(() => true),

--- a/src/app/app-cache-handler.ts
+++ b/src/app/app-cache-handler.ts
@@ -14,14 +14,13 @@ const cacheCheckFilePath: string = path.join(userDataPath, 'CacheCheck');
  * Cleans old cache
  */
 const cleanOldCache = (): void => {
-    const configFilename = 'Symphony.config';
-    const cloudConfigFilename = 'cloudConfig.config';
+    const fileRemovalList = ['blob_storage', 'Cache', 'Cookies', 'temp', 'Cookies-journal', 'GPUCache'];
 
     const files = fs.readdirSync(userDataPath);
 
     files.forEach((file) => {
         const filePath = path.join(userDataPath, file);
-        if (file === configFilename || file === cloudConfigFilename) {
+        if (!fileRemovalList.includes(file)) {
             return;
         }
 


### PR DESCRIPTION
## Description
As opposed to how it was done in #1091, we only delete a select set of directories now that are related to the cache.
[SDA-2559](https://perzoinc.atlassian.net/browse/SDA-2559)

## Solution Approach
Only delete a select set of directories related to the cache.

## Related PRs
#1091 

Notes: Delete app cache on Install & Crash