### PR TITLE
fix: SDA-2526 Display uninstall confirmation dialog

### DIFF
--- a/installer/win/WixSharpInstaller/Symphony.cs
+++ b/installer/win/WixSharpInstaller/Symphony.cs
@@ -215,6 +215,7 @@ class Script
                                        .Add<Symphony.ExitDlg>();
 
         project.Load += project_Load;
+        project.BeforeInstall += project_BeforeInstall;
 
         project.Platform = Platform.x64;
 
@@ -253,6 +254,25 @@ class Script
         }
     }
 
+    static void project_BeforeInstall(SetupEventArgs e)
+    {
+        try
+        {
+            if (e.IsUninstalling)
+            {
+                var result = System.Windows.Forms.MessageBox.Show("Are you sure you want to uninstall this product?",
+                    "Windows Installer", System.Windows.Forms.MessageBoxButtons.YesNo);
+                if (result != System.Windows.Forms.DialogResult.Yes)
+                {
+                    e.Result = ActionResult.UserExit; // Signal to installer to exit
+                }
+            }
+        }
+        catch (System.Exception ex)
+        {
+            e.Session.Log("Error displaying uninstall confirmation dialog: " + ex.ToString() );
+        }
+    }
 }
 
 public class CustomActions

--- a/installer/win/WixSharpInstaller/Symphony.cs
+++ b/installer/win/WixSharpInstaller/Symphony.cs
@@ -254,6 +254,7 @@ class Script
         }
     }
 
+    // Display a confirmation dialog when uninstalling Symphony, and cancel uninstall unless user confirms.
     static void project_BeforeInstall(SetupEventArgs e)
     {
         try


### PR DESCRIPTION
## Description
By default, wixsharp does not display a confirmation dialog on uninstall, like the previous installer did
[SDA-2526](https://perzoinc.atlassian.net/browse/SDA-2526)

## Solution Approach
Added a dialog box on uninstall, to let user confirm uninstall.

Notes: Display uninstall confirmation dialog