### PR TITLE
fix: screen-share indicator zoomed in

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -1263,6 +1263,11 @@ export class WindowHandler {
         if (!focusedWindow || !windowExists(focusedWindow)) {
             return;
         }
+
+        if (focusedWindow.getTitle() === 'Screen Sharing Indicator - Symphony') {
+            return;
+        }
+
         // electron/lib/browser/api/menu-item-roles.js row 159
         const currentZoomLevel = focusedWindow.webContents.getZoomLevel();
         focusedWindow.webContents.setZoomLevel(currentZoomLevel + 0.5);

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -1029,6 +1029,8 @@ export class WindowHandler {
             if (!this.screenSharingIndicatorWindow || !windowExists(this.screenSharingIndicatorWindow)) {
                 return;
             }
+            this.screenSharingIndicatorWindow.webContents.setZoomFactor(1);
+            this.screenSharingIndicatorWindow.webContents.setVisualZoomLevelLimits(1, 1);
             this.screenSharingIndicatorWindow.webContents.send('screen-sharing-indicator-data', { id, streamId });
         });
         const stopScreenSharing = (_event, indicatorId) => {


### PR DESCRIPTION
Two mac users have pinged me and said/showed the screen share indicator is zoomed.
1) Always reset zoom at start of the screen-sharing indicator
2) onZoomIn for mac, disregard if it is the screen-sharing indicator

Note: Tried on windows, can not zoom in/out on the screen-share indicator. Only on mac

Notes: fix screen-share indicator zoomed in