### PR TITLE
feat: SDA-2170: set context isolation to true by default

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -125,7 +125,10 @@ export class WindowHandler {
         const { disableThrottling } = config.getCloudConfigFields(['disableThrottling']) as any;
 
         this.windows = {};
-        this.contextIsolation = this.globalConfig.contextIsolation || false;
+        this.contextIsolation = true;
+        if (this.globalConfig.contextIsolation !== undefined) {
+            this.contextIsolation = this.globalConfig.contextIsolation;
+        }
         this.backgroundThrottling = (customFlags.disableThrottling !== CloudConfigDataTypes.ENABLED || disableThrottling !== CloudConfigDataTypes.ENABLED);
         this.isCustomTitleBar = isWindowsOS && this.config.isCustomTitleBar === CloudConfigDataTypes.ENABLED;
         this.windowOpts = {


### PR DESCRIPTION
## Description
Set `Context Isolation` to true by default in the window handler
[SDA-2170](https://perzoinc.atlassian.net/browse/SDA-2170)

## Solution Approach
- If there's no config value for context isolation, set it to true by default

Notes: set context isolation to true by default