### PR TITLE
fix: SDA-2593 Disabled cancel button in progress dialog

### DIFF
--- a/installer/win/WixSharpInstaller/ProgressDialog.Designer.cs
+++ b/installer/win/WixSharpInstaller/ProgressDialog.Designer.cs
@@ -170,6 +170,7 @@ namespace Symphony
             this.cancel.Text = "[WixUICancel]";
             this.cancel.UseVisualStyleBackColor = true;
             this.cancel.Click += new System.EventHandler(this.cancel_Click);
+            this.cancel.Enabled = false;
             //
             // bottomBorder
             //


### PR DESCRIPTION
## Description
In the flow as originally defined, the cancel button on the progress dialog, while technically working (at the end of install, if cancelled had been pressed the installation was rolled back), it made for a confusing user experience
[SDA-2593](https://perzoinc.atlassian.net/browse/SDA-2593)

## Solution Approach
Disabled the cancel button on the progress dialog

notes: Disabled cancel button in progress dialog