### PR TITLE
chore: SDA-2451: add support to run snyk monitor on build scripts

### DIFF
--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -2,6 +2,7 @@
 
 NODE_REQUIRED_VERSION=v12.13.1
 SNYK_ORG=sda
+SNYK_PROJECT_NAME="Symphony Desktop Application"
 
 if ! [ -x "$(command -v git)" ]; then
   echo 'GIT does not exist! Please set it up before running this script!' >&2
@@ -69,7 +70,8 @@ npm install
 
 # Run Snyk Security Tests
 echo "Running snyk security tests"
-snyk test --file=package.json --org="$SNYK_ORG"
+snyk test --file=package-lock.json --org="$SNYK_ORG"
+snyk monitor --file=package-lock.json --org="$SNYK_ORG" --project-name="$SNYK_PROJECT_NAME"
 
 # replace url in config
 echo "Setting default pod url to https://corporate.symphony.com"

--- a/scripts/build-mac.sh
+++ b/scripts/build-mac.sh
@@ -2,6 +2,7 @@
 
 NODE_REQUIRED_VERSION=v12.13.1
 SNYK_ORG=sda
+SNYK_PROJECT_NAME="Symphony Desktop Application"
 
 # Check basic dependencies
 if ! [ -x "$(command -v git)" ]; then
@@ -85,7 +86,8 @@ codesign --force --options runtime -s "Developer ID Application: Symphony Commun
 
 # Run Snyk Security Tests
 echo "Running snyk security tests"
-snyk test --file=package.json --org="$SNYK_ORG"
+snyk test --file=package-lock.json --org="$SNYK_ORG"
+snyk monitor --file=package-lock.json --org="$SNYK_ORG" --project-name="$SNYK_PROJECT_NAME"
 
 # Replace url in config
 echo "Setting default pod url to https://my.symphony.com"

--- a/scripts/build-win32.bat
+++ b/scripts/build-win32.bat
@@ -7,6 +7,7 @@ echo %PATH%
 set DISABLE_REBUILD=true
 set NODE_REQUIRED_VERSION=12.13.1
 set SNYK_ORG=sda
+set SNYK_PROJECT_NAME="Symphony Desktop Application"
 
 set PATH=%PATH%;C:\Program Files\nodejs\;C:\Program Files\Git\cmd
 echo %PATH%
@@ -56,7 +57,8 @@ call npm install
 
 # Run Snyk Security Tests
 echo "Running snyk security tests"
-call snyk test --file=package.json --org=%SNYK_ORG%
+call snyk test --file=package-lock.json --org=%SNYK_ORG%
+call snyk monitor --file=package-lock.json --org=%SNYK_ORG% --project-name=%SNYK_PROJECT_NAME%
 
 :: Set expiry if required
 IF "%EXPIRY_PERIOD%"=="" (

--- a/scripts/build-win64.bat
+++ b/scripts/build-win64.bat
@@ -7,6 +7,7 @@ echo %PATH%
 set DISABLE_REBUILD=true
 set NODE_REQUIRED_VERSION=12.13.1
 set SNYK_ORG=sda
+set SNYK_PROJECT_NAME="Symphony Desktop Application"
 
 set PATH=%PATH%;C:\Program Files\nodejs\;C:\Program Files\Git\cmd
 echo %PATH%
@@ -44,7 +45,8 @@ call npm install
 
 # Run Snyk Security Tests
 echo "Running snyk security tests"
-call snyk test --file=package.json --org=%SNYK_ORG%
+call snyk test --file=package-lock.json --org=%SNYK_ORG%
+call snyk monitor --file=package-lock.json --org=%SNYK_ORG% --project-name=%SNYK_PROJECT_NAME%
 
 :: Set expiry if required
 IF "%EXPIRY_PERIOD%"=="" (


### PR DESCRIPTION
## Description
Add support to run `snyk monitor` in the build pipeline along with `snyk test` to support snapshot testing directly on Snyk.
[SDA-2451](https://perzoinc.atlassian.net/browse/SDA-2451)

## Solution Approach
Add `snyk monitor` command in the shell script (Mac, Linux) and batch script (Windows)

## Related PRs
N/A

Notes: add support to run snyk monitor on build scripts