### PR TITLE
fix: SDA-2651 Using EndSession message to terminate SDA on uninstall

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -534,6 +534,19 @@ export class WindowHandler {
       },
     );
 
+    // When uninstalling Symphony, the installer needs to tell the app to close down
+    // The dedault way of doing this, is to send the 'close' event to the app, but
+    // since we intercept and ignore the 'close' event if the user have turned on the
+    // option "minimize on close", we use an alternative way of signalling that the
+    // application should terminate. The installer sends the 'session-end' message
+    // instead of the 'close' message, and when we receive it, we quit the app.
+    this.mainWindow.on('session-end', () => {
+      logger.info(
+        `window-handler: session-end received`,
+      );
+      app.quit();
+    });
+
     // Handle main window close
     this.mainWindow.on('close', (event) => {
       if (!this.mainWindow || !windowExists(this.mainWindow)) {


### PR DESCRIPTION
## Description
There's a crash while trying to uninstall the SDA on the 1st try.
Note: User can uninstall SDA successfully on the 2nd try.
[SDA-2651](https://perzoinc.atlassian.net/browse/SDA-2651)

## Solution Approach
When installing or uninstalling, we want Symphony to be closed down, but the standard way of sending a WM_CLOSE message will not work for us, as we have a "minimize on close" option, which stops the app from terminating on WM_CLOSE. So we instruct the installer to not send a Close message, but instead send the EndSession message, and we have a custom event handler in the SDA code which listens for this message, and ensures app termination when it is received.

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
other_pr_dev | [link]()

Notes: FIxed uninstall shutdown