### PR TITLE
fix: SDA-2694: fix blank screen issues occurred by app cache deletion

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -60,7 +60,7 @@
       "outFiles": [
         "${workspaceFolder}/lib/**/*.js"
       ]
-    }
+    },
     {
       "name": "demo",
       "type": "node",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "browserify": "16.5.1",
     "cross-env": "5.2.0",
     "del": "3.0.0",
-    "electron": "9.3.2",
+    "electron": "9.3.5",
     "electron-builder": "22.7.0",
     "electron-builder-squirrel-windows": "20.38.3",
     "electron-icon-maker": "0.0.4",

--- a/src/app/config-handler.ts
+++ b/src/app/config-handler.ts
@@ -403,9 +403,12 @@ class Config {
         }
         logger.info(`config-handler: install variant is the same as the existing one, not a first time launch`);
         this.isFirstTime = false;
-        if (this.bootCount) {
+        this.bootCount = (this.getConfigFields(['bootCount']) as IConfig).bootCount;
+        if (this.bootCount !== undefined) {
             this.bootCount++;
             await this.updateUserConfig({ bootCount: this.bootCount });
+        } else {
+            await this.updateUserConfig({ bootCount: 0 });
         }
     }
 }

--- a/src/app/config-handler.ts
+++ b/src/app/config-handler.ts
@@ -38,6 +38,7 @@ export interface IConfig {
     mainWinPos?: ICustomRectangle;
     locale?: string;
     installVariant?: string;
+    bootCount?: number;
 }
 
 export interface IGlobalConfig {
@@ -116,6 +117,7 @@ class Config {
     public filteredCloudConfig: ICloudConfig | {};
     private isFirstTime: boolean = true;
     private installVariant: string | undefined;
+    private bootCount: number | undefined;
     private readonly configFileName: string;
     private readonly installVariantFilename: string;
     private readonly installVariantPath: string;
@@ -276,10 +278,19 @@ class Config {
             // update to the new build number
             filteredFields.buildNumber = buildNumber;
             filteredFields.installVariant = this.installVariant;
+            filteredFields.bootCount = 0;
             logger.info(`config-handler: setting first time launch for build`, buildNumber);
             return await this.updateUserConfig(filteredFields);
         }
-        await this.updateUserConfig({ buildNumber, installVariant: this.installVariant });
+        await this.updateUserConfig({ buildNumber, installVariant: this.installVariant, bootCount: this.bootCount });
+    }
+
+    /**
+     * Gets the boot count for an SDA installation
+     */
+    public getBootCount(): number | undefined {
+        logger.info(`config-handler: Current boot count is ${this.bootCount}`);
+        return this.bootCount;
     }
 
     /**
@@ -289,9 +300,9 @@ class Config {
         const { acpFeatureLevelEntitlements, podLevelEntitlements, pmpEntitlements } = this.cloudConfig as ICloudConfig;
 
         // Filter out some values
-        const filteredACP = filterOutSelectedValues(acpFeatureLevelEntitlements, [ true, 'NOT_SET', '', [] ]);
-        const filteredPod = filterOutSelectedValues(podLevelEntitlements, [ true, 'NOT_SET', '', [] ]);
-        const filteredPMP = filterOutSelectedValues(pmpEntitlements, [ true, 'NOT_SET', '', [] ]);
+        const filteredACP = filterOutSelectedValues(acpFeatureLevelEntitlements, [true, 'NOT_SET', '', []]);
+        const filteredPod = filterOutSelectedValues(podLevelEntitlements, [true, 'NOT_SET', '', []]);
+        const filteredPMP = filterOutSelectedValues(pmpEntitlements, [true, 'NOT_SET', '', []]);
 
         // priority is PMP > ACP > SDA
         this.filteredCloudConfig = { ...filteredACP, ...filteredPod, ...filteredPMP };
@@ -380,16 +391,22 @@ class Config {
         if (!installVariant) {
             logger.info(`config-handler: there's no install variant found, this is a first time launch`);
             this.isFirstTime = true;
+            this.bootCount = 0;
             return;
         }
 
         if (installVariant && typeof installVariant === 'string' && installVariant !== this.installVariant) {
             logger.info(`config-handler: install variant found is of a different instance, this is a first time launch`);
             this.isFirstTime = true;
+            this.bootCount = 0;
             return;
         }
         logger.info(`config-handler: install variant is the same as the existing one, not a first time launch`);
         this.isFirstTime = false;
+        if (this.bootCount) {
+            this.bootCount++;
+            await this.updateUserConfig({ bootCount: this.bootCount });
+        }
     }
 }
 

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -71,8 +71,8 @@ if (!isDevEnv) {
  */
 const restartOnFirstInstall = async (): Promise<void> => {
     const bootCount = config.getBootCount();
-    if (bootCount !== undefined && bootCount < 1) {
-        logger.warn(`Boot count fits the criteria of lesser than or equal to 1, restarting the app`);
+    if (bootCount !== undefined && bootCount === 1) {
+        logger.warn(`Boot count fits the criteria of equal to 1, restarting the app`);
         app.relaunch();
         app.quit();
     }
@@ -94,7 +94,6 @@ const startApplication = async () => {
         }
     }
     await app.whenReady();
-    restartOnFirstInstall();
     if (oneStart) {
         return;
     }
@@ -104,6 +103,7 @@ const startApplication = async () => {
     createAppCacheFile();
     setSessionProperties();
     await windowHandler.createApplication();
+    restartOnFirstInstall();
     logger.info(`main: created application`);
 };
 

--- a/src/app/version-handler.ts
+++ b/src/app/version-handler.ts
@@ -1,4 +1,4 @@
-import { app, net } from 'electron';
+import { net } from 'electron';
 import * as nodeURL from 'url';
 import { buildNumber, clientVersion, optionalDependencies, searchAPIVersion, sfeVersion, version } from '../../package.json';
 import { logger } from '../common/logger';
@@ -171,8 +171,6 @@ class VersionHandler {
                 res.on('error', (error: Error) => {
                     logger.error(`version-handler: Error getting SFE version data from the server! ${error}`);
                     resolve(this.versionInfo);
-                    // Restart the app to resolve network issues
-                    this.restart();
                     return;
                 });
 
@@ -194,19 +192,6 @@ class VersionHandler {
 
             requestSfeVersion.end();
         });
-    }
-
-    /**
-     * Restarts the app in case of network issues
-     */
-    private async restart(): Promise<void> {
-        const bootCount = config.getBootCount();
-        if (bootCount && bootCount <= 1) {
-            logger.warn(`Boot count fits the criteria of lesser than or equal to 1, restarting the app`);
-            app.relaunch();
-            app.quit();
-        }
-        logger.warn(`Boot count does not fit the criteria of lesser than or equal to 1, not restarting the app`);
     }
 
 }

--- a/src/app/version-handler.ts
+++ b/src/app/version-handler.ts
@@ -1,4 +1,4 @@
-import { net } from 'electron';
+import { app, net } from 'electron';
 import * as nodeURL from 'url';
 import { buildNumber, clientVersion, optionalDependencies, searchAPIVersion, sfeVersion, version } from '../../package.json';
 import { logger } from '../common/logger';
@@ -76,7 +76,8 @@ class VersionHandler {
             }
 
             if (!this.mainUrl) {
-                logger.error(`version-handler: Unable to get pod url for getting version data from server! Setting defaults!`);
+                logger.error(`version-handler: Unable to get pod url for getting version data from server!`);
+                logger.info(`version-handler: Setting defaults -> ${JSON.stringify(this.versionInfo)}`);
                 resolve(this.versionInfo);
                 return;
             }
@@ -170,6 +171,8 @@ class VersionHandler {
                 res.on('error', (error: Error) => {
                     logger.error(`version-handler: Error getting SFE version data from the server! ${error}`);
                     resolve(this.versionInfo);
+                    // Restart the app to resolve network issues
+                    this.restart();
                     return;
                 });
 
@@ -191,6 +194,19 @@ class VersionHandler {
 
             requestSfeVersion.end();
         });
+    }
+
+    /**
+     * Restarts the app in case of network issues
+     */
+    private async restart(): Promise<void> {
+        const bootCount = config.getBootCount();
+        if (bootCount && bootCount <= 1) {
+            logger.warn(`Boot count fits the criteria of lesser than or equal to 1, restarting the app`);
+            app.relaunch();
+            app.quit();
+        }
+        logger.warn(`Boot count does not fit the criteria of lesser than or equal to 1, not restarting the app`);
     }
 
 }

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -309,18 +309,17 @@ export class WindowHandler {
         const logEvents = [
             'did-fail-provisional-load', 'did-frame-finish-load',
             'did-start-loading', 'did-stop-loading', 'will-redirect',
-            'did-navigate', 'did-navigate-in-page', 'destroyed', 'preload-error',
+            'did-navigate', 'did-navigate-in-page', 'preload-error',
         ];
 
         logEvents.forEach((windowEvent: any) => {
-            this.mainWindow?.webContents.on(windowEvent, (event: Electron.Event) => {
+            this.mainWindow?.webContents.on(windowEvent, () => {
                 logger.info(`window-handler: Main Window Event Occurred: ${windowEvent}`);
-                logger.info(`Event details: ${JSON.stringify(event)}`);
             });
         });
 
         this.mainWindow.once('ready-to-show', (event: Electron.Event) => {
-            logger.info(`window-handler: Main Window ready to show: ${JSON.stringify(event)}`);
+            logger.info(`window-handler: Main Window ready to show: ${event}`);
         });
 
         this.mainWindow.webContents.on('did-finish-load', async () => {

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -286,6 +286,7 @@ export class WindowHandler {
 
         cleanAppCacheOnCrash(this.mainWindow);
         // loads the main window with url from config/cmd line
+        logger.info(`Loading main window with url ${this.url}`);
         this.mainWindow.loadURL(this.url);
         // check for build expiry in case of test builds
         this.checkExpiry(this.mainWindow);
@@ -303,6 +304,23 @@ export class WindowHandler {
             // monitors network connection and
             // displays error banner on failure
             monitorNetworkInterception(this.url || this.userConfig.url || this.globalConfig.url);
+        });
+
+        const logEvents = [
+            'did-fail-provisional-load', 'did-frame-finish-load',
+            'did-start-loading', 'did-stop-loading', 'will-redirect',
+            'did-navigate', 'did-navigate-in-page', 'destroyed', 'preload-error',
+        ];
+
+        logEvents.forEach((windowEvent: any) => {
+            this.mainWindow?.webContents.on(windowEvent, (event: Electron.Event) => {
+                logger.info(`window-handler: Main Window Event Occurred: ${windowEvent}`);
+                logger.info(`Event details: ${JSON.stringify(event)}`);
+            });
+        });
+
+        this.mainWindow.once('ready-to-show', (event: Electron.Event) => {
+            logger.info(`window-handler: Main Window ready to show: ${JSON.stringify(event)}`);
         });
 
         this.mainWindow.webContents.on('did-finish-load', async () => {


### PR DESCRIPTION
## Description
- Move the logic of deleting app cache on install to before the app being initialized
- Add logic to force restart app on first install to avoid network issues
[SDA-2694](https://perzoinc.atlassian.net/browse/SDA-2694)

## Solution Approach
- Delete app cache before app is initialized to avoid blank screen issues

## Related PRs
N/A

Notes: fix blank screen issues occurred by app cache deletion