### PR TITLE
fix: SDA-2533 Fixed double scroll bars on windows

### DIFF
--- a/src/renderer/styles/snipping-tool.less
+++ b/src/renderer/styles/snipping-tool.less
@@ -5,6 +5,7 @@
 @text-padding: 10px;
 
 body {
+  overflow: hidden;
   background-color: white;
   margin: 0;
   height: 100%;


### PR DESCRIPTION
## Description
This PR fixes the bug on Windows with scroll bars both on window and image for annotate tool. No bug ticket was created since it was found during production, tested by @NavyaGopalakrishna.

Notes: Fix double scroll bars