### PR TITLE
feat: SDA-2650 Generate PDF with installation instruction

### DIFF
--- a/installer/win/install_instructions_win.md
+++ b/installer/win/install_instructions_win.md
@@ -1,0 +1,23 @@
+Windows Installer Instructions
+==============================
+
+Install parameters
+------------------
+ALLUSERS", "1"
+ALWAYS_ON_TOP", "DISABLED"
+AUTO_LAUNCH_PATH", ""
+AUTO_START", "ENABLED"
+BRING_TO_FRONT", "DISABLED"
+CUSTOM_TITLE_BAR", "ENABLED"
+DEV_TOOLS_ENABLED", "true"
+FULL_SCREEN", "true"
+LOCATION", "true"
+MEDIA", "true"
+MIDI_SYSEX", "true"
+MINIMIZE_ON_CLOSE", "ENABLED"
+NOTIFICATIONS", "true"
+OPEN_EXTERNAL", "true"
+POD_URL", "https://my.symphony.com"
+POINTER_LOCK", "true"
+MSIINSTALLPERUSER", "1"
+PROGRAMSFOLDER", System.Environment.ExpandEnvironmentVariables(@"%PROGRAMFILES%")

--- a/installer/win/install_instructions_win.md
+++ b/installer/win/install_instructions_win.md
@@ -3,21 +3,369 @@ Windows Installer Instructions
 
 Install parameters
 ------------------
-ALLUSERS", "1"
-ALWAYS_ON_TOP", "DISABLED"
-AUTO_LAUNCH_PATH", ""
-AUTO_START", "ENABLED"
-BRING_TO_FRONT", "DISABLED"
-CUSTOM_TITLE_BAR", "ENABLED"
-DEV_TOOLS_ENABLED", "true"
-FULL_SCREEN", "true"
-LOCATION", "true"
-MEDIA", "true"
-MIDI_SYSEX", "true"
-MINIMIZE_ON_CLOSE", "ENABLED"
-NOTIFICATIONS", "true"
-OPEN_EXTERNAL", "true"
-POD_URL", "https://my.symphony.com"
-POINTER_LOCK", "true"
-MSIINSTALLPERUSER", "1"
-PROGRAMSFOLDER", System.Environment.ExpandEnvironmentVariables(@"%PROGRAMFILES%")
+
+
+
+
+-------------------------------------------------------------------
+### ALLUSERS
+
+Expected values:
+
+* "1"
+  Install *For all users* (default)
+* ""
+  Install *Only for me*
+
+#### Example, install *For all users*
+
+    msiexec /i Symphony.msi /q ALLUSERS="1"
+
+or
+
+    msiexec /i Symphony.msi
+
+
+#### Example, install *Only for me*
+
+    msiexec /i Symphony.msi /q ALLUSERS=""
+
+
+-------------------------------------------------------------------
+### ALWAYS_ON_TOP
+
+Expected values:
+
+* "DISABLED"
+  Always-on-top disabled (default)
+* "ENABLED"
+  Always-on-top enabled
+
+#### Example, install with always-on-top disabled
+
+    msiexec /i Symphony.msi /q ALWAYS_ON_TOP="DISABLED"
+
+or
+
+    msiexec /i Symphony.msi /q
+
+#### Example, install with always-on-top enabled
+
+    msiexec /i Symphony.msi /q ALWAYS_ON_TOP="ENABLED"
+
+
+
+-------------------------------------------------------------------
+### AUTO_LAUNCH_PATH
+
+Expected values:
+
+* Full file path for custom auto launch path
+
+#### Example
+
+    msiexec /i Symphony.msi /q AUTO_LAUNCH_PATH="C:\Program Files\internet explorer\iexplore.exe"
+
+
+
+-------------------------------------------------------------------
+### AUTO_START
+
+Expected values:
+
+* "ENABLED"
+  Auto start enabled (default)
+* "DISABLED"
+  Auto start disabled
+
+#### Example, install with auto start enabled
+
+    msiexec /i Symphony.msi /q AUTO_START="ENABLED"
+
+or
+
+    msiexec /i Symphony.msi /q
+
+#### Example, install with auto start disabled
+
+    msiexec /i Symphony.msi /q AUTO_START="DISABLED"
+
+
+
+-------------------------------------------------------------------
+### BRING_TO_FRONT
+
+Expected values:
+
+* "DISABLED"
+  Bring-to-front disabled (default)
+* "ENABLED"
+  Bring-to-front enabled
+
+#### Example, install with bring-to-front disabled
+
+    msiexec /i Symphony.msi /q BRING_TO_FRONT="DISABLED"
+
+or
+
+    msiexec /i Symphony.msi /q
+
+#### Example, install with bring-to-front enabled
+
+    msiexec /i Symphony.msi /q BRING_TO_FRONT="ENABLED"
+
+
+
+-------------------------------------------------------------------
+### CUSTOM_TITLE_BAR
+
+Expected values:
+
+* "ENABLED"
+  Custom title bar enabled (default)
+* "DISABLED"
+  Custom title bar disabled
+
+#### Example, install with custom title bar enabled
+
+    msiexec /i Symphony.msi /q CUSTOM_TITLE_BAR="ENABLED"
+
+or
+
+    msiexec /i Symphony.msi /q
+
+#### Example, install with custom title bar disabled
+
+    msiexec /i Symphony.msi /q CUSTOM_TITLE_BAR="DISABLED"
+
+
+
+-------------------------------------------------------------------
+### DEV_TOOLS_ENABLED
+
+Expected values:
+
+* "true"
+  Dev tools enabled (default)
+* "false"
+  Dev tools disabled
+
+#### Example, install with dev tools enabled
+
+    msiexec /i Symphony.msi /q DEV_TOOLS_ENABLED="true"
+
+or
+
+    msiexec /i Symphony.msi /q
+
+#### Example, install with dev tools disabled
+
+    msiexec /i Symphony.msi /q DEV_TOOLS_ENABLED="false"
+
+
+
+-------------------------------------------------------------------
+### FULL_SCREEN
+
+Expected values:
+
+* "true"
+  Full screen enabled (default)
+* "false"
+  Full screen disabled
+
+#### Example, install with full screen enabled
+
+    msiexec /i Symphony.msi /q FULL_SCREEN="true"
+
+or
+
+    msiexec /i Symphony.msi /q
+
+#### Example, install with full screen disabled
+
+    msiexec /i Symphony.msi /q FULL_SCREEN="false"
+
+
+
+-------------------------------------------------------------------
+### LOCATION
+
+Expected values:
+
+* "true"
+  Location enabled (default)
+* "false"
+  Location disabled
+
+#### Example, install with location enabled
+
+    msiexec /i Symphony.msi /q LOCATION="true"
+
+or
+
+    msiexec /i Symphony.msi /q
+
+#### Example, install with location disabled
+
+    msiexec /i Symphony.msi /q LOCATION="false"
+
+
+
+-------------------------------------------------------------------
+### MEDIA
+
+Expected values:
+
+* "true"
+  Media enabled (default)
+* "false"
+  Media disabled
+
+#### Example, install with media enabled
+
+    msiexec /i Symphony.msi /q MEDIA="true"
+
+or
+
+    msiexec /i Symphony.msi /q
+
+#### Example, install with media disabled
+
+    msiexec /i Symphony.msi /q MEDIA="false"
+
+
+
+-------------------------------------------------------------------
+### MIDI_SYSEX
+
+Expected values:
+
+* "true"
+  Midi SysEx enabled (default)
+* "false"
+  Midi SysEx disabled
+
+#### Example, install with Midi SysEx enabled
+
+    msiexec /i Symphony.msi /q MIDI_SYSEX="true"
+
+or
+
+    msiexec /i Symphony.msi /q
+
+#### Example, install with Midi SysEx disabled
+
+    msiexec /i Symphony.msi /q MIDI_SYSEX="false"
+
+
+
+-------------------------------------------------------------------
+### MINIMIZE_ON_CLOSE
+
+Expected values:
+
+* "ENABLED"
+  Minimize-on-close enabled (default)
+* "DISABLED"
+  Minimize-on-close disabled
+
+#### Example, install with minimize-on-close enabled
+
+    msiexec /i Symphony.msi /q MINIMIZE_ON_CLOSE="ENABLED"
+
+or
+
+    msiexec /i Symphony.msi /q
+
+#### Example, install with minimize-on-close disabled
+
+    msiexec /i Symphony.msi /q MINIMIZE_ON_CLOSE="DISABLED"
+
+
+
+-------------------------------------------------------------------
+### NOTIFICATIONS
+
+Expected values:
+
+* "true"
+  Notifications enabled (default)
+* "false"
+  Notifications disabled
+
+#### Example, install with notifications enabled
+
+    msiexec /i Symphony.msi /q NOTIFICATIONS="true"
+
+or
+
+    msiexec /i Symphony.msi /q
+
+#### Example, install with notifications disabled
+
+    msiexec /i Symphony.msi /q NOTIFICATIONS="false"
+
+
+
+-------------------------------------------------------------------
+### OPEN_EXTERNAL
+
+Expected values:
+
+* "true"
+  Open external enabled (default)
+* "false"
+  Open external disabled
+
+#### Example, install with open external enabled
+
+    msiexec /i Symphony.msi /q OPEN_EXTERNAL="true"
+
+or
+
+    msiexec /i Symphony.msi /q
+
+#### Example, install with open external disabled
+
+    msiexec /i Symphony.msi /q OPEN_EXTERNAL="false"
+
+
+
+-------------------------------------------------------------------
+### POD_URL
+
+Expected values:
+
+* Full url to POD
+  (default is "https://my.symphony.com" )
+
+#### Example
+
+    msiexec /i Symphony.msi /q POD_URL="https://my.symphony.com"
+
+
+
+-------------------------------------------------------------------
+### POINTER_LOCK
+
+Expected values:
+
+* "true"
+  Pointer lock enabled (default)
+* "false"
+  Pointer lock disabled
+
+#### Example, install with pointer lock enabled
+
+    msiexec /i Symphony.msi /q POINTER_LOCK="true"
+
+or
+
+    msiexec /i Symphony.msi /q
+
+#### Example, install with pointer lock disabled
+
+    msiexec /i Symphony.msi /q POINTER_LOCK="false"
+
+

--- a/scripts/jenkins-win64.bat
+++ b/scripts/jenkins-win64.bat
@@ -107,8 +107,8 @@ if NOT EXIST c:\electron-installer\signing.bat (
 call c:\electron-installer\signing.bat
 copy "WixSharpInstaller\Symphony.msi" "%targetsDir%\Experimental-%archiveName%.msi"
 
-%SystemRoot%\System32\where.exe markdown-pdf
-if NOT ERRORLEVEL 0 (
-    npm install -g markdown-pdf
+%SystemRoot%\System32\where.exe /q markdown-pdf
+if ERRORLEVEL 1 (
+    call npm install -g markdown-pdf
 )
 markdown-pdf install_instructions_win.md -o "%targetsDir%\Install-Instructions-Experimental-%archiveName%.pdf"

--- a/scripts/jenkins-win64.bat
+++ b/scripts/jenkins-win64.bat
@@ -112,4 +112,5 @@ if ERRORLEVEL 1 (
     call npm install -g markdown-pdf
 )
 %appdata%\npm\markdown-pdf install_instructions_win.md
-copy install_instructions_win.pdf %targetsDir%\Install-Instructions-Experimental-%archiveName%.pdf
+echo "%targetsDir%\Install-Instructions-Experimental-%archiveName%.pdf"
+copy install_instructions_win.pdf "%targetsDir%\Install-Instructions-Experimental-%archiveName%.pdf"

--- a/scripts/jenkins-win64.bat
+++ b/scripts/jenkins-win64.bat
@@ -113,6 +113,6 @@ if ERRORLEVEL 1 (
     call npm install -g markdown-pdf
 )
 echo Generating install instructions
-%appdata%\npm\markdown-pdf install_instructions_win.md
+call %appdata%\npm\markdown-pdf install_instructions_win.md
 echo Install instructions generated: %targetsDir%\Install-Instructions-Experimental-%archiveName%.pdf
 copy install_instructions_win.pdf "%targetsDir%\Install-Instructions-Experimental-%archiveName%.pdf"

--- a/scripts/jenkins-win64.bat
+++ b/scripts/jenkins-win64.bat
@@ -112,4 +112,4 @@ if ERRORLEVEL 1 (
     call npm install -g markdown-pdf
 )
 %appdata%\npm\markdown-pdf install_instructions_win.md
-
+copy install_instructions_win.pdf %targetsDir%\Install-Instructions-Experimental-%archiveName%.pdf

--- a/scripts/jenkins-win64.bat
+++ b/scripts/jenkins-win64.bat
@@ -107,10 +107,12 @@ if NOT EXIST c:\electron-installer\signing.bat (
 call c:\electron-installer\signing.bat
 copy "WixSharpInstaller\Symphony.msi" "%targetsDir%\Experimental-%archiveName%.msi"
 
+echo Setup for install instructions
 %SystemRoot%\System32\where.exe /q markdown-pdf
 if ERRORLEVEL 1 (
     call npm install -g markdown-pdf
 )
+echo Generating install instructions
 %appdata%\npm\markdown-pdf install_instructions_win.md
-echo "%targetsDir%\Install-Instructions-Experimental-%archiveName%.pdf"
+echo Install instructions generated: %targetsDir%\Install-Instructions-Experimental-%archiveName%.pdf
 copy install_instructions_win.pdf "%targetsDir%\Install-Instructions-Experimental-%archiveName%.pdf"

--- a/scripts/jenkins-win64.bat
+++ b/scripts/jenkins-win64.bat
@@ -107,7 +107,7 @@ if NOT EXIST c:\electron-installer\signing.bat (
 call c:\electron-installer\signing.bat
 copy "WixSharpInstaller\Symphony.msi" "%targetsDir%\Experimental-%archiveName%.msi"
 
-%SystemRoot%\System32\where.exe /q markdown-pdf
+%SystemRoot%\System32\where.exe markdown-pdf
 if NOT ERRORLEVEL 0 (
     npm install -g markdown-pdf
 )

--- a/scripts/jenkins-win64.bat
+++ b/scripts/jenkins-win64.bat
@@ -114,5 +114,4 @@ if ERRORLEVEL 1 (
 )
 echo Generating install instructions
 call %appdata%\npm\markdown-pdf install_instructions_win.md
-echo Install instructions generated: %targetsDir%\Install-Instructions-Experimental-%archiveName%.pdf
 copy install_instructions_win.pdf "%targetsDir%\Install-Instructions-Experimental-%archiveName%.pdf"

--- a/scripts/jenkins-win64.bat
+++ b/scripts/jenkins-win64.bat
@@ -111,4 +111,5 @@ copy "WixSharpInstaller\Symphony.msi" "%targetsDir%\Experimental-%archiveName%.m
 if ERRORLEVEL 1 (
     call npm install -g markdown-pdf
 )
-%appdata%\npm\markdown-pdf install_instructions_win.md -o "%targetsDir%\Install-Instructions-Experimental-%archiveName%.pdf"
+%appdata%\npm\markdown-pdf install_instructions_win.md
+

--- a/scripts/jenkins-win64.bat
+++ b/scripts/jenkins-win64.bat
@@ -107,7 +107,7 @@ if NOT EXIST c:\electron-installer\signing.bat (
 call c:\electron-installer\signing.bat
 copy "WixSharpInstaller\Symphony.msi" "%targetsDir%\Experimental-%archiveName%.msi"
 
-%SystemRoot%\System32\where.exe /q markdown-pdf
+%SystemRoot%\System32\where.exe markdown-pdf
 if ERRORLEVEL 1 (
     call npm install -g markdown-pdf
 )

--- a/scripts/jenkins-win64.bat
+++ b/scripts/jenkins-win64.bat
@@ -107,7 +107,7 @@ if NOT EXIST c:\electron-installer\signing.bat (
 call c:\electron-installer\signing.bat
 copy "WixSharpInstaller\Symphony.msi" "%targetsDir%\Experimental-%archiveName%.msi"
 
-where /q markdown-pdf
+%SystemRoot%\System32\where.exe /q markdown-pdf
 if NOT ERRORLEVEL 0 (
     npm install -g markdown-pdf
 )

--- a/scripts/jenkins-win64.bat
+++ b/scripts/jenkins-win64.bat
@@ -106,3 +106,9 @@ if NOT EXIST c:\electron-installer\signing.bat (
 
 call c:\electron-installer\signing.bat
 copy "WixSharpInstaller\Symphony.msi" "%targetsDir%\Experimental-%archiveName%.msi"
+
+where /q markdown-pdf
+if NOT ERRORLEVEL 0 (
+    npm install -g markdown-pdf
+)
+markdown-pdf install_instructions_win.md -o "%targetsDir%\Install-Instructions-Experimental-%archiveName%.pdf"

--- a/scripts/jenkins-win64.bat
+++ b/scripts/jenkins-win64.bat
@@ -107,8 +107,8 @@ if NOT EXIST c:\electron-installer\signing.bat (
 call c:\electron-installer\signing.bat
 copy "WixSharpInstaller\Symphony.msi" "%targetsDir%\Experimental-%archiveName%.msi"
 
-%SystemRoot%\System32\where.exe markdown-pdf
+%SystemRoot%\System32\where.exe /q markdown-pdf
 if ERRORLEVEL 1 (
     call npm install -g markdown-pdf
 )
-markdown-pdf install_instructions_win.md -o "%targetsDir%\Install-Instructions-Experimental-%archiveName%.pdf"
+%appdata%\npm\markdown-pdf install_instructions_win.md -o "%targetsDir%\Install-Instructions-Experimental-%archiveName%.pdf"


### PR DESCRIPTION
## Description
We want installation instructions in markdown, and to generate a pdf file from that on every build
[SDA-2650](https://perzoinc.atlassian.net/browse/SDA-2650)

## Solution Approach
Using markdown-pdf npm module

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
other_pr_dev | [link]()

Notes: Added install instructions