### PR TITLE
fix: SDA-2745 Added support for APPDIR parameter

### DIFF
--- a/installer/win/WixSharpInstaller/WelcomeDialog.cs
+++ b/installer/win/WixSharpInstaller/WelcomeDialog.cs
@@ -49,17 +49,30 @@ namespace Symphony
             // To enable Wix to use the "MSIINSTALLPERUSER" property being set below, ALLUSERS must be set to 2
             Runtime.Session["ALLUSERS"] = "2";
 
-
+            var installDir = "";
             if (radioButtonCurrentUser.Checked)
             {
                 // Install for current user
                 Runtime.Session["MSIINSTALLPERUSER"] = "1"; // per-user
                 Runtime.Session["INSTALLDIR"] = System.Environment.ExpandEnvironmentVariables(@"%LOCALAPPDATA%\Programs\Symphony\" + Runtime.ProductName);
-            } else if (radioButtonAllUsers.Checked)
+            }
+            else if (radioButtonAllUsers.Checked)
             {
                 // Install for all users
                 Runtime.Session["MSIINSTALLPERUSER"] = ""; // per-machine
                 Runtime.Session["INSTALLDIR"] = Runtime.Session["PROGRAMSFOLDER"]  + @"\Symphony\" + Runtime.ProductName;
+            }
+
+            // Set INSTALLDIR
+            if( Runtime.Session["APPDIR"] != "" )
+            {
+                // If APPDIR param was specified, just use that as is
+                Runtime.Session["INSTALLDIR"] = Runtime.Session["APPDIR"];
+            }
+            else
+            {
+                // Apply the install dir as determined by radio buttons
+                Runtime.Session["INSTALLDIR"] = installDir;
             }
 
             // Detect if Symphony is running

--- a/installer/win/install_instructions_win.md
+++ b/installer/win/install_instructions_win.md
@@ -31,6 +31,27 @@ or
     msiexec /i Symphony.msi /q ALLUSERS=""
 
 
+
+-------------------------------------------------------------------
+### APPDIR
+
+Expected values:
+
+* Full file path for target location to install Symphony to
+
+The default value differs depending on ALLUSERS setting.
+
+* %LOCALAPPDATA%\Programs\Symphony\Symphony
+  If installing *Only for me* (ALLUSERS="")
+* %PROGRAMFILES%\Symphony\Symphony
+  If installing *For all users* (ALLUSERS="1")
+
+#### Example
+
+    msiexec /i Symphony.msi /q APPDIR="C:\Program Files\Symphony"
+
+
+
 -------------------------------------------------------------------
 ### ALWAYS_ON_TOP
 


### PR DESCRIPTION
## Description
Support for APPDIR param was missing
[SDA-2745](https://perzoinc.atlassian.net/browse/SDA-2745)

## Solution Approach
Added support for APPDIR params

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
other_pr_dev | [link]()

Notes: Added support for APPDIR params
