### PR TITLE
fix: SDA-2762: load correct page on network issues

### DIFF
--- a/config/Symphony.config
+++ b/config/Symphony.config
@@ -1,5 +1,5 @@
 {
-    "url":"https://corporate.symphony.com",
+    "url":"https://my.symphony.com",
     "minimizeOnClose" : "ENABLED",
     "launchOnStartup" : "ENABLED",
     "alwaysOnTop" : "DISABLED",

--- a/config/Symphony.config
+++ b/config/Symphony.config
@@ -1,5 +1,5 @@
 {
-    "url":"https://my.symphony.com",
+    "url":"https://corporate.symphony.com",
     "minimizeOnClose" : "ENABLED",
     "launchOnStartup" : "ENABLED",
     "alwaysOnTop" : "DISABLED",

--- a/docs/features/network-error.md
+++ b/docs/features/network-error.md
@@ -1,18 +1,25 @@
 # Intro
-The SDA displays a network error page when there is some network related issue Including the error code. which makes it easier for users to understand what's the actual problem is.
+The SDA displays a network error page when there are network failures.
 
 # Platforms Supported
-macOS, Windows 10, Windows 7
+macOS, Windows 10
 
 # Purpose
-To let the users know the exact error the page stopped loading, instead of just displaying a blank screen.
+To create awareness for users to try and reload Symphony and also to understand the network error in case they need to engage the support team.
 
 # Details
-This error info page will be displayed in the main electron app and can be any of the following reasons (Network offline, Proxy connection failed, Endpoint not access able, etc..)
+This error info page will be displayed in the SDA and can be any of the following reasons
 
-The error info page will be included with retry button which on clicking the SDA will be reloaded with the global config POD URL ex: "https://my.symphony.com"
+- Network offline
+- Proxy connection failed,
+- Endpoint not access able
+- Etc..
 
 The list of all the error codes can be found [here](https://cs.chromium.org/chromium/src/net/base/net_error_list.h)
+
+We also show a **Retry** button which upon a user clicking, Symphony is reloaded with two scenarios handled:
+- If a user has already logged in, Symphony is reloaded and a user doesn't need to login
+- If a user hasn't logged in yet or is on the verge of it, Symphony is reloaded and user is taken back to the login page
 
 # Example
 N/A

--- a/src/app/main-api-handler.ts
+++ b/src/app/main-api-handler.ts
@@ -61,6 +61,7 @@ ipcMain.on(apiName.symphonyApi, async (event: Electron.IpcMainEvent, arg: IApiAr
             // Set this to false once the SFE is completely loaded
             // so, we can prevent from showing error banners
             windowHandler.isWebPageLoading = false;
+            windowHandler.isLoggedIn = true;
             break;
         case apiCmds.registerLogRetriever:
             registerLogRetriever(event.sender, arg.logName);
@@ -105,7 +106,7 @@ ipcMain.on(apiName.symphonyApi, async (event: Electron.IpcMainEvent, arg: IApiAr
         case apiCmds.bringToFront:
             // validates the user bring to front config and activates the wrapper
             if (typeof arg.reason === 'string' && arg.reason === 'notification') {
-                const { bringToFront } = config.getConfigFields([ 'bringToFront' ]);
+                const { bringToFront } = config.getConfigFields(['bringToFront']);
                 if (bringToFront === CloudConfigDataTypes.ENABLED) {
                     activate(arg.windowName, false);
                 }
@@ -185,7 +186,7 @@ ipcMain.on(apiName.symphonyApi, async (event: Electron.IpcMainEvent, arg: IApiAr
             }
             break;
         case apiCmds.getConfigUrl:
-            const { url } = config.getGlobalConfigFields([ 'url' ]);
+            const { url } = config.getGlobalConfigFields(['url']);
             event.returnValue = url;
             break;
         case apiCmds.registerAnalyticsHandler:

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -1639,6 +1639,23 @@ export class WindowHandler {
   }
 
   /**
+   * Reloads symphony in case of network failures
+   */
+  public reloadSymphony() {
+    if (this.mainWindow && windowExists(this.mainWindow)) {
+      // If the client is fully loaded, upon network interruption, load that
+      if (this.isLoggedIn) {
+        logger.info(`window-utils: user has logged in, getting back to Symphony app`);
+        this.mainWindow.loadURL(this.url || this.userConfig.url || this.globalConfig.url);
+        return;
+      }
+      // If not, revert to loading the starting pod url
+      logger.info(`window-utils: user hasn't logged in yet, loading login page again`);
+      this.mainWindow.loadURL(this.userConfig.url || this.globalConfig.url);
+    }
+  }
+
+  /**
    * Listens for app load timeouts and reloads if required
    */
   private listenForLoad() {
@@ -1917,22 +1934,6 @@ export class WindowHandler {
     return { ...defaultWindowOpts, ...windowOpts };
   }
 
-  /**
-   * Reloads symphony in case of network failures
-   */
-  private reloadSymphony() {
-    if (this.mainWindow && windowExists(this.mainWindow)) {
-      // If the client is fully loaded, upon network interruption, load that
-      if (this.isLoggedIn) {
-        logger.info(`window-utils: user has logged in, getting back to Symphony app`);
-        this.mainWindow.loadURL(this.url || this.userConfig.url || this.globalConfig.url);
-        return;
-      }
-      // If not, revert to loading the starting pod url
-      logger.info(`window-utils: user hasn't logged in yet, loading login page again`);
-      this.mainWindow.loadURL(this.userConfig.url || this.globalConfig.url);
-    }
-  }
 }
 
 const windowHandler = new WindowHandler();

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -114,6 +114,7 @@ export class WindowHandler {
   public spellchecker: SpellChecker | undefined;
   public isCustomTitleBar: boolean;
   public isWebPageLoading: boolean = true;
+  public isLoggedIn: boolean = false;
   public screenShareIndicatorFrameUtil: string;
   public shouldShowWelcomeScreen: boolean = false;
 
@@ -611,9 +612,7 @@ export class WindowHandler {
 
     // Reloads the Symphony
     ipcMain.on('reload-symphony', () => {
-      if (this.mainWindow && windowExists(this.mainWindow)) {
-        this.mainWindow.loadURL(this.url || this.globalConfig.url);
-      }
+      this.reloadSymphony();
     });
 
     // Certificate verification proxy
@@ -1916,6 +1915,23 @@ export class WindowHandler {
     };
 
     return { ...defaultWindowOpts, ...windowOpts };
+  }
+
+  /**
+   * Reloads symphony in case of network failures
+   */
+  private reloadSymphony() {
+    if (this.mainWindow && windowExists(this.mainWindow)) {
+      // If the client is fully loaded, upon network interruption, load that
+      if (this.isLoggedIn) {
+        logger.info(`window-utils: user has logged in, getting back to Symphony app`);
+        this.mainWindow.loadURL(this.url || this.userConfig.url || this.globalConfig.url);
+        return;
+      }
+      // If not, revert to loading the starting pod url
+      logger.info(`window-utils: user hasn't logged in yet, loading login page again`);
+      this.mainWindow.loadURL(this.userConfig.url || this.globalConfig.url);
+    }
   }
 }
 

--- a/src/app/window-utils.ts
+++ b/src/app/window-utils.ts
@@ -539,7 +539,13 @@ export const isSymphonyReachable = (window: ICustomBrowserWindow | null, url: st
         fetch(podUrl, { method: 'GET' }).then((rsp) => {
             if (rsp.status === 200 && windowHandler.isOnline) {
                 logger.info(`window-utils: pod ${podUrl} is reachable, loading main window!`);
-                window.loadURL(url);
+                if (windowHandler.isLoggedIn) {
+                    logger.info(`window-utils: user has logged in, getting back to Symphony app`);
+                    window.loadURL(url);
+                } else {
+                    logger.info(`window-utils: user hasn't logged in yet, loading login page again`);
+                    window.loadURL(windowHandler.url || url);
+                }
                 if (networkStatusCheckIntervalId) {
                     clearInterval(networkStatusCheckIntervalId);
                     networkStatusCheckIntervalId = null;

--- a/src/app/window-utils.ts
+++ b/src/app/window-utils.ts
@@ -539,13 +539,7 @@ export const isSymphonyReachable = (window: ICustomBrowserWindow | null, url: st
         fetch(podUrl, { method: 'GET' }).then((rsp) => {
             if (rsp.status === 200 && windowHandler.isOnline) {
                 logger.info(`window-utils: pod ${podUrl} is reachable, loading main window!`);
-                if (windowHandler.isLoggedIn) {
-                    logger.info(`window-utils: user has logged in, getting back to Symphony app`);
-                    window.loadURL(url);
-                } else {
-                    logger.info(`window-utils: user hasn't logged in yet, loading login page again`);
-                    window.loadURL(windowHandler.url || url);
-                }
+                windowHandler.reloadSymphony();
                 if (networkStatusCheckIntervalId) {
                     clearInterval(networkStatusCheckIntervalId);
                     networkStatusCheckIntervalId = null;


### PR DESCRIPTION
## Description
For special cases like corp, load the actual pod url if login is not complete yet in case of network connection issues.
[SDA-2762](https://perzoinc.atlassian.net/browse/SDA-2762)

## Solution Approach
- Add a new flag called `isLoggedIn` in window handler
- Initialize the above flag to false by default
- Once SFE is loaded, set the flag to true

- If the above flag is false, load the original pod url
- If the flag is true, load the current window url

## Related PRs
N/A

Notes: load correct page on network issues