### PR TITLE
fix: SDA-2751 Fixed so BI can be sent from renderer process, etc

### DIFF
--- a/src/app/screen-snippet-handler.ts
+++ b/src/app/screen-snippet-handler.ts
@@ -16,6 +16,7 @@ import {
 } from '../common/env';
 import { i18n } from '../common/i18n';
 import { logger } from '../common/logger';
+import { analytics, AnalyticsElements, ScreenSnippetActionTypes } from './analytics-handler';
 import { updateAlwaysOnTop } from './window-actions';
 import { windowHandler } from './window-handler';
 import { windowExists } from './window-utils';
@@ -115,6 +116,7 @@ class ScreenSnippet {
         windowHandler.closeSnippingToolWindow();
         windowHandler.createSnippingToolWindow(this.outputFileName, imageSize);
         this.uploadSnippet(webContents);
+        this.sendAnalytics();
       return;
     }
       const {
@@ -316,6 +318,16 @@ class ScreenSnippet {
       }
     });
   }
+
+  /**
+   * Send analytics data to analytics module
+   */
+  private sendAnalytics() {
+    ipcMain.on('send-tracking-data-to-main', async (_event, eventData: { element: AnalyticsElements, type: ScreenSnippetActionTypes }) => {
+      analytics.track({element: eventData.element, action_type: eventData.type});
+    });
+  }
+
 }
 
 const screenSnippet = new ScreenSnippet();

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -987,10 +987,17 @@ export class WindowHandler {
       width: number;
     },
   ): void {
-    const parentWindow = BrowserWindow.getFocusedWindow();
     // Prevents creating multiple instances
-    if (didVerifyAndRestoreWindow(this.snippingToolWindow) || !parentWindow) {
+    if (didVerifyAndRestoreWindow(this.snippingToolWindow)) {
       logger.error('window-handler: Could not open snipping tool window');
+      return;
+    }
+
+    const electronWindows = BrowserWindow.getAllWindows();
+    const mainWindow = electronWindows[0];
+
+    if (!mainWindow) {
+      logger.error('window-handler: Could not get main window');
       return;
     }
 
@@ -1001,7 +1008,7 @@ export class WindowHandler {
     const BUTTON_BAR_BOTTOM_HEIGHT = 72;
     const BUTTON_BARS_HEIGHT = BUTTON_BAR_TOP_HEIGHT + BUTTON_BAR_BOTTOM_HEIGHT;
 
-    const display = electron.screen.getDisplayMatching(parentWindow.getBounds());
+    const display = electron.screen.getDisplayMatching(mainWindow.getBounds());
     const workAreaSize = display.workAreaSize;
     const maxToolHeight = Math.floor(calculatePercentage(workAreaSize.height, 90));
     const maxToolWidth = Math.floor(calculatePercentage(workAreaSize.width, 90));
@@ -1056,8 +1063,8 @@ export class WindowHandler {
       opts.alwaysOnTop = true;
     }
 
-    if (isWindowsOS && parentWindow) {
-      opts.parent = parentWindow;
+    if (isWindowsOS && mainWindow) {
+      opts.parent = mainWindow;
     }
 
     this.snippingToolWindow = createComponentWindow('snipping-tool', opts);
@@ -1073,8 +1080,9 @@ export class WindowHandler {
         snippetImageWidth: snipDimensions.width,
       };
       if (this.snippingToolWindow && windowExists(this.snippingToolWindow)) {
-        logger.info('window-handler: Opening snipping tool window with size: ', { toolHeight, toolWidth });
-        logger.info('window-handler: Opening snipping tool content with metadata: ', snippingToolInfo);
+        logger.info('window-handler: Opening snipping tool window on display: ' + JSON.stringify(display));
+        logger.info('window-handler: Opening snipping tool window with size: ' + JSON.stringify({ toolHeight, toolWidth }));
+        logger.info('window-handler: Opening snipping tool content with metadata: ' + JSON.stringify(snippingToolInfo));
         this.snippingToolWindow.webContents.send(
           'snipping-tool-data',
           snippingToolInfo,

--- a/src/renderer/components/annotate-area.tsx
+++ b/src/renderer/components/annotate-area.tsx
@@ -1,7 +1,7 @@
 import { LazyBrush } from 'lazy-brush';
 import * as React from 'react';
-import { analytics, AnalyticsElements, ScreenSnippetActionTypes } from './../../app/analytics-handler';
-import { IDimensions, IPath, IPoint, Tool } from './snipping-tool';
+import { AnalyticsElements, ScreenSnippetActionTypes } from './../../app/analytics-handler';
+import { IDimensions, IPath, IPoint, sendAnalyticsToMain, Tool } from './snipping-tool';
 
 const { useState } = React;
 
@@ -50,10 +50,7 @@ const AnnotateArea: React.FunctionComponent<IAnnotateAreaProps> = ({
       updPaths.map((p) => {
         if (p && p.key === key) {
           p.shouldShow = false;
-          analytics.track({
-            element: AnalyticsElements.SCREEN_CAPTURE_ANNOTATE,
-            action_type: ScreenSnippetActionTypes.ANNOTATE_ERASED,
-          });
+          sendAnalyticsToMain(AnalyticsElements.SCREEN_CAPTURE_ANNOTATE, ScreenSnippetActionTypes.ANNOTATE_ERASED);
         }
         return p;
       });
@@ -232,16 +229,10 @@ const AnnotateArea: React.FunctionComponent<IAnnotateAreaProps> = ({
   const handleMouseUp = () => {
     stopDrawing();
     if (chosenTool === Tool.pen) {
-      analytics.track({
-        element: AnalyticsElements.SCREEN_CAPTURE_ANNOTATE,
-        action_type: ScreenSnippetActionTypes.ANNOTATE_ADDED_PEN,
-      });
+      sendAnalyticsToMain(AnalyticsElements.SCREEN_CAPTURE_ANNOTATE, ScreenSnippetActionTypes.ANNOTATE_ADDED_PEN);
     }
     if (chosenTool === Tool.highlight) {
-      analytics.track({
-        element: AnalyticsElements.SCREEN_CAPTURE_ANNOTATE,
-        action_type: ScreenSnippetActionTypes.ANNOTATE_ADDED_HIGHLIGHT,
-      });
+      sendAnalyticsToMain(AnalyticsElements.SCREEN_CAPTURE_ANNOTATE, ScreenSnippetActionTypes.ANNOTATE_ADDED_HIGHLIGHT);
     }
   };
 

--- a/src/renderer/components/snipping-tool.tsx
+++ b/src/renderer/components/snipping-tool.tsx
@@ -2,7 +2,7 @@ import { ipcRenderer } from 'electron';
 import * as React from 'react';
 import { svgAsPngUri } from 'save-svg-as-png';
 import { i18n } from '../../common/i18n-preload';
-import { analytics, AnalyticsElements, ScreenSnippetActionTypes } from './../../app/analytics-handler';
+import { AnalyticsElements, ScreenSnippetActionTypes } from './../../app/analytics-handler';
 import AnnotateArea from './annotate-area';
 import ColorPickerPill, { IColor } from './color-picker-pill';
 
@@ -51,6 +51,10 @@ const availableHighlightColors: IColor[] = [
 ];
 const SNIPPING_TOOL_NAMESPACE = 'ScreenSnippet';
 
+export const sendAnalyticsToMain = (element: AnalyticsElements, type: ScreenSnippetActionTypes): void => {
+  ipcRenderer.send('send-tracking-data-to-main', { element, type });
+};
+
 const SnippingTool: React.FunctionComponent<ISnippingToolProps> = ({ existingPaths }) => {
   // State preparation functions
 
@@ -91,10 +95,7 @@ const SnippingTool: React.FunctionComponent<ISnippingToolProps> = ({ existingPat
 
   useLayoutEffect(() => {
   ipcRenderer.once('snipping-tool-data', getSnipImageData);
-    analytics.track({
-      element: AnalyticsElements.SCREEN_CAPTURE_ANNOTATE,
-      action_type: ScreenSnippetActionTypes.SCREENSHOT_TAKEN,
-    });
+  sendAnalyticsToMain(AnalyticsElements.SCREEN_CAPTURE_ANNOTATE, ScreenSnippetActionTypes.SCREENSHOT_TAKEN);
   return () => {
     ipcRenderer.removeListener('snipping-tool-data', getSnipImageData);
   };
@@ -165,10 +166,7 @@ const SnippingTool: React.FunctionComponent<ISnippingToolProps> = ({ existingPat
       return p;
     });
     setPaths(updPaths);
-    analytics.track({
-      element: AnalyticsElements.SCREEN_CAPTURE_ANNOTATE,
-      action_type: ScreenSnippetActionTypes.ANNOTATE_CLEARED,
-    });
+    sendAnalyticsToMain(AnalyticsElements.SCREEN_CAPTURE_ANNOTATE, ScreenSnippetActionTypes.ANNOTATE_CLEARED);
   };
 
   // Utility functions
@@ -202,10 +200,7 @@ const SnippingTool: React.FunctionComponent<ISnippingToolProps> = ({ existingPat
   const done = async () => {
     const svg = document.getElementById('annotate-area');
     const mergedImageData = svg ? await svgAsPngUri(document.getElementById('annotate-area'), {}) : 'MERGE_FAIL';
-    analytics.track({
-      element: AnalyticsElements.SCREEN_CAPTURE_ANNOTATE,
-      action_type: ScreenSnippetActionTypes.ANNOTATE_DONE,
-    });
+    sendAnalyticsToMain(AnalyticsElements.SCREEN_CAPTURE_ANNOTATE, ScreenSnippetActionTypes.ANNOTATE_DONE );
     ipcRenderer.send('upload-snippet', { screenSnippetPath, mergedImageData });
   };
 


### PR DESCRIPTION
## Description
Fixed so BI can be sent from renderer process, also fixed so annotate can be triggered with proper screen dimensions when alt tabed away. Also tidied up the logging from screen snippet.

[SDA-2571](https://perzoinc.atlassian.net/browse/SDA-2571)

Notes: Fixed BI, logging and alt tab with annotate