### PR TITLE
fix: SDA-2806 (Fix notification inline reply focus issue with Windows)

### DIFF
--- a/src/renderer/notification.ts
+++ b/src/renderer/notification.ts
@@ -415,6 +415,20 @@ class Notification extends NotificationHandler {
                 if (windowExists(window)) {
                     this.renderNotification(window, data);
                 }
+                // This is a workaround to make sure the notification
+                // with visible input always stays on top of normal notifications
+                if (isWindowsOS) {
+                    this.activeNotifications.forEach((activeNotification) => {
+                        if (!activeNotification || !windowExists(activeNotification)) {
+                            return;
+                        }
+                        const [, height] = activeNotification.getSize();
+                        // Height of notification window with input will be 104
+                        if (height > notificationSettings.height) {
+                            activeNotification.moveTop();
+                        }
+                    });
+                }
                 return resolve(window);
             });
         });


### PR DESCRIPTION
## Description
- Fix notification inline reply focus issue with Windows
- Write a custom logic to move all the notifications with inline reply open to the top

### Screencast
![2020-12-29 15 45 26](https://user-images.githubusercontent.com/13243259/103276703-42b27300-49ed-11eb-90d6-023a739d413b.gif)



Notes: Fix notification inline reply focus issue with Windows