### PR TITLE
fix: SDA-2811 (Replace native electron notification with same tag)

### DIFF
--- a/src/app/notifications/notification-helper.ts
+++ b/src/app/notifications/notification-helper.ts
@@ -7,9 +7,11 @@ import { ElectronNotification } from './electron-notification';
 
 class NotificationHelper {
     private electronNotification: Map<number, ElectronNotification>;
+    private activeElectronNotification: Map<string, ElectronNotification>;
 
     constructor() {
         this.electronNotification = new Map<number, ElectronNotification>();
+        this.activeElectronNotification = new Map<string, ElectronNotification>();
     }
 
     /**
@@ -22,8 +24,19 @@ class NotificationHelper {
         if (options.isElectronNotification) {
             // MacOS: Electron notification only supports static image path
             options.icon = this.getIcon(options);
+
+            // This is replace notification with same tag
+            if (this.activeElectronNotification.has(options.tag)) {
+                const electronNotification = this.activeElectronNotification.get(options.tag);
+                if (electronNotification) {
+                    electronNotification.close();
+                }
+                this.activeElectronNotification.delete(options.tag);
+            }
+
             const electronToast = new ElectronNotification(options, this.notificationCallback);
             this.electronNotification.set(options.id, electronToast);
+            this.activeElectronNotification.set(options.tag, electronToast);
             electronToast.show();
             return;
         }


### PR DESCRIPTION
## Description
- Replace existing notification with the same tag as new notification

## Screencast
![2020-12-30 12 48 44](https://user-images.githubusercontent.com/13243259/103336260-92507780-4a9d-11eb-8508-cb5149b91640.gif)

Note: Replace existing notification with the same tag as new notification

