### PR TITLE
fix: SDA-2838: Fix notification settings button for french

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -1337,7 +1337,7 @@ export class WindowHandler {
     const opts = this.getWindowOpts(
       {
         width: 540,
-        height: 440,
+        height: 455,
         show: false,
         modal: true,
         minimizable: false,

--- a/src/renderer/styles/notification-settings.less
+++ b/src/renderer/styles/notification-settings.less
@@ -116,7 +116,7 @@ body {
 
   .position-button {
     width: 116px;
-    height: 32px;
+    height: 45px;
 
     top: 1px;
 


### PR DESCRIPTION
## Description

When switching to french language, the notification settings window has alignment issues on the buttons. This PR fixes the issue.

## Screenshots

### Before

![SDA-2838_0106](https://user-images.githubusercontent.com/5968790/103880393-0c68a800-50ff-11eb-8008-5f55a121da6d.png)

### After

<img width="544" alt="Screenshot 2021-01-07 at 15 38 42" src="https://user-images.githubusercontent.com/5968790/103880257-e3e0ae00-50fe-11eb-8fe2-ba9c2773915a.png">
