### PR TITLE
feat: SDA-2846, SDA-2847: add support for context origin url in installer

### DIFF
--- a/installer/mac/install_instructions_mac.md
+++ b/installer/mac/install_instructions_mac.md
@@ -20,15 +20,30 @@ SDA can be automatically installed from the terminal. The process of customizing
 The parameters that should be configured in `sym_settings.txt` are listed below. They need to be in the same order as they'll be picked up by the installer in the same order. Do not skip any parameters.
 
 - Pod Url
+- Context Origin Url (Only required if your Pod url is set to your SSO provider URL, otherwise, leave it blank.)
 - Minimize On Close
 - Launch On Startup
 - Always on Top
 - Bring to Front
 - Dev Tools Enabled
 
-You can find a sample below:
+You can find samples below:
+
+Your SSO URL is set as the POD URL
 ```
-https://corporate.symphony.com/login/sso/initsso
+https://mysso.mycompany.com/login/sso/initsso
+https://mypod.symphony.com
+ENABLED
+ENABLED
+DISABLED
+DISABLED
+ENABLED
+```
+
+Your POD takes care of SSO as well
+```
+https://mypod.symphony.com/login/sso/initsso
+
 ENABLED
 ENABLED
 DISABLED
@@ -85,6 +100,7 @@ settings_temp_file="/tmp/sym_settings.txt"
 ## Set the POD URL and other user related settings.
 ## Note, all the user related settings should be either "ENABLED", "DISABLED" or "NOT_SET"
 pod_url="https://corporate.symphony.com/login/sso/initsso"
+context_origin_url=""
 minimize_on_close="ENABLED"
 launch_on_startup="ENABLED"
 always_on_top="DISABLED"
@@ -93,6 +109,7 @@ dev_tools_enabled="ENABLED"
 
 ## DO NOT CHANGE THIS
 sudo echo ${pod_url} > ${settings_temp_file}
+sudo echo ${context_origin_url} >> ${settings_temp_file}
 sudo echo ${minimize_on_close} >> ${settings_temp_file}
 sudo echo ${launch_on_startup} >> ${settings_temp_file}
 sudo echo ${always_on_top} >> ${settings_temp_file}

--- a/installer/mac/install_instructions_mac.md
+++ b/installer/mac/install_instructions_mac.md
@@ -37,7 +37,7 @@ ENABLED
 ENABLED
 DISABLED
 DISABLED
-ENABLED
+true
 ```
 
 Your POD takes care of SSO as well
@@ -48,7 +48,7 @@ ENABLED
 ENABLED
 DISABLED
 DISABLED
-ENABLED
+true
 ```
 
 ## sym_permissions.txt
@@ -65,13 +65,13 @@ The parameters that should be configured in `sym_permissions.txt` are listed bel
 
 You can find a sample below:
 ```
-ENABLED
-ENABLED
-ENABLED
-ENABLED
-ENABLED
-ENABLED
-ENABLED
+true
+true
+true
+true
+true
+true
+true
 ```
 
 # Installation
@@ -100,12 +100,12 @@ settings_temp_file="/tmp/sym_settings.txt"
 ## Set the POD URL and other user related settings.
 ## Note, all the user related settings should be either "ENABLED", "DISABLED" or "NOT_SET"
 pod_url="https://corporate.symphony.com/login/sso/initsso"
-context_origin_url=""
+context_origin_url="https://corporate.symphony.com"
 minimize_on_close="ENABLED"
 launch_on_startup="ENABLED"
 always_on_top="DISABLED"
 bring_to_front="DISABLED"
-dev_tools_enabled="ENABLED"
+dev_tools_enabled=true
 
 ## DO NOT CHANGE THIS
 sudo echo ${pod_url} > ${settings_temp_file}
@@ -120,13 +120,13 @@ sudo echo ${dev_tools_enabled} >> ${settings_temp_file}
 permissions_temp_file="/tmp/sym_permissions.txt"
 
 ## Set the permissions. By default, it should be "ENABLED" for all unless you know what you are doing
-media="ENABLED"
-geo_location="ENABLED"
-notifications="ENABLED"
-midi_sysex="ENABLED"
-pointer_lock="ENABLED"
-full_screen="ENABLED"
-open_external_app="ENABLED"
+media=true
+geo_location=true
+notifications=true
+midi_sysex=true
+pointer_lock=true
+full_screen=true
+open_external_app=true
 
 ## DO NOT CHANGE THIS
 sudo echo ${media} > ${permissions_temp_file}
@@ -141,5 +141,6 @@ sudo installer -store -pkg ${package_path} -target /
 
 rm -rf ${settings_temp_file}
 rm -rf ${permissions_temp_file}
+
 
 ```

--- a/installer/mac/postinstall.sh
+++ b/installer/mac/postinstall.sh
@@ -19,24 +19,24 @@ bring_to_front=$(sed -n '6p' ${settingsFilePath});
 dev_tools_enabled=$(sed -n '7p' ${settingsFilePath});
 
 ## If any of the above values turn out to be empty, set default values ##
-if [ "$pod_url" == "" ]; then pod_url="https://my.symphony.com"; fi
-if [ "$context_origin_url" == "" ]; then context_origin_url=""; fi
-if [ "$minimize_on_close" == "" ] || [ "$minimize_on_close" == 'true' ]; then minimize_on_close='ENABLED'; else minimize_on_close='DISABLED'; fi
-if [ "$launch_on_startup" == "" ] || [ "$launch_on_startup" == 'true' ]; then launch_on_startup='ENABLED'; else launch_on_startup='DISABLED'; fi
-if [ "$always_on_top" == "" ] || [ "$always_on_top" == 'false' ]; then always_on_top='DISABLED'; else always_on_top='ENABLED'; fi
-if [ "$bring_to_front" == "" ] || [ "$bring_to_front" == 'false' ]; then bring_to_front='DISABLED'; else bring_to_front='ENABLED'; fi
-if [ "$dev_tools_enabled" == "" ]; then dev_tools_enabled=true; fi
+if [ "$pod_url" = "" ]; then pod_url="https://my.symphony.com"; fi
+if [ "$context_origin_url" = "" ]; then context_origin_url=""; fi
+if [ "$minimize_on_close" = "" ] || [ "$minimize_on_close" = 'true' ]; then minimize_on_close='ENABLED'; else minimize_on_close='DISABLED'; fi
+if [ "$launch_on_startup" = "" ] || [ "$launch_on_startup" = 'true' ]; then launch_on_startup='ENABLED'; else launch_on_startup='DISABLED'; fi
+if [ "$always_on_top" = "" ] || [ "$always_on_top" = 'false' ]; then always_on_top='DISABLED'; else always_on_top='ENABLED'; fi
+if [ "$bring_to_front" = "" ] || [ "$bring_to_front" = 'false' ]; then bring_to_front='DISABLED'; else bring_to_front='ENABLED'; fi
+if [ "$dev_tools_enabled" = "" ]; then dev_tools_enabled=true; fi
 pod_url_escaped=$(sed 's#[&/\]#\\&#g' <<<"$pod_url")
 context_origin_url_escaped=$(sed 's#[&/\]#\\&#g' <<<"$context_origin_url")
 
 ## Replace the default settings with the user selected settings ##
 sed -i "" -E "s#\"url\" ?: ?\".*\"#\"url\"\: \"$pod_url_escaped\"#g" "${newPath}"
 sed -i "" -E "s#\"contextOriginUrl\" ?: ?\".*\"#\"contextOriginUrl\"\: \"$context_origin_url_escaped\"#g" "${newPath}"
-sed -i "" -E "s#\"minimizeOnClose\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"minimizeOnClose\":\ \"$minimize_on_close\"#g" ${newPath}
-sed -i "" -E "s#\"alwaysOnTop\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"alwaysOnTop\":\ \"$always_on_top\"#g" ${newPath}
-sed -i "" -E "s#\"launchOnStartup\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"launchOnStartup\":\ \"$launch_on_startup\"#g" ${newPath}
-sed -i "" -E "s#\"bringToFront\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"bringToFront\":\ \"$bring_to_front\"#g" ${newPath}
-sed -i "" -E "s#\"devToolsEnabled\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"devToolsEnabled\":\ $dev_tools_enabled#g" ${newPath}
+sed -i "" -E "s#\"minimizeOnClose\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"minimizeOnClose\":\ \"$minimize_on_close\"#g" "${newPath}"
+sed -i "" -E "s#\"alwaysOnTop\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"alwaysOnTop\":\ \"$always_on_top\"#g" "${newPath}"
+sed -i "" -E "s#\"launchOnStartup\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"launchOnStartup\":\ \"$launch_on_startup\"#g" "${newPath}"
+sed -i "" -E "s#\"bringToFront\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"bringToFront\":\ \"$bring_to_front\"#g" "${newPath}"
+sed -i "" -E "s#\"devToolsEnabled\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"devToolsEnabled\":\ $dev_tools_enabled#g" "${newPath}"
 
 ## Get Symphony Permissions from the temp file ##
 media=$(sed -n '1p' ${permissionsFilePath});
@@ -48,25 +48,25 @@ full_screen=$(sed -n '6p' ${permissionsFilePath});
 open_external_app=$(sed -n '7p' ${permissionsFilePath});
 
 ## If any of the above values turn out to be empty, set default values ##
-if [ "$media" == "" ]; then media=true; fi
-if [ "$geo_location" == "" ]; then geo_location=true; fi
-if [ "$notifications" == "" ]; then notifications=true; fi
-if [ "$midi_sysex" == "" ]; then midi_sysex=true; fi
-if [ "$pointer_lock" == "" ]; then pointer_lock=true;fi
-if [ "$full_screen" == "" ]; then full_screen=true; fi
-if [ "$open_external_app" == "" ]; then open_external_app=true; fi
+if [ "$media" = "" ]; then media=true; fi
+if [ "$geo_location" = "" ]; then geo_location=true; fi
+if [ "$notifications" = "" ]; then notifications=true; fi
+if [ "$midi_sysex" = "" ]; then midi_sysex=true; fi
+if [ "$pointer_lock" = "" ]; then pointer_lock=true;fi
+if [ "$full_screen" = "" ]; then full_screen=true; fi
+if [ "$open_external_app" = "" ]; then open_external_app=true; fi
 
 ## Replace the default permissions with the user selected permissions ##
-sed -i "" -E "s#\"media\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"media\":\ $media#g" ${newPath}
-sed -i "" -E "s#\"geolocation\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"geolocation\":\ $geo_location#g" ${newPath}
-sed -i "" -E "s#\"notifications\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"notifications\":\ $notifications#g" ${newPath}
-sed -i "" -E "s#\"midiSysex\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"midiSysex\":\ $midi_sysex#g" ${newPath}
-sed -i "" -E "s#\"pointerLock\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"pointerLock\":\ $pointer_lock#g" ${newPath}
-sed -i "" -E "s#\"fullscreen\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"fullscreen\":\ $full_screen#g" ${newPath}
-sed -i "" -E "s#\"openExternal\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"openExternal\":\ $open_external_app#g" ${newPath}
+sed -i "" -E "s#\"media\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"media\":\ $media#g" "${newPath}"
+sed -i "" -E "s#\"geolocation\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"geolocation\":\ $geo_location#g" "${newPath}"
+sed -i "" -E "s#\"notifications\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"notifications\":\ $notifications#g" "${newPath}"
+sed -i "" -E "s#\"midiSysex\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"midiSysex\":\ $midi_sysex#g" "${newPath}"
+sed -i "" -E "s#\"pointerLock\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"pointerLock\":\ $pointer_lock#g" "${newPath}"
+sed -i "" -E "s#\"fullscreen\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"fullscreen\":\ $full_screen#g" "${newPath}"
+sed -i "" -E "s#\"openExternal\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"openExternal\":\ $open_external_app#g" "${newPath}"
 
 ## Remove the temp settings & permissions file created ##
 rm -f ${settingsFilePath}
 rm -f ${permissionsFilePath}
 
-uuidgen > ${installVariantPath}
+uuidgen > "${installVariantPath}"

--- a/installer/mac/postinstall.sh
+++ b/installer/mac/postinstall.sh
@@ -11,23 +11,27 @@ newPath=${configFilePath}
 
 ## Get Symphony Settings from the temp file ##
 pod_url=$(sed -n '1p' ${settingsFilePath});
-minimize_on_close=$(sed -n '2p' ${settingsFilePath});
-launch_on_startup=$(sed -n '3p' ${settingsFilePath});
-always_on_top=$(sed -n '4p' ${settingsFilePath});
-bring_to_front=$(sed -n '5p' ${settingsFilePath});
-dev_tools_enabled=$(sed -n '6p' ${settingsFilePath});
+context_origin_url=$(sed -n '2p' ${settingsFilePath});
+minimize_on_close=$(sed -n '3p' ${settingsFilePath});
+launch_on_startup=$(sed -n '4p' ${settingsFilePath});
+always_on_top=$(sed -n '5p' ${settingsFilePath});
+bring_to_front=$(sed -n '6p' ${settingsFilePath});
+dev_tools_enabled=$(sed -n '7p' ${settingsFilePath});
 
 ## If any of the above values turn out to be empty, set default values ##
 if [ "$pod_url" == "" ]; then pod_url="https://my.symphony.com"; fi
+if [ "$context_origin_url" == "" ]; then context_origin_url=""; fi
 if [ "$minimize_on_close" == "" ] || [ "$minimize_on_close" == 'true' ]; then minimize_on_close='ENABLED'; else minimize_on_close='DISABLED'; fi
 if [ "$launch_on_startup" == "" ] || [ "$launch_on_startup" == 'true' ]; then launch_on_startup='ENABLED'; else launch_on_startup='DISABLED'; fi
 if [ "$always_on_top" == "" ] || [ "$always_on_top" == 'false' ]; then always_on_top='DISABLED'; else always_on_top='ENABLED'; fi
 if [ "$bring_to_front" == "" ] || [ "$bring_to_front" == 'false' ]; then bring_to_front='DISABLED'; else bring_to_front='ENABLED'; fi
 if [ "$dev_tools_enabled" == "" ]; then dev_tools_enabled=true; fi
 pod_url_escaped=$(sed 's#[&/\]#\\&#g' <<<"$pod_url")
+context_origin_url_escaped=$(sed 's#[&/\]#\\&#g' <<<"$context_origin_url")
 
 ## Replace the default settings with the user selected settings ##
-sed -i "" -E "s#\"url\" ?: ?\".*\"#\"url\"\: \"$pod_url_escaped\"#g" ${newPath}
+sed -i "" -E "s#\"url\" ?: ?\".*\"#\"url\"\: \"$pod_url_escaped\"#g" "${newPath}"
+sed -i "" -E "s#\"contextOriginUrl\" ?: ?\".*\"#\"contextOriginUrl\"\: \"$context_origin_url_escaped\"#g" "${newPath}"
 sed -i "" -E "s#\"minimizeOnClose\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"minimizeOnClose\":\ \"$minimize_on_close\"#g" ${newPath}
 sed -i "" -E "s#\"alwaysOnTop\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"alwaysOnTop\":\ \"$always_on_top\"#g" ${newPath}
 sed -i "" -E "s#\"launchOnStartup\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"launchOnStartup\":\ \"$launch_on_startup\"#g" ${newPath}

--- a/installer/win/WixSharpInstaller/Symphony.cs
+++ b/installer/win/WixSharpInstaller/Symphony.cs
@@ -172,6 +172,7 @@ class Script
             new PublicProperty("NOTIFICATIONS", "true"),
             new PublicProperty("OPEN_EXTERNAL", "true"),
             new PublicProperty("POD_URL", "https://my.symphony.com"),
+            new PublicProperty("CONTEXT_ORIGIN_URL", ""),
             new PublicProperty("POINTER_LOCK", "true"),
             new Property("MSIINSTALLPERUSER", "1"),
             new Property("PROGRAMSFOLDER", System.Environment.ExpandEnvironmentVariables(@"%PROGRAMFILES%"))
@@ -200,7 +201,7 @@ class Script
             new ElevatedManagedAction(CustomActions.UpdateConfig, Return.check, When.After, Step.InstallFiles, Condition.NOT_BeingRemoved )
             {
                 // The UpdateConfig action needs the built-in property INSTALLDIR as well as most of the custom properties
-                UsesProperties = "INSTALLDIR,POD_URL,MINIMIZE_ON_CLOSE,ALWAYS_ON_TOP,AUTO_START,BRING_TO_FRONT,MEDIA,LOCATION,NOTIFICATIONS,MIDI_SYSEX,POINTER_LOCK,FULL_SCREEN,OPEN_EXTERNAL,CUSTOM_TITLE_BAR,DEV_TOOLS_ENABLED,AUTO_LAUNCH_PATH"
+                UsesProperties = "INSTALLDIR,POD_URL,CONTEXT_ORIGIN_URL,MINIMIZE_ON_CLOSE,ALWAYS_ON_TOP,AUTO_START,BRING_TO_FRONT,MEDIA,LOCATION,NOTIFICATIONS,MIDI_SYSEX,POINTER_LOCK,FULL_SCREEN,OPEN_EXTERNAL,CUSTOM_TITLE_BAR,DEV_TOOLS_ENABLED,AUTO_LAUNCH_PATH"
             },
 
             // CleanRegistry
@@ -341,6 +342,7 @@ public class CustomActions
 
             // Replace all the relevant settings with values from the properties
             data = ReplaceProperty(data, "url", session.Property("POD_URL"));
+            data = ReplaceProperty(data, "contextOriginUrl", session.Property("CONTEXT_ORIGIN_URL"));
             data = ReplaceProperty(data, "minimizeOnClose", session.Property("MINIMIZE_ON_CLOSE"));
             data = ReplaceProperty(data, "alwaysOnTop", session.Property("ALWAYS_ON_TOP"));
             data = ReplaceProperty(data, "launchOnStartup", session.Property("AUTO_START"));

--- a/installer/win/install_instructions_win.md
+++ b/installer/win/install_instructions_win.md
@@ -368,6 +368,20 @@ Expected values:
 
 
 -------------------------------------------------------------------
+### CONTEXT_ORIGIN_URL
+
+Expected values:
+
+* Your actual POD URL and not the SSO URL
+  (default is "" )
+
+#### Example
+
+    msiexec /i Symphony.msi /q CONTEXT_ORIGIN_URL="https://my.symphony.com"
+
+
+
+-------------------------------------------------------------------
 ### POINTER_LOCK
 
 Expected values:


### PR DESCRIPTION
## Description

Currently, there's no way to set the context origin url from the installers on Windows & macOS.

This PR adds support for the same.
