### PR TITLE
fix: SDA-2875: add defense for statSync in logger

### DIFF
--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -251,10 +251,12 @@ class Logger {
         const deleteTimeStamp = new Date().getTime() - (5 * 24 * 60 * 60 * 1000);
         files.forEach((file) => {
             const filePath = path.join(this.logPath, file);
-            const stat = fs.statSync(filePath);
-            const fileTimestamp = new Date(util.inspect(stat.mtime)).getTime();
-            if ((fileTimestamp < deleteTimeStamp) && fs.existsSync(filePath)) {
-                fs.unlinkSync(filePath);
+            if (fs.existsSync(filePath)) {
+                const stat = fs.statSync(filePath);
+                const fileTimestamp = new Date(util.inspect(stat.mtime)).getTime();
+                if ((fileTimestamp < deleteTimeStamp)) {
+                    fs.unlinkSync(filePath);
+                }
             }
         });
     }


### PR DESCRIPTION
## Description

When we are cleaning up old logs, we check for timestamp of a log file, and, if there's no defensive check to see if the file exists, we see a JS exception. This PR fixes that issue.

## Related PRs

N/A