### PR TITLE
fix: SDA-2882 (Validate notification background color)

### DIFF
--- a/src/renderer/components/notification-comp.tsx
+++ b/src/renderer/components/notification-comp.tsx
@@ -378,6 +378,8 @@ export default class NotificationComp extends React.Component<{}, IState> {
         data.isInputHidden = true;
         data.containerHeight = CONTAINER_HEIGHT;
 
+        data.color = this.isValidColor(data.color) ? data.color : '';
+
         this.resetNotificationData();
         this.setState(data as IState);
 
@@ -395,6 +397,15 @@ export default class NotificationComp extends React.Component<{}, IState> {
                 }
             }, 1000);
         }
+    }
+
+    /**
+     * Validates the color
+     * @param color
+     * @private
+     */
+    private isValidColor(color: string): boolean {
+        return /^#([A-Fa-f0-9]{6})/.test(color);
     }
 
     /**


### PR DESCRIPTION
## Description
- Validate toast notification background-color

[SDA-2882](https://perzoinc.atlassian.net/browse/SDA-2882)
## Related PRs
[SFE-Lite](https://github.com/SymphonyOSF/SFE-Lite/pull/5573)

Notes: Validate toast notification background-color