### PR TITLE
fix: SDA-2934: Upgrade electron to 9.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "browserify": "16.5.1",
     "cross-env": "5.2.0",
     "del": "3.0.0",
-    "electron": "9.3.5",
+    "electron": "9.4.1",
     "electron-builder": "22.7.0",
     "electron-builder-squirrel-windows": "20.38.3",
     "electron-icon-maker": "0.0.4",


### PR DESCRIPTION
## Description

Upgrade Electron to fix security vulnerability -> https://github.com/electron/electron/security/advisories/GHSA-hvf8-h2qh-37m9

## Related PRs

N/A