### PR TITLE
fix: SDA-2931 Set Symphony as the publisher name

### DIFF
--- a/installer/win/WixSharpInstaller/Symphony.cs
+++ b/installer/win/WixSharpInstaller/Symphony.cs
@@ -235,7 +235,8 @@ class Script
         project.ControlPanelInfo.NoRepair = true;
         project.ControlPanelInfo.NoModify = true;
         project.ControlPanelInfo.ProductIcon = @"..\..\..\images\icon.ico";
-
+        project.ControlPanelInfo.Manufacturer = "Symphony";
+        
         project.Platform = Platform.x64;
 
         // Generate an MSI from all settings done above


### PR DESCRIPTION
## Description
The default Publisher/Manufacturer name is the user name of the user logged in when building the installer. This PR fix it by explicitly setting it to "Symphony"
