### PR TITLE
fix: SDA-2889 (Send analytic events for toast_closed)

### DIFF
--- a/src/app/analytics-handler.ts
+++ b/src/app/analytics-handler.ts
@@ -1,7 +1,8 @@
 export interface IAnalyticsData {
   element: AnalyticsElements;
-  action_type?: MenuActionTypes | ScreenSnippetActionTypes;
+  action_type?: MenuActionTypes | ScreenSnippetActionTypes | ToastNotificationActionTypes;
   action_result?: AnalyticsActions;
+  extra_data?: object;
 }
 
 export interface ICrashData extends IAnalyticsData {
@@ -29,6 +30,10 @@ export enum ScreenSnippetActionTypes {
   ANNOTATE_ERASED = 'annotate_erased',
 }
 
+export enum ToastNotificationActionTypes {
+  TOAST_CLOSED = 'toast_closed',
+}
+
 export enum AnalyticsActions {
   ENABLED = 'ON',
   DISABLED = 'OFF',
@@ -37,6 +42,7 @@ export enum AnalyticsActions {
 export enum AnalyticsElements {
   MENU = 'Menu',
   SCREEN_CAPTURE_ANNOTATE = 'screen_capture_annotate',
+  TOAST_NOTIFICATION = 'toast_notification',
   SDA_CRASH = 'sda_crash',
 }
 

--- a/src/renderer/notification.ts
+++ b/src/renderer/notification.ts
@@ -1,6 +1,10 @@
 import { app, BrowserWindow, ipcMain } from 'electron';
 
-import { analytics, AnalyticsElements, ToastNotificationActionTypes } from '../app/analytics-handler';
+import {
+  analytics,
+  AnalyticsElements,
+  ToastNotificationActionTypes,
+} from '../app/analytics-handler';
 import { config } from '../app/config-handler';
 import { createComponentWindow, windowExists } from '../app/window-utils';
 import { AnimationQueue } from '../common/animation-queue';
@@ -74,18 +78,22 @@ class Notification extends NotificationHandler {
   constructor(opts) {
     super(opts);
     ipcMain.on('close-notification', (_event, windowId) => {
-    const browserWindow = this.getNotificationWindow(windowId);
-        if (browserWindow && windowExists(browserWindow) && browserWindow.notificationData) {
-            const notificationData = (browserWindow.notificationData as any).data;
-            analytics.track({
-                element: AnalyticsElements.TOAST_NOTIFICATION,
-                action_type: ToastNotificationActionTypes.TOAST_CLOSED,
-                extra_data: notificationData || {},
-            });
-        }
-        // removes the event listeners on the client side
-        this.notificationClosed(windowId);
-        this.hideNotification(windowId);
+      const browserWindow = this.getNotificationWindow(windowId);
+      if (
+        browserWindow &&
+        windowExists(browserWindow) &&
+        browserWindow.notificationData
+      ) {
+        const notificationData = (browserWindow.notificationData as any).data;
+        analytics.track({
+          element: AnalyticsElements.TOAST_NOTIFICATION,
+          action_type: ToastNotificationActionTypes.TOAST_CLOSED,
+          extra_data: notificationData || {},
+        });
+      }
+      // removes the event listeners on the client side
+      this.notificationClosed(windowId);
+      this.hideNotification(windowId);
     });
 
     ipcMain.on('notification-clicked', (_event, windowId) => {


### PR DESCRIPTION
## Description
- Update toast_closed analytic event to track only UI click actions

## Related PRs
[SFE-Lite](https://github.com/SymphonyOSF/SFE-Lite/pull/5714)

Notes: Analytic events for toast_closed