### PR TITLE
fix: SDA-2977: fix copying email address on context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "electron-dl": "3.0.0",
     "electron-fetch": "1.4.0",
     "electron-log": "4.0.7",
-    "electron-spellchecker": "git+https://github.com/symphonyoss/electron-spellchecker.git#v2.0.4",
+    "electron-spellchecker": "git+https://github.com/symphonyoss/electron-spellchecker.git#v2.3.1",
     "ffi-napi": "3.0.0",
     "filesize": "6.1.0",
     "lazy-brush": "^1.0.1",


### PR DESCRIPTION
## Description

When we copy email address from right click context menu, it should copy the email address properly, this wasn't the case before, this PR fixes the issue.

Effectively, I've fixed the issue on the `electron-spellchecker` repo here -> https://github.com/symphonyoss/electron-spellchecker/commit/956382a98f4985a218d980b0fb4be96261ccf228

## Related Commits

https://github.com/symphonyoss/electron-spellchecker/commit/956382a98f4985a218d980b0fb4be96261ccf228