### PR TITLE
fix: update electron spellchecker

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "electron-dl": "3.0.0",
     "electron-fetch": "1.4.0",
     "electron-log": "4.0.7",
-    "electron-spellchecker": "git+https://github.com/symphonyoss/electron-spellchecker.git#v2.3.1",
+    "electron-spellchecker": "git+https://github.com/symphonyoss/electron-spellchecker.git#v2.3.2",
     "ffi-napi": "3.0.0",
     "filesize": "6.1.0",
     "lazy-brush": "^1.0.1",


### PR DESCRIPTION
![2021-03-23 13 53 48](https://user-images.githubusercontent.com/55975938/112149461-4bc37280-8bdf-11eb-8213-01b1c6b8d14b.gif)

https://perzoinc.atlassian.net/browse/sda-3041 CORE - SDA - Right click > Search with Google does not parse the correct syntax for search results