### PR TITLE
SDA-3039: force opening external app for symphony and mailto

### DIFF
--- a/src/app/window-actions.ts
+++ b/src/app/window-actions.ts
@@ -524,6 +524,12 @@ export const handlePermissionRequests = (
             callback,
           );
         case Permissions.OPEN_EXTERNAL:
+          if (
+            details?.externalURL?.startsWith('symphony:') ||
+            details?.externalURL?.startsWith('mailto:')
+          ) {
+            return callback(true);
+          }
           return handleSessionPermissions(
             permissions.openExternal,
             i18n.t(


### PR DESCRIPTION
## Description

Force opening external app in case the Url's protocol is `symphony` or `mailto`

## Related PRs

#1205 