### PR TITLE
fix: go back to swift-search 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,12 +174,12 @@
     "rimraf": "^3.0.2",
     "save-svg-as-png": "^1.4.17",
     "shell-path": "2.1.0",
-    "swift-search": "2.0.2",
-    "screen-share-indicator-frame": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#v1.4.10"
+    "swift-search": "2.0.2"
   },
   "optionalDependencies": {
     "auto-update": "file:auto_update",
-    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#v2.0.0"
+    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#v2.0.0",
+    "screen-share-indicator-frame": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#v1.4.10"
   },
   "ava": {
     "failFast": true,

--- a/package.json
+++ b/package.json
@@ -173,13 +173,13 @@
     "ref-napi": "1.4.3",
     "rimraf": "^3.0.2",
     "save-svg-as-png": "^1.4.17",
-    "shell-path": "2.1.0"
+    "shell-path": "2.1.0",
+    "swift-search": "2.0.2",
+    "screen-share-indicator-frame": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#v1.4.10"
   },
   "optionalDependencies": {
     "auto-update": "file:auto_update",
-    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#v2.0.0",
-    "screen-share-indicator-frame": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#v1.4.10",
-    "swift-search": "git+https://github.com/symphonyoss/SwiftSearch.git#v2.0.2"
+    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#v2.0.0"
   },
   "ava": {
     "failFast": true,

--- a/package.json
+++ b/package.json
@@ -173,13 +173,13 @@
     "ref-napi": "1.4.3",
     "rimraf": "^3.0.2",
     "save-svg-as-png": "^1.4.17",
-    "shell-path": "2.1.0",
-    "swift-search": "2.0.2"
+    "shell-path": "2.1.0"
   },
   "optionalDependencies": {
     "auto-update": "file:auto_update",
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#v2.0.0",
-    "screen-share-indicator-frame": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#v1.4.10"
+    "screen-share-indicator-frame": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#v1.4.10",
+    "swift-search": "2.0.2"
   },
   "ava": {
     "failFast": true,


### PR DESCRIPTION
Using the git repo of swift-search, solves the build problem but the SDA can not consume swift-search, we get errors in the console output swift-search