### PR TITLE
SDA-3167 Added version check 

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
   },
   "optionalDependencies": {
     "auto-update": "file:auto_update",
-    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#v2.0.0",
+    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#v2.1.0",
     "screen-share-indicator-frame": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#v1.4.10",
     "swift-search": "git+https://github.com/symphonyoss/SwiftSearch.git#v2.0.2"
   },

--- a/src/app/screen-snippet-handler.ts
+++ b/src/app/screen-snippet-handler.ts
@@ -46,7 +46,10 @@ class ScreenSnippet {
       }
     }
     this.isOldWindows =
-      isWindowsOS && parseInt(os.release().split('.')[0], 10) < 10;
+      isWindowsOS &&
+      (parseInt(os.release().split('.')[0], 10) < 10 ||
+        parseInt(os.release().split('.')[2], 10) < 15002);
+
     logger.info(
       `screen-snippet-handler: isOldWindows ${
         this.isOldWindows


### PR DESCRIPTION
Added version check to not use built in snipping tool when /clip flag is not available

