### PR TITLE
SDA-3201 RBC hotfix -  Removing Electron from user-agents to support SSSO

### DIFF
--- a/config/Symphony.config
+++ b/config/Symphony.config
@@ -1,5 +1,6 @@
 {
     "url":"https://my.symphony.com",
+    "overrideUserAgent": false,
     "minimizeOnClose" : "ENABLED",
     "launchOnStartup" : "ENABLED",
     "alwaysOnTop" : "DISABLED",

--- a/docs/development/DEV_SETUP.md
+++ b/docs/development/DEV_SETUP.md
@@ -33,6 +33,20 @@
 
 ## Build Instructions:
 
+- Add Artifactory credentials to your home directory `.npmrc` file
+
+1. Login to https://repo.symphony.com/ in your browser
+2. Open https://repo.symphony.com/artifactory/webapp/#/profile
+3. Click generate token
+4. Execute `curl --location --request GET 'https://repo.symphony.com/artifactory/api/npm/auth' --header 'X-JFrog-Art-Api: <token from #3>'`
+5. Update ~/.npmrc with:
+
+```
+registry = https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/
+_auth = <auth value from #4>
+always-auth = true
+```
+
 ### Mac 🖥
 - npm install
 - npm run dev (to run locally)

--- a/docs/features/silent-installation-windows.md
+++ b/docs/features/silent-installation-windows.md
@@ -48,6 +48,7 @@ Add “/l* symphony_install.log” to get debug information from the install wri
 - OPEN_EXTERNAL (Boolean)
 - DEV_TOOLS_ENABLED (Boolean)
 - AUTO_LAUNCH_PATH (String)
+- OVERRIDE_USER_AGENT (Boolean)
 You'll need to quote the Boolean values when passing from the command line.
 
 #### Check-boxes (in the installer UI) that can be altered are listed below:

--- a/installer/win/WixSharpInstaller/Symphony.cs
+++ b/installer/win/WixSharpInstaller/Symphony.cs
@@ -186,6 +186,7 @@ class Script
             new PublicProperty("CONTEXT_ORIGIN_URL", ""),
             new PublicProperty("POINTER_LOCK", "true"),
             new PublicProperty("USER_DATA_PATH", ""),
+            new PublicProperty("OVERRIDE_USER_AGENT", "false"),
             new Property("MSIINSTALLPERUSER", "1"),
             new Property("PROGRAMSFOLDER", System.Environment.ExpandEnvironmentVariables(@"%PROGRAMFILES%"))
         };
@@ -213,7 +214,7 @@ class Script
             new ElevatedManagedAction(CustomActions.UpdateConfig, Return.check, When.After, Step.InstallFiles, Condition.NOT_BeingRemoved )
             {
                 // The UpdateConfig action needs the built-in property INSTALLDIR as well as most of the custom properties
-                UsesProperties = "INSTALLDIR,POD_URL,CONTEXT_ORIGIN_URL,MINIMIZE_ON_CLOSE,ALWAYS_ON_TOP,AUTO_START,BRING_TO_FRONT,MEDIA,LOCATION,NOTIFICATIONS,MIDI_SYSEX,POINTER_LOCK,FULL_SCREEN,OPEN_EXTERNAL,CUSTOM_TITLE_BAR,DEV_TOOLS_ENABLED,AUTO_LAUNCH_PATH,USER_DATA_PATH"
+                UsesProperties = "INSTALLDIR,POD_URL,CONTEXT_ORIGIN_URL,MINIMIZE_ON_CLOSE,ALWAYS_ON_TOP,AUTO_START,BRING_TO_FRONT,MEDIA,LOCATION,NOTIFICATIONS,MIDI_SYSEX,POINTER_LOCK,FULL_SCREEN,OPEN_EXTERNAL,CUSTOM_TITLE_BAR,DEV_TOOLS_ENABLED,AUTO_LAUNCH_PATH,USER_DATA_PATH,OVERRIDE_USER_AGENT"
             },
 
             // CleanRegistry
@@ -382,6 +383,7 @@ public class CustomActions
             data = ReplaceProperty(data, "devToolsEnabled", session.Property("DEV_TOOLS_ENABLED"));
             data = ReplaceProperty(data, "autoLaunchPath", FixPathFormat(session.Property("AUTO_LAUNCH_PATH")));
             data = ReplaceProperty(data, "userDataPath", FixPathFormat(session.Property("USER_DATA_PATH")));
+            data = ReplaceProperty(data, "overrideUserAgent", session.Property("OVERRIDE_USER_AGENT"));
 
             // Write the contents back to the file
             System.IO.File.WriteAllText(filename, data);

--- a/installer/win/install_instructions_win.md
+++ b/installer/win/install_instructions_win.md
@@ -430,7 +430,7 @@ Expected values:
 * "true"
   "Electron/X.X" is removed from user-agents.
 * "false"
-  User-agents are not modified.
+  User-agents are not modified (default)
 
 #### Example, install with user-agent override
 

--- a/installer/win/install_instructions_win.md
+++ b/installer/win/install_instructions_win.md
@@ -431,3 +431,15 @@ Expected values:
   "Electron/X.X" is removed from user-agents.
 * "false"
   User-agents are not modified.
+
+#### Example, install with user-agent override
+
+    msiexec /i Symphony.msi OVERRIDE_USER_AGENT="true"
+
+#### Example, install without user-agent override
+
+    msiexec /i Symphony.msi OVERRIDE_USER_AGENT="false"
+
+or
+
+    msiexec /i Symphony.msi

--- a/installer/win/install_instructions_win.md
+++ b/installer/win/install_instructions_win.md
@@ -422,3 +422,12 @@ The default (if not specified, or if specified as empty string "") is
 
 
 
+-------------------------------------------------------------------
+### OVERRIDE_USER_AGENT
+
+Expected values:
+
+* "true"
+  "Electron/X.X" is removed from user-agents.
+* "false"
+  User-agents are not modified.

--- a/spec/chromeFlags.spec.ts
+++ b/spec/chromeFlags.spec.ts
@@ -60,8 +60,12 @@ describe('chrome flags', () => {
   it('should call `setChromeFlags` correctly', () => {
     const spy = jest.spyOn(app.commandLine, 'appendSwitch');
     setChromeFlags();
-    expect(spy).nthCalledWith(1, 'auth-negotiate-delegate-whitelist', 'url');
-    expect(spy).nthCalledWith(2, 'auth-server-whitelist', 'whitelist');
+    expect(spy).nthCalledWith(
+      1,
+      'auth-negotiate-delegate-whitelist',
+      'whitelist',
+    );
+    expect(spy).nthCalledWith(2, 'auth-server-whitelist', 'url');
     expect(spy).nthCalledWith(3, 'disable-background-timer-throttling', 'true');
     expect(spy).nthCalledWith(4, 'disable-d3d11', true);
     expect(spy).nthCalledWith(5, 'disable-gpu', true);
@@ -79,8 +83,12 @@ describe('chrome flags', () => {
     });
     const spy = jest.spyOn(app.commandLine, 'appendSwitch');
     setChromeFlags();
-    expect(spy).nthCalledWith(1, 'auth-negotiate-delegate-whitelist', 'url');
-    expect(spy).nthCalledWith(2, 'auth-server-whitelist', 'whitelist');
+    expect(spy).nthCalledWith(
+      1,
+      'auth-negotiate-delegate-whitelist',
+      'whitelist',
+    );
+    expect(spy).nthCalledWith(2, 'auth-server-whitelist', 'url');
     expect(spy).nthCalledWith(3, 'disable-background-timer-throttling', 'true');
     expect(spy).not.nthCalledWith(4);
   });
@@ -166,8 +174,12 @@ describe('chrome flags', () => {
     it('should call `setChromeFlags` correctly', () => {
       const spy = jest.spyOn(app.commandLine, 'appendSwitch');
       setChromeFlags();
-      expect(spy).nthCalledWith(1, 'auth-negotiate-delegate-whitelist', 'url');
-      expect(spy).nthCalledWith(2, 'auth-server-whitelist', 'whitelist');
+      expect(spy).nthCalledWith(
+        1,
+        'auth-negotiate-delegate-whitelist',
+        'whitelist',
+      );
+      expect(spy).nthCalledWith(2, 'auth-server-whitelist', 'url');
       expect(spy).nthCalledWith(
         3,
         'disable-background-timer-throttling',

--- a/src/app/chrome-flags.ts
+++ b/src/app/chrome-flags.ts
@@ -35,9 +35,8 @@ export const setChromeFlags = () => {
   ]) as any;
   const configFlags: object = {
     'auth-negotiate-delegate-whitelist':
-      flagsConfig.customFlags.authServerWhitelist,
-    'auth-server-whitelist':
       flagsConfig.customFlags.authNegotiateDelegateWhitelist,
+    'auth-server-whitelist': flagsConfig.customFlags.authServerWhitelist,
     'disable-background-timer-throttling': 'true',
     'disable-d3d11': flagsConfig.disableGpu || null,
     'disable-gpu': flagsConfig.disableGpu || null,

--- a/src/app/config-handler.ts
+++ b/src/app/config-handler.ts
@@ -47,6 +47,7 @@ export interface IGlobalConfig {
   contextOriginUrl: string;
   url: string;
   contextIsolation: boolean;
+  overrideUserAgent?: boolean;
 }
 
 export interface ICloudConfig {

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -2071,7 +2071,9 @@ export class WindowHandler {
     let userAgent = mainWindow.webContents.getUserAgent();
     if (doOverrideUserAgents) {
       const electronUserAgentRegex = /(Electron[0-9\/.]*)/;
-      userAgent = userAgent.replace(electronUserAgentRegex, '');
+      userAgent = userAgent
+        .replace(electronUserAgentRegex, '')
+        .replace('  ', ' ');
     }
     return userAgent;
   }

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -165,6 +165,7 @@ export class WindowHandler {
       'url',
       'contextIsolation',
       'contextOriginUrl',
+      'overrideUserAgent',
     ]);
     this.userConfig = config.getUserConfigFields(['url']);
 
@@ -383,7 +384,8 @@ export class WindowHandler {
     cleanAppCacheOnCrash(this.mainWindow);
     // loads the main window with url from config/cmd line
     logger.info(`Loading main window with url ${this.url}`);
-    this.mainWindow.loadURL(this.url);
+    const userAgent = this.getUserAgent(this.mainWindow);
+    this.mainWindow.loadURL(this.url, { userAgent });
     // check for build expiry in case of test builds
     this.checkExpiry(this.mainWindow);
     // update version info from server
@@ -454,9 +456,9 @@ export class WindowHandler {
           `Looks like about:blank got loaded which may lead to blank screen`,
         );
         logger.info(`Reloading the app to check if it resolves the issue`);
-        await this.mainWindow.loadURL(
-          this.userConfig.url || this.globalConfig.url,
-        );
+        const url = this.userConfig.url || this.globalConfig.url;
+        const userAgent = this.getUserAgent(this.mainWindow);
+        await this.mainWindow.loadURL(url, { userAgent });
         return;
       }
       logger.info('window-handler: did-finish-load, url: ' + this.url);
@@ -1752,8 +1754,10 @@ export class WindowHandler {
         logger.info(
           `window-utils: user has logged in, getting back to Symphony app`,
         );
+        const userAgent = this.getUserAgent(this.mainWindow);
         this.mainWindow.loadURL(
           this.url || this.userConfig.url || this.globalConfig.url,
+          { userAgent },
         );
         return;
       }
@@ -1761,7 +1765,10 @@ export class WindowHandler {
       logger.info(
         `window-utils: user hasn't logged in yet, loading login page again`,
       );
-      this.mainWindow.loadURL(this.userConfig.url || this.globalConfig.url);
+      const userAgent = this.getUserAgent(this.mainWindow);
+      this.mainWindow.loadURL(this.userConfig.url || this.globalConfig.url, {
+        userAgent,
+      });
     }
   }
 
@@ -1780,7 +1787,8 @@ export class WindowHandler {
           const reloadUrl =
             webContentsUrl || this.userConfig.url || this.globalConfig.url;
           logger.info(`window-handler: Trying to reload ${reloadUrl}.`);
-          await this.mainWindow.loadURL(reloadUrl);
+          const userAgent = this.getUserAgent(this.mainWindow);
+          await this.mainWindow.loadURL(reloadUrl, { userAgent });
           return;
         }
         logger.error(
@@ -1967,7 +1975,8 @@ export class WindowHandler {
           this.url = this.globalConfig.url + `?x-km-csrf-token=${csrfToken}`;
       }
       this.execCmd(this.screenShareIndicatorFrameUtil, []);
-      await this.mainWindow.loadURL(this.url);
+      const userAgent = this.getUserAgent(this.mainWindow);
+      await this.mainWindow.loadURL(this.url, { userAgent });
     } catch (e) {
       logger.error(
         `window-handler: failed to switch client because of error ${e}`,
@@ -2048,6 +2057,23 @@ export class WindowHandler {
     };
 
     return { ...defaultWindowOpts, ...windowOpts };
+  }
+
+  /**
+   * getUserAgent retrieves current window user-agent and updates it
+   * depending on global config setup
+   * Electron user-agent is removed due to Microsoft Azure not supporting SSO if found - cf SDA-3201
+   * @param mainWindow
+   * @returns updated user-agents
+   */
+  private getUserAgent(mainWindow: ICustomBrowserWindow): string {
+    const doOverrideUserAgents = !!this.globalConfig.overrideUserAgent;
+    let userAgent = mainWindow.webContents.getUserAgent();
+    if (doOverrideUserAgents) {
+      const electronUserAgentRegex = /(Electron[0-9\/.]*)/;
+      userAgent = userAgent.replace(electronUserAgentRegex, '');
+    }
+    return userAgent;
   }
 }
 


### PR DESCRIPTION
RBC is blocked: they are using Azure ADFS for SSO.

Azure is using a regular expression to check user-agents. This regular expression reject queries having "Electron" as user agent.

We decided to remove "Electron" from our user-agents to quickly fix this issue and allow RBC users (maybe other customers as well) to have SSSO.

JIRA Ticket:
[SDA-3201](https://perzoinc.atlassian.net/browse/SDA-3201)