### PR TITLE
SDA-3203 Removed leftover delete which caused a crash on some Windows versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
   },
   "optionalDependencies": {
     "auto-update": "file:auto_update",
-    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#v2.2.0",
+    "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#v2.4.0",
     "screen-share-indicator-frame": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#v1.4.10",
     "swift-search": "2.0.3"
   },


### PR DESCRIPTION
Version bump to get the fix for SDA-3203