### PR TITLE
SDA-3201 Replacing user-agent to support Calls and snipping tool

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -2070,10 +2070,8 @@ export class WindowHandler {
     const doOverrideUserAgents = !!this.globalConfig.overrideUserAgent;
     let userAgent = mainWindow.webContents.getUserAgent();
     if (doOverrideUserAgents) {
-      const electronUserAgentRegex = /(Electron[0-9\/.]*)/;
-      userAgent = userAgent
-        .replace(electronUserAgentRegex, '')
-        .replace('  ', ' ');
+      const electronUserAgentRegex = /Electron/;
+      userAgent = userAgent.replace(electronUserAgentRegex, 'ElectronSymphony');
     }
     return userAgent;
   }


### PR DESCRIPTION
## Description

We are not removing Electron from user-agents anymore as it has impacts on our app (unable to call and to take screenshots + BI).

```Electron``` user-agent is replaced by ElectronSymphony to not be caught by Microsoft Azure regex.

