### PR TITLE
SDA-3226 Adding contextIsolation for notifications

### DIFF
--- a/src/renderer/notification.ts
+++ b/src/renderer/notification.ts
@@ -595,6 +595,8 @@ class Notification extends NotificationHandler {
    * notification window opts
    */
   private getNotificationOpts(): Electron.BrowserWindowConstructorOptions {
+    const contextIsolation = config.getGlobalConfigFields(['contextIsolation'])
+      .contextIsolation;
     return {
       width: 344,
       height: 88,
@@ -611,6 +613,11 @@ class Notification extends NotificationHandler {
         sandbox: !isNodeEnv,
         nodeIntegration: isNodeEnv,
         devTools: true,
+        contextIsolation: isNodeEnv
+          ? false
+          : typeof contextIsolation === 'boolean'
+          ? contextIsolation
+          : true,
       },
     };
   }


### PR DESCRIPTION
## Description
Context isolation wasn't set for notifications windows.

[SDA-3226](https://perzoinc.atlassian.net/browse/SDA-3226)