### PR TITLE
SDA-3237 SDA-3271 Additional colors use-cases

### DIFF
--- a/src/renderer/styles/notification-comp.less
+++ b/src/renderer/styles/notification-comp.less
@@ -143,13 +143,14 @@ body {
         cursor: default;
         text-overflow: ellipsis;
         color: var(--text-color);
+        white-space: pre-line;
       }
     }
   }
 }
 
 .external-border {
-  border: 2px solid #f7ca3b !important;
+  border: 2px solid #f7ca3b;
 }
 
 .header:lang(fr-FR) {

--- a/src/renderer/styles/notifications-animations.less
+++ b/src/renderer/styles/notifications-animations.less
@@ -64,19 +64,15 @@
 }
 
 @keyframes light-ext-flashing {
-  0% {
-    background-color: @light-notification-bg-color;
-  }
   50% {
-    background-color: @light-external-flash-mention-bg-color;
+    background-color: @light-notification-bg-color;
+    border-color: @light-external-flash-border-color;
   }
 }
 
 @keyframes dark-ext-flashing {
-  0% {
-    background-color: @dark-notification-bg-color;
-  }
   50% {
-    background-color: @dark-external-flash-bg-color;
+    background-color: @dark-notification-bg-color;
+    border-color: @dark-external-flash-border-color;
   }
 }

--- a/src/renderer/styles/variables.less
+++ b/src/renderer/styles/variables.less
@@ -14,4 +14,4 @@
 @light-mention-flash-mention-bg-color: #fcc1b9;
 @light-mention-flash-border-color: #ff5d50;
 @light-external-flash-border-color: #f7ca3b;
-@light-external-flash-mention-bg-color: #f6e5a6;
+@light-external-flash-bg-color: #f6e5a6;


### PR DESCRIPTION
## Description
Adding behaviours to custom notifications:
- non flashing mode and external message: should use custom color if available.
- having a lighter border color when gettting a custom color (valid only in dark mode)

Took the opportunity to fix new lines not being displayed properly in notification message preview.

## JIRA Tickets
[SDA-3237](https://perzoinc.atlassian.net/browse/SDA-3237)
[SDA-3271](https://perzoinc.atlassian.net/browse/SDA-3271)