### PR TITLE
Backward compatibility fix with SDA 9.2.0 and client 1.5

### DIFF
--- a/src/renderer/components/notification-comp.tsx
+++ b/src/renderer/components/notification-comp.tsx
@@ -169,7 +169,7 @@ export default class NotificationComp extends React.Component<
           title={i18n.t('Close')()}
           onClick={this.eventHandlers.onClose(id)}
         >
-          <img src={closeImgFilePath} alt='close' />
+          <img src={closeImgFilePath} title={i18n.t('Close')()} alt='close' />
         </div>
         <div
           className='main-container'
@@ -429,10 +429,24 @@ export default class NotificationComp extends React.Component<
    */
   private updateState(_event, data): void {
     const { color } = data;
-    data.color = this.isValidColor(color) ? color : '';
+    // FYI: 1.5 sends hex color but without '#', reason why we check and add prefix if necessary.
+    // Goal is to keep backward compatibility with 1.5 colors (SDA v. 9.2.0)
+    const isOldColor = /^([A-Fa-f0-9]{6})/.test(color);
+    data.color = isOldColor
+      ? `#${color}`
+      : this.isValidColor(color)
+      ? color
+      : '';
     data.isInputHidden = true;
     data.containerHeight = CONTAINER_HEIGHT;
-    data.theme = data.theme ? data.theme : Themes.LIGHT;
+    // FYI: 1.5 doesn't send current theme. We need to deduce it from the color that is sent.
+    // Goal is to keep backward compatibility with 1.5 themes (SDA v. 9.2.0)
+    data.theme =
+      isOldColor && darkTheme.includes(data.color)
+        ? Themes.DARK
+        : data.theme
+        ? data.theme
+        : Themes.LIGHT;
     this.resetNotificationData();
     this.setState(data as INotificationState);
   }

--- a/src/renderer/components/notification-comp.tsx
+++ b/src/renderer/components/notification-comp.tsx
@@ -70,7 +70,8 @@ export default class NotificationComp extends React.Component<
   INotificationState
 > {
   private readonly eventHandlers = {
-    onClose: (winKey) => (_event: mouseEventButton) => this.close(winKey),
+    onClose: (winKey) => (_event: mouseEventButton) =>
+      this.close(_event, winKey),
     onClick: (data) => (_event: mouseEventButton) => this.click(data),
     onContextMenu: (event) => this.contextMenu(event),
     onMouseEnter: (winKey) => (_event: mouseEventButton) =>
@@ -167,9 +168,13 @@ export default class NotificationComp extends React.Component<
         <div
           className={`close-button ${themeClassName}`}
           title={i18n.t('Close')()}
-          onClick={this.eventHandlers.onClose(id)}
         >
-          <img src={closeImgFilePath} title={i18n.t('Close')()} alt='close' />
+          <img
+            src={closeImgFilePath}
+            title={i18n.t('Close')()}
+            alt='close'
+            onClick={this.eventHandlers.onClose(id)}
+          />
         </div>
         <div
           className='main-container'
@@ -308,7 +313,8 @@ export default class NotificationComp extends React.Component<
    *
    * @param id {number}
    */
-  private close(id: number): void {
+  private close(event: any, id: number): void {
+    event.stopPropagation();
     ipcRenderer.send('close-notification', id);
   }
 

--- a/src/renderer/styles/notification-comp.less
+++ b/src/renderer/styles/notification-comp.less
@@ -27,7 +27,6 @@
   --notification-border-color: #717681;
   --button-color: #b0b3ba;
   --button-border-color: #b0b3ba;
-  --button-border-color: #717681;
   --button-hover-color: #cdcfd4;
   --button-hover-border-color: #cdcfd4;
   --button-hover-bg-color: #3a3d43;

--- a/src/renderer/styles/notification-comp.less
+++ b/src/renderer/styles/notification-comp.less
@@ -61,6 +61,7 @@ body {
   line-height: 15px;
   &:hover > .close-button {
     display: block;
+    z-index: 5;
   }
 
   .main-container {


### PR DESCRIPTION
## Description
This fix aims at supporting Client 1.5 custom colors and theme with SDA >= 9.2.3.
Comments have been added to avoid any regression.

Flashing behaviour will be changed: we won't have flashing notifications background color switching from custom to red but it will switch from base color (light grey / dark grey) to custom color.

This PR contains a bugfix (SDA-3267) for notification closing that brings SDA to the front.

## Demo on Windows: 
![2021-08-05 21 28 18](https://user-images.githubusercontent.com/51402489/128409846-83565b5a-ce09-4e8b-9581-1b6f85d50d78.gif)

