### PR TITLE
SDA-3237 Notification border color fix in light mode

### DIFF
--- a/src/renderer/styles/notifications-animations.less
+++ b/src/renderer/styles/notifications-animations.less
@@ -21,7 +21,7 @@
   }
   50% {
     background-color: @light-mention-flash-mention-bg-color;
-    border-color: @light-mention-flash-border-color;
+    border-color: transparent;
   }
 }
 


### PR DESCRIPTION
## Description
Notifications with mentions shouldn't have red border. It should be transparent.
This PR aims at fixing this small issue.
