### PR TITLE
SDA-3237 Notification border color fix in light mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "symphony",
   "productName": "Symphony",
-  "version": "9.2.2",
+  "version": "9.2.3",
   "clientVersion": "2.0.1",
   "buildNumber": "0",
   "searchAPIVersion": "1.55.3",

--- a/src/renderer/styles/notifications-animations.less
+++ b/src/renderer/styles/notifications-animations.less
@@ -21,7 +21,7 @@
   }
   50% {
     background-color: @light-mention-flash-mention-bg-color;
-    border-color: @light-mention-flash-border-color;
+    border-color: transparent;
   }
 }
 


### PR DESCRIPTION
## Description
Notification border doesn't have the right border color in light mode. This PR aims at back-porting this issue on 9.2.3
