### PR TITLE
SDA-3281 Client 1.5 not sending user picture

### DIFF
--- a/spec/notificationComp.spec.ts
+++ b/spec/notificationComp.spec.ts
@@ -34,6 +34,16 @@ describe('Toast notification component', () => {
     expect(imageContainer.exists()).toBeFalsy();
   });
 
+  it('should render Symphony logo if no icon sent - Client 1.5 settings use-case with "See sample" ', () => {
+    ipcRenderer.send(IPC_RENDERER_NOTIFICATION_DATA_CHANNEL, {
+      ...defaultProps,
+    });
+    const defaultLogoContainer = wrapper.find('.default-logo');
+    expect(defaultLogoContainer).toBeTruthy();
+    const imageContainer = wrapper.find('.profile-picture');
+    expect(imageContainer.exists()).toBeFalsy();
+  });
+
   it('should render Symphony logo if Symphony default image provided', () => {
     const logo = './default.png';
     ipcRenderer.send(IPC_RENDERER_NOTIFICATION_DATA_CHANNEL, {

--- a/src/renderer/components/notification-comp.tsx
+++ b/src/renderer/components/notification-comp.tsx
@@ -41,7 +41,7 @@ interface INotificationState {
   company: string;
   body: string;
   image: string;
-  icon: string;
+  icon: string | undefined;
   id: number;
   color: string;
   flash: boolean;
@@ -263,11 +263,11 @@ export default class NotificationComp extends React.Component<
    * Renders image if provided otherwise renders symphony logo
    * @param imageUrl
    */
-  private renderImage(imageUrl: string): JSX.Element | undefined {
+  private renderImage(imageUrl: string | undefined): JSX.Element | undefined {
     let imgClass = 'default-logo';
     let url = '../renderer/assets/notification-symphony-logo.svg';
     let alt = 'Symphony logo';
-    const isDefaultUrl = imageUrl.includes('default.png');
+    const isDefaultUrl = imageUrl && imageUrl.includes('default.png');
     const shouldDisplayBadge = !!imageUrl && !isDefaultUrl;
     if (imageUrl && !isDefaultUrl) {
       imgClass = 'profile-picture';


### PR DESCRIPTION
## Description
In client 1.5, "See sample" button which displays a notification sample in Settings > Alerts is sending notification data without any icon, reason why we don't have any notification displayed.

This PR fix this issue.

