### PR TITLE
SDA-3345 Fix for failing unit test

### DIFF
--- a/auto_update/tests.cpp
+++ b/auto_update/tests.cpp
@@ -9,7 +9,13 @@
 #include <string.h>
 #include <windows.h>
 
-void disable_log( char const*, ... ) { };
+void disable_log( char const* format, ... ) { 
+	va_list args;
+	va_start( args, format );
+	vprintf( format, args );
+	va_end( args );
+};
+
 #define IPC_LOG_INFO disable_log
 #define IPC_LOG_ERROR disable_log 
 #define IPC_LOG_LAST_ERROR disable_log
@@ -67,7 +73,6 @@ void ipc_tests() {
         TESTFW_TEST_END();
     }
 
-    /* Disabled because it fails on build server, but works when run locally. 
 	{
         TESTFW_TEST_BEGIN( "Can connect multiple IPC clients multiple times" );
         ipc_server_t* server = ipc_server_start( "test_pipe", 
@@ -85,7 +90,7 @@ void ipc_tests() {
         }
         ipc_server_stop( server );
         TESTFW_TEST_END();
-    }*/
+    }
 
     {
         TESTFW_TEST_BEGIN( "Can connect IPC client" );

--- a/auto_update/tests.cpp
+++ b/auto_update/tests.cpp
@@ -10,7 +10,6 @@
 #include <windows.h>
 
 void disable_log( char const*, ... ) { };
-
 #define IPC_LOG_INFO disable_log
 #define IPC_LOG_ERROR disable_log 
 #define IPC_LOG_LAST_ERROR disable_log

--- a/auto_update/tests.cpp
+++ b/auto_update/tests.cpp
@@ -9,8 +9,7 @@
 #include <string.h>
 #include <windows.h>
 
-void disable_log( char const*, ... ) { 
-};
+void disable_log( char const*, ... ) { };
 
 #define IPC_LOG_INFO disable_log
 #define IPC_LOG_ERROR disable_log 

--- a/auto_update/tests.cpp
+++ b/auto_update/tests.cpp
@@ -75,22 +75,28 @@ void ipc_tests() {
     }
 
 	{
+        printf( "\nTest start\n\n" );
         TESTFW_TEST_BEGIN( "Can connect multiple IPC clients multiple times" );
         ipc_server_t* server = ipc_server_start( "test_pipe", 
             []( char const*, void*, char*, size_t ) { }, NULL );
         TESTFW_EXPECTED( server != NULL );
         for( int j = 0; j < 10; ++j ) {
+            printf( "\nj: %d\n\n", j );
             ipc_client_t* clients[ 32 ];
             for( int i = 0; i < sizeof( clients ) / sizeof( *clients ); ++i ) {
+                printf( "\ni1: %d\n\n", i );
                 clients[ i ] = ipc_client_connect( "test_pipe" );
                 TESTFW_EXPECTED( clients[ i ] );
             }
             for( int i = 0; i < sizeof( clients ) / sizeof( *clients ); ++i ) {
+                printf( "\ni2: %d\n\n", i );
                 ipc_client_disconnect( clients[ i ] );
             }
         }
+        printf( "\nStop\n\n" );
         ipc_server_stop( server );
         TESTFW_TEST_END();
+        printf( "\nTest end\n\n" );
     }
 
     {

--- a/auto_update/tests.cpp
+++ b/auto_update/tests.cpp
@@ -13,6 +13,7 @@ void disable_log( char const* format, ... ) {
 	va_list args;
 	va_start( args, format );
 	vprintf( format, args );
+	printf("\n");
 	va_end( args );
 };
 

--- a/auto_update/tests.cpp
+++ b/auto_update/tests.cpp
@@ -9,12 +9,7 @@
 #include <string.h>
 #include <windows.h>
 
-void disable_log( char const* format, ... ) { 
-	va_list args;
-	va_start( args, format );
-	vprintf( format, args );
-	printf("\n");
-	va_end( args );
+void disable_log( char const*, ... ) { 
 };
 
 #define IPC_LOG_INFO disable_log
@@ -75,28 +70,22 @@ void ipc_tests() {
     }
 
 	{
-        printf( "\nTest start\n\n" );
         TESTFW_TEST_BEGIN( "Can connect multiple IPC clients multiple times" );
         ipc_server_t* server = ipc_server_start( "test_pipe", 
             []( char const*, void*, char*, size_t ) { }, NULL );
         TESTFW_EXPECTED( server != NULL );
         for( int j = 0; j < 10; ++j ) {
-            printf( "\nj: %d\n\n", j );
             ipc_client_t* clients[ 32 ];
             for( int i = 0; i < sizeof( clients ) / sizeof( *clients ); ++i ) {
-                printf( "\ni1: %d\n\n", i );
                 clients[ i ] = ipc_client_connect( "test_pipe" );
                 TESTFW_EXPECTED( clients[ i ] );
             }
             for( int i = 0; i < sizeof( clients ) / sizeof( *clients ); ++i ) {
-                printf( "\ni2: %d\n\n", i );
                 ipc_client_disconnect( clients[ i ] );
             }
         }
-        printf( "\nStop\n\n" );
         ipc_server_stop( server );
         TESTFW_TEST_END();
-        printf( "\nTest end\n\n" );
     }
 
     {


### PR DESCRIPTION
The unit test "Can connect multiple IPC clients multiple times" failed on the build machine. This turned out to be caused by a ERROR_PIPE_BUSY error when creating the named pipe instance, most likely caused by the build machine being slower. Adding a retry (once) after a short delay makes the test succeed consistently.